### PR TITLE
fix(api): Parse header before verifying token

### DIFF
--- a/src/auth/login.controller.spec.ts
+++ b/src/auth/login.controller.spec.ts
@@ -59,7 +59,7 @@ describe('LoginController', () => {
           .spyOn(magicLinkService, 'validate')
           .mockImplementationOnce(jest.fn());
         jest
-          .spyOn(magicLinkService, 'getMetadataByToken')
+          .spyOn(magicLinkService, 'getMetadataByHeader')
           .mockImplementationOnce(async () =>
             Promise.resolve({
               issuer: null,
@@ -95,7 +95,7 @@ describe('LoginController', () => {
           .spyOn(magicLinkService, 'validate')
           .mockImplementationOnce(jest.fn());
         jest
-          .spyOn(magicLinkService, 'getMetadataByToken')
+          .spyOn(magicLinkService, 'getMetadataByHeader')
           .mockImplementationOnce(async () =>
             Promise.resolve({
               issuer: null,

--- a/src/auth/strategies/magic-link.strategy.ts
+++ b/src/auth/strategies/magic-link.strategy.ts
@@ -22,14 +22,14 @@ export class MagicLinkStrategy extends PassportStrategy(
   }
 
   async authenticate(req: Request): Promise<void> {
-    const { authorization: didToken } = req.headers;
-    if (!didToken) {
+    const { authorization } = req.headers;
+    if (!authorization) {
       return this.fail();
     }
     try {
-      this.magicLinkService.validate(didToken);
-      const { email } = await this.magicLinkService.getMetadataByToken(
-        didToken,
+      this.magicLinkService.validate(authorization);
+      const { email } = await this.magicLinkService.getMetadataByHeader(
+        authorization,
       );
       if (!email) {
         throw new Error('No email found for token');

--- a/src/magic-link/magic-link.service.ts
+++ b/src/magic-link/magic-link.service.ts
@@ -13,11 +13,15 @@ export class MagicLinkService {
     this.magic = new Magic(this.config.get('MAGIC_SECRET_KEY'));
   }
 
-  validate(didToken: string): void {
-    this.magic.token.validate(didToken);
+  validate(header: string): void {
+    this.magic.token.validate(
+      this.magic.utils.parseAuthorizationHeader(header),
+    );
   }
 
-  async getMetadataByToken(didToken: string): Promise<MagicUserMetadata> {
-    return this.magic.users.getMetadataByToken(didToken);
+  async getMetadataByHeader(header: string): Promise<MagicUserMetadata> {
+    return this.magic.users.getMetadataByToken(
+      this.magic.utils.parseAuthorizationHeader(header),
+    );
   }
 }

--- a/src/users/me.controller.spec.ts
+++ b/src/users/me.controller.spec.ts
@@ -48,7 +48,7 @@ describe('MeController', () => {
           .spyOn(magicLinkService, 'validate')
           .mockImplementationOnce(jest.fn());
         jest
-          .spyOn(magicLinkService, 'getMetadataByToken')
+          .spyOn(magicLinkService, 'getMetadataByHeader')
           .mockImplementationOnce(async () =>
             Promise.resolve({
               issuer: null,


### PR DESCRIPTION
The API is incorrectly parsing the `Bearer ` prefix