### PR TITLE
IRO-1009: Allow for CORS Origin from Block Explorer Previews

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,9 @@ async function bootstrap() {
     new ExpressAdapter(server),
   );
   app.enableCors({
-    origin: LOCAL ? /localhost./ : [/website-testnet.*\.vercel\.app/, /block-explorer.*\.vercel\.app/],
+    origin: LOCAL
+      ? /localhost./
+      : [/website-testnet.*\.vercel\.app/, /block-explorer.*\.vercel\.app/],
     methods: 'GET,POST,OPTIONS',
     preflightContinue: false,
     optionsSuccessStatus: 204,


### PR DESCRIPTION
This PR allows the new API to receive requests from block explorer preview deployments.