### PR TITLE
feat(api): s/last_login_at/confirmed_at

### DIFF
--- a/src/events/events.controller.spec.ts
+++ b/src/events/events.controller.spec.ts
@@ -145,7 +145,7 @@ describe('EventsController', () => {
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
-            last_login_at: new Date(),
+            confirmed_at: new Date(),
           },
         });
         const occurredAt = new Date().toISOString();

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -63,7 +63,7 @@ describe('UsersService', () => {
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
-            last_login_at: new Date(),
+            confirmed_at: new Date(),
           },
         });
         const record = await usersService.findByGraffiti(user.graffiti);
@@ -134,7 +134,7 @@ describe('UsersService', () => {
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
-            last_login_at: new Date(),
+            confirmed_at: new Date(),
           },
         });
         const record = await usersService.findOrThrowByGraffiti(user.graffiti);
@@ -194,7 +194,7 @@ describe('UsersService', () => {
               email: faker.internet.email(),
               graffiti,
               country_code: faker.address.countryCode('alpha-3'),
-              last_login_at: new Date(),
+              confirmed_at: new Date(),
             },
           });
 
@@ -244,7 +244,7 @@ describe('UsersService', () => {
               email,
               graffiti: uuid(),
               country_code: faker.address.countryCode('alpha-3'),
-              last_login_at: new Date(),
+              confirmed_at: new Date(),
             },
           });
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -38,7 +38,7 @@ export class UsersService {
     return client.user.findFirst({
       where: {
         graffiti,
-        last_login_at: {
+        confirmed_at: {
           not: null,
         },
       },
@@ -78,7 +78,7 @@ export class UsersService {
   }: CreateUserDto): Promise<User> {
     const existingRecord = await this.prisma.user.findFirst({
       where: {
-        last_login_at: {
+        confirmed_at: {
           not: null,
         },
         OR: [


### PR DESCRIPTION
Now that we have confirmation tokens, we can move away from using last login timestamps when looking for users.