### PR TITLE
feat(api): Adjust points with weekly limits

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,8 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { EventType } from '.prisma/client';
+
 export const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 // Pagination limits
 export const DEFAULT_LIMIT = 20;
 export const MAX_LIMIT = 100;
+
+// Event categories
+export const WEEKLY_POINT_LIMITS_BY_EVENT_TYPE: Record<EventType, number> = {
+  [EventType.BLOCK_MINED]: 1000,
+  [EventType.BUG_CAUGHT]: 1000,
+  [EventType.COMMUNITY_CONTRIBUTION]: 1000,
+  [EventType.NODE_HOSTED]: 1000,
+  [EventType.PULL_REQUEST_MERGED]: 1000,
+  [EventType.SOCIAL_MEDIA_PROMOTION]: 1000,
+};

--- a/src/common/utils/date.ts
+++ b/src/common/utils/date.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export function getMondayOfThisWeek(): Date {
+  const now = new Date();
+  const monday = new Date(now.setUTCDate(now.getUTCDate() - now.getUTCDay()));
+  monday.setUTCHours(0, 0, 0, 0);
+  return monday;
+}


### PR DESCRIPTION
This code change adjusts the points assigned to event records on creation. On a given request, the API will sum up the total points for a given category in the current week (the start of week is defined as anything >= midnight UTC of the most recent Monday). If the future sum with the payload will cross a given weekly limit, the points for the event are adjusted so the limit is not crossed.

The point scheme used is defined in the Linear ticket [here](https://linear.app/ironfish/issue/IRO-809/categories-and-nfts-decide-on-point-scheme), although these thresholds can be easily adjusted with future discussion and testing.