### PR TITLE
feat(api): Add block and transaction metrics to `blocks_daily`

### DIFF
--- a/prisma/migrations/20211116192521_add_blocks_and_transactions_metrics_to_blocks_daily/migration.sql
+++ b/prisma/migrations/20211116192521_add_blocks_and_transactions_metrics_to_blocks_daily/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "blocks_daily" DROP COLUMN "marked_blocks",
+ADD COLUMN     "average_block_time_ms" INTEGER NOT NULL,
+ADD COLUMN     "average_difficulty" INTEGER NOT NULL,
+ADD COLUMN     "blocks_count" INTEGER NOT NULL,
+ADD COLUMN     "blocks_with_graffiti_count" INTEGER NOT NULL,
+ADD COLUMN     "cumulative_unique_graffiti" INTEGER NOT NULL,
+ADD COLUMN     "transactions_count" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "index_blocks_daily_on_date" ON "blocks_daily"("date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,13 +124,18 @@ model FaucetTransaction {
 }
 
 model BlockDaily {
-  id              Int      @id @default(autoincrement())
-  created_at      DateTime @default(now()) @db.Timestamp(6)
-  updated_at      DateTime @default(now()) @updatedAt @db.Timestamp(6)
-  date            DateTime @db.Timestamp(6)
-  unique_graffiti Int
-  marked_blocks   Int
-  chain_height    Int
+  id                         Int      @id @default(autoincrement())
+  created_at                 DateTime @default(now()) @db.Timestamp(6)
+  updated_at                 DateTime @default(now()) @updatedAt @db.Timestamp(6)
+  date                       DateTime @db.Timestamp(6)
+  unique_graffiti            Int
+  chain_height               Int
+  average_block_time_ms      Int
+  average_difficulty         Int
+  blocks_count               Int
+  blocks_with_graffiti_count Int
+  cumulative_unique_graffiti Int
+  transactions_count         Int
 
   @@index([date], map: "index_blocks_daily_on_date")
   @@map("blocks_daily")


### PR DESCRIPTION
* Average block time in ms
* Average block difficulty
* Number of blocks for the day
* Cumulative unique graffiti for all blocks up until the day
* Number of blocks with graffiti 