### PR TITLE
feat(api): Add some type assertions for responses from Postgres

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@nestjs/passport": "8.0.1",
     "@nestjs/platform-express": "8.0.6",
     "@prisma/client": "2.29.1",
+    "@sindresorhus/is": "4.0.1",
     "class-transformer": "0.4.0",
     "class-validator": "0.13.1",
     "compression": "1.7.4",

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable } from '@nestjs/common';
+import is from '@sindresorhus/is';
 import {
   DEFAULT_LIMIT,
   MAX_LIMIT,
@@ -369,6 +370,14 @@ export class EventsService {
         id = $1`,
       user.id,
     );
+    if (
+      !is.array(userRanks) ||
+      !is.object(userRanks[0]) ||
+      !('type' in userRanks[0]) ||
+      !('rank' in userRanks[0])
+    ) {
+      throw new Error('Unexpected database response');
+    }
     const getRankForType = (type: EventType) => {
       const userRankForEvent = userRanks.find((o) => o.type === type);
       if (!userRankForEvent) {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import is from '@sindresorhus/is';
 import { DEFAULT_LIMIT, MAX_LIMIT } from '../common/constants';
 import { SortOrder } from '../common/enums/sort-order';
 import { PrismaService } from '../prisma/prisma.service';
@@ -271,8 +272,14 @@ export class UsersService {
         id = $1`,
       id,
     );
-    if (rankResponse === undefined || rankResponse.length !== 1) {
-      throw new Error(`Invalid response when fetching rank for user '${id}'`);
+    if (
+      !is.array(rankResponse) ||
+      rankResponse.length !== 1 ||
+      !is.object(rankResponse[0]) ||
+      !('id' in rankResponse[0]) ||
+      !('rank' in rankResponse[0])
+    ) {
+      throw new Error('Unexpected database response');
     }
     return rankResponse[0].rank;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,6 +682,11 @@
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@sindresorhus/is@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
+  integrity sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"


### PR DESCRIPTION
Prisma doesn't do runtime type assertions on raw queries, so we should throw exceptions for unexpected responses.