### PR TITLE
[FEEDBACK NEEDED] Change default .env to development files

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,9 +1,0 @@
-API_URL=http://localhost:8003
-BLOCK_EXPLORER_URL=http://localhost:3000
-DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_development
-INCENTIVIZED_TESTNET_URL=http://localhost:3001
-IRONFISH_API_KEY=test
-MAGIC_SECRET_KEY=test
-NETWORK_VERSION=0
-NODE_ENV=development
-POSTMARK_API_KEY=test

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,6 +37,7 @@ export const REST_MODULES = [
     AuthModule,
     ConfigModule.forRoot({
       isGlobal: true,
+      envFilePath: process.env.NODE_ENV === 'production' ? [] : '.env',
       validationSchema: joi.object({
         API_URL: joi.string().required(),
         BLOCK_EXPLORER_URL: joi.string().required(),


### PR DESCRIPTION
This is a proposal to make local development easier. It will allow
people to start developing without figuring out why the API doesn't
start correctly. I'm trying to reduce friction so this thing basically just
works for any new developer that wants to contribute.

Unfortunately NestJS's env config implementation is broken. Normally
when you have a competing ENV variables set, it will prefer that over
what is inside the file. So to avoid that, when NODE_ENV is in production,
it will only use the machine environment variables.

We also need to put the staging in production mode for this fix to
work.

*Alternatively* I've also just deleted or renamed these env files in my build scripts, which would also be a 1 liner fix.