### PR TITLE
feat(api): Redirect to login with toast on invalid confirmation tokens

### DIFF
--- a/src/users/registration.controller.spec.ts
+++ b/src/users/registration.controller.spec.ts
@@ -27,15 +27,23 @@ describe('RegistrationController', () => {
 
   describe('GET /registration/:token/confirm', () => {
     describe('with an invalid token', () => {
-      it('returns a 404', async () => {
-        await request(app.getHttpServer())
+      it('redirects with an error toast', async () => {
+        const message = 'Invalid confirmation token';
+        const { header } = await request(app.getHttpServer())
           .get('/registration/token/confirm')
-          .expect(HttpStatus.NOT_FOUND);
+          .expect(HttpStatus.FOUND);
+
+        expect((header as Record<string, unknown>).location).toBe(
+          `${config.get<string>(
+            'INCENTIVIZED_TESTNET_URL',
+          )}/login?toast=${Buffer.from(message).toString('base64')}`,
+        );
       });
     });
 
     describe('with an already confirmed user', () => {
-      it('returns a 404', async () => {
+      it('redirects with an error toast', async () => {
+        const message = 'Invalid confirmation token';
         const user = await usersService.create({
           email: faker.internet.email(),
           graffiti: uuid(),
@@ -43,9 +51,15 @@ describe('RegistrationController', () => {
         });
         await usersService.confirm(user);
 
-        await request(app.getHttpServer())
-          .get(`/registration/${user.confirmation_token}/confirm`)
-          .expect(HttpStatus.NOT_FOUND);
+        const { header } = await request(app.getHttpServer())
+          .get('/registration/token/confirm')
+          .expect(HttpStatus.FOUND);
+
+        expect((header as Record<string, unknown>).location).toBe(
+          `${config.get<string>(
+            'INCENTIVIZED_TESTNET_URL',
+          )}/login?toast=${Buffer.from(message).toString('base64')}`,
+        );
       });
     });
 

--- a/src/users/registration.controller.ts
+++ b/src/users/registration.controller.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Controller, Get, NotFoundException, Param, Res } from '@nestjs/common';
+import { Controller, Get, Param, Res } from '@nestjs/common';
 import { ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Response } from 'express';
 import { ApiConfigService } from '../api-config/api-config.service';
@@ -22,13 +22,19 @@ export class RegistrationController {
   ): Promise<void> {
     const user = await this.usersService.findByConfirmationToken(token);
     if (!user || user.confirmed_at) {
-      throw new NotFoundException();
+      const message = 'Invalid confirmation token';
+      res.redirect(
+        `${this.config.get<string>(
+          'INCENTIVIZED_TESTNET_URL',
+        )}/login?toast=${Buffer.from(message).toString('base64')}`,
+      );
+    } else {
+      await this.usersService.confirm(user);
+      res.redirect(
+        `${this.config.get<string>(
+          'INCENTIVIZED_TESTNET_URL',
+        )}/login?confirmed=true`,
+      );
     }
-    await this.usersService.confirm(user);
-    res.redirect(
-      `${this.config.get<string>(
-        'INCENTIVIZED_TESTNET_URL',
-      )}/login?confirmed=true`,
-    );
   }
 }


### PR DESCRIPTION
If a user clicks on a confirmation token twice or has an invalid value, the browser will show an API error message. This code change redirects to the UI with a toast message.