### PR TITLE
IRO-1132: Remove transactions_count from Payload

### DIFF
--- a/src/blocks-transactions-loader/block-transactions-loader.ts
+++ b/src/blocks-transactions-loader/block-transactions-loader.ts
@@ -26,7 +26,7 @@ export class BlocksTransactionsLoader {
       for (const block of blocks) {
         const createdBlock = await this.blocksService.upsert(prisma, {
           ...block,
-          transactionsCount: block.transactions_count,
+          transactionsCount: block.transactions.length,
         });
         const transactions = await this.transactionsService.bulkUpsert(
           prisma,

--- a/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
@@ -43,7 +43,6 @@ describe('BlocksTransactionsLoader', () => {
               sequence: faker.datatype.number(),
               difficulty: faker.datatype.number(),
               timestamp: new Date(),
-              transactions_count: 1,
               type: BlockOperation.CONNECTED,
               graffiti: uuid(),
               previous_block_hash: uuid(),

--- a/src/blocks/__snapshots__/blocks.controller.spec.ts.snap
+++ b/src/blocks/__snapshots__/blocks.controller.spec.ts.snap
@@ -64,7 +64,6 @@ Object {
     "blocks.0.difficulty must be an integer number",
     "blocks.0.type must be a valid enum value",
     "blocks.0.timestamp must be a Date instance",
-    "blocks.0.transactions_count must be an integer number",
     "blocks.0.graffiti must be a string",
     "blocks.0.transactions must contain at least 1 elements",
     "blocks.0.transactions must be an array",

--- a/src/blocks/blocks.controller.spec.ts
+++ b/src/blocks/blocks.controller.spec.ts
@@ -125,7 +125,6 @@ describe('BlocksController', () => {
               type: BlockOperation.CONNECTED,
               sequence: faker.datatype.number(),
               timestamp: new Date(),
-              transactions_count: 0,
               graffiti: uuid(),
               previous_block_hash: uuid(),
               size: faker.datatype.number(),
@@ -156,7 +155,7 @@ describe('BlocksController', () => {
           difficulty: block.difficulty,
           sequence: block.sequence,
           timestamp: block.timestamp.toISOString(),
-          transactions_count: block.transactions_count,
+          transactions_count: 1,
           previous_block_hash: block.previous_block_hash,
           size: block.size,
         });

--- a/src/blocks/dto/upsert-blocks.dto.ts
+++ b/src/blocks/dto/upsert-blocks.dto.ts
@@ -35,10 +35,6 @@ export class BlockDto {
   @Type(() => Date)
   readonly timestamp!: Date;
 
-  @IsInt()
-  @Type(() => Number)
-  readonly transactions_count!: number;
-
   @IsString()
   readonly graffiti!: string;
 


### PR DESCRIPTION
Changelog
---
- Remove `transactions_count` from UpsertBlocksDto
- Replace call to `block.transactions_count` field with `block.transactions.length`
- Fix tests and snapshot