### PR TITLE
Revert change to enabled origins

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,6 @@ async function bootstrap() {
           /localhost/,
           /block-explorer.*\.vercel\.app/,
           /website-testnet.*\.vercel\.app/,
-          /explorer.ironfish.network/,
         ]
       : defaultOrigins;
 


### PR DESCRIPTION
Instead of adding different endpoints to the enabled origins object, we will be using environment variables set through the hosting service, which allows us to use particular endpoints for different development environments. 