### PR TITLE
IRO-1107: Implement BlocksTransactions Service, Part 2

### DIFF
--- a/src/blocks-transactions/blocks-transactions.service.spec.ts
+++ b/src/blocks-transactions/blocks-transactions.service.spec.ts
@@ -103,7 +103,7 @@ describe('BlocksTransactionsService', () => {
           await blocksTransactionsService.upsert(block, transaction);
         }
 
-        const blocksTransactions = await blocksTransactionsService.find({
+        const blocksTransactions = await blocksTransactionsService.list({
           blockId: block.id,
         });
         for (const record of blocksTransactions) {
@@ -135,7 +135,7 @@ describe('BlocksTransactionsService', () => {
           await blocksTransactionsService.upsert(block, transaction);
         }
 
-        const blocksTransactions = await blocksTransactionsService.find({
+        const blocksTransactions = await blocksTransactionsService.list({
           transactionId: transaction.id,
         });
 

--- a/src/blocks-transactions/blocks-transactions.service.ts
+++ b/src/blocks-transactions/blocks-transactions.service.ts
@@ -5,7 +5,7 @@ import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { Block, BlockTransaction, Transaction } from '@prisma/client';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { FindBlockTransactionOptions } from './interfaces/find-block-transactions-options';
+import { ListBlockTransactionOptions } from './interfaces/list-block-transactions-options';
 
 @Injectable()
 export class BlocksTransactionsService {
@@ -38,8 +38,8 @@ export class BlocksTransactionsService {
     });
   }
 
-  async find(
-    options: FindBlockTransactionOptions,
+  async list(
+    options: ListBlockTransactionOptions,
   ): Promise<BlockTransaction[]> {
     if (options.blockId) {
       return this.prisma.blockTransaction.findMany({

--- a/src/blocks-transactions/interfaces/list-block-transactions-options.ts
+++ b/src/blocks-transactions/interfaces/list-block-transactions-options.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export interface FindBlockTransactionOptions {
+export interface ListBlockTransactionOptions {
   blockId?: number;
   transactionId?: number;
 }


### PR DESCRIPTION
Changelog
---
- Implement `find()` on BlocksTransactions service
-- Associated records can be found by passing either a block ID or transaction ID
- Added tests for `find()` method