### PR TITLE
fix(api): Check for existing confirmed user in addition to token

### DIFF
--- a/src/users/registration.controller.ts
+++ b/src/users/registration.controller.ts
@@ -28,6 +28,19 @@ export class RegistrationController {
           'INCENTIVIZED_TESTNET_URL',
         )}/login?toast=${Buffer.from(message).toString('base64')}`,
       );
+      return;
+    }
+
+    const existingUser = await this.usersService.findConfirmedByEmail(
+      user.email,
+    );
+    if (existingUser) {
+      const message = 'User already confirmed';
+      res.redirect(
+        `${this.config.get<string>(
+          'INCENTIVIZED_TESTNET_URL',
+        )}/login?toast=${Buffer.from(message).toString('base64')}`,
+      );
     } else {
       await this.usersService.confirm(user);
       res.redirect(


### PR DESCRIPTION
It's possible for a user to register with an email and graffiti, not click the confirmation link, re-register with the same values, get a second confirmation link, and then confirm both users. This fix checks for an existing confirmed user after the token check.