### PR TITLE
IRO-1319: Dual write difficulty so that new blocks have proper bigint type

### DIFF
--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -65,6 +65,7 @@ export class BlocksService {
         previous_block_hash,
         searchable_text,
         size,
+        difficulty_temporary: difficulty,
       },
       update: {
         sequence,
@@ -75,6 +76,7 @@ export class BlocksService {
         transactions_count: transactionsCount,
         previous_block_hash,
         size,
+        difficulty_temporary: difficulty,
       },
       where: {
         uq_blocks_on_hash_and_network_version: {


### PR DESCRIPTION
We're writing to difficulty_temporary in order to make sure that new blocks have the proper difficulty and then subsequent PRs will adjust difficulty for prior blocks.