### PR TITLE
feat(api): Add Datadog module

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,7 @@
 API_URL=http://localhost:8003
 BLOCK_EXPLORER_URL=http://localhost:3000
 DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_development
+DATADOG_URL=127.0.0.1
 INCENTIVIZED_TESTNET_URL=http://localhost:3001
 IRONFISH_API_KEY=test
 MAGIC_SECRET_KEY=test

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
 API_URL=http://localhost:8003
 BLOCK_EXPLORER_URL=test
 DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_test
+DATADOG_URL=127.0.0.1
 INCENTIVIZED_TESTNET_URL=http://localhost:3001
 IRONFISH_API_KEY=test
 MAGIC_SECRET_KEY=test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ env:
   API_URL: http://localhost:8003
   BLOCK_EXPLORER_URL: http://localhost:3000
   DATABASE_URL: postgres://postgres:password@localhost:5432/ironfish_api_test
+  DATADOG_URL: 127.0.0.1
   INCENTIVIZED_TESTNET_URL: http://localhost:3001
   IRONFISH_API_KEY: test
   IRONFISH_POSTGRES_CONTAINER: ironfish_postgres

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "express": "4.17.1",
     "graphile-worker": "0.12.1",
     "helmet": "4.6.0",
+    "hot-shots": "9.0.0",
     "joi": "17.5.0",
     "passport": "0.4.1",
     "postmark": "2.7.8",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { BlocksDailyJobsModule } from './blocks-daily/blocks-daily.jobs.module';
 import { BlocksDailyRestModule } from './blocks-daily/blocks-daily.rest.module';
 import { ContextMiddleware } from './common/middlewares/context.middleware';
 import { RequireSslMiddleware } from './common/middlewares/require-ssl.middleware';
+import { DatadogModule } from './datadog/datadog.module';
 import { EventsRestModule } from './events/events.rest.module';
 import { FaucetTransactionsRestModule } from './faucet-transactions/faucet-transactions.rest.module';
 import { HealthRestModule } from './health/health.rest.module';
@@ -48,6 +49,7 @@ export const REST_MODULES = [
         API_URL: joi.string().required(),
         BLOCK_EXPLORER_URL: joi.string().required(),
         DATABASE_URL: joi.string().required(),
+        DATADOG_URL: joi.string().required(),
         INCENTIVIZED_TESTNET_URL: joi.string().required(),
         IRONFISH_API_KEY: joi.string().required(),
         MAGIC_SECRET_KEY: joi.string().required(),
@@ -57,6 +59,7 @@ export const REST_MODULES = [
         POSTMARK_API_KEY: joi.string().required(),
       }),
     }),
+    DatadogModule,
     ...JOBS_MODULES,
     ...REST_MODULES,
   ],

--- a/src/datadog/datadog.interceptor.ts
+++ b/src/datadog/datadog.interceptor.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { catchError, Observable, tap, throwError } from 'rxjs';
+import { DatadogService } from './datadog.service';
+
+@Injectable()
+export class DatadogInterceptor implements NestInterceptor {
+  constructor(private readonly datadogService: DatadogService) {}
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<unknown>,
+  ): Observable<unknown> {
+    const start = new Date().getTime();
+    return next.handle().pipe(
+      tap(() => {
+        const duration = new Date().getTime() - start;
+
+        const request = context.switchToHttp().getRequest<Request>();
+        if (!request) {
+          return;
+        }
+
+        this.datadogService.timing('requests.success', duration, {
+          method: request.method,
+          path: request.path,
+        });
+      }),
+      catchError((error: Error) => {
+        let method = 'no-method';
+        let path = 'no-path';
+
+        const request = context.switchToHttp().getRequest<Request>();
+        if (request) {
+          method = request.method;
+          path = request.path;
+        }
+
+        this.datadogService.increment('requests.error', 1, {
+          method,
+          path,
+          type: error.constructor.name,
+        });
+
+        return throwError(() => error);
+      }),
+    );
+  }
+}

--- a/src/datadog/datadog.module.ts
+++ b/src/datadog/datadog.module.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { ApiConfigModule } from '../api-config/api-config.module';
+import { DatadogInterceptor } from './datadog.interceptor';
+import { DatadogService } from './datadog.service';
+
+@Module({
+  exports: [DatadogService],
+  imports: [ApiConfigModule],
+  providers: [
+    DatadogService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: DatadogInterceptor,
+    },
+  ],
+})
+export class DatadogModule {}

--- a/src/datadog/datadog.service.spec.ts
+++ b/src/datadog/datadog.service.spec.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { INestApplication } from '@nestjs/common';
+import { StatsD } from 'hot-shots';
+import { bootstrapTestApp } from '../test/test-app';
+import { DatadogService } from './datadog.service';
+
+describe('DatadogService', () => {
+  let app: INestApplication;
+  let datadogService: DatadogService;
+
+  beforeAll(async () => {
+    app = await bootstrapTestApp();
+    datadogService = app.get(DatadogService);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('timing', () => {
+    it('calls `timing` on the client', () => {
+      const timing = jest
+        .spyOn(StatsD.prototype, 'timing')
+        .mockImplementationOnce(jest.fn());
+      const stat = 'ironfish.test';
+      const value = 1;
+      const tags = { foo: 'bar ' };
+
+      datadogService.timing(stat, value, tags);
+
+      expect(timing).toHaveBeenCalledWith(stat, value, tags);
+    });
+  });
+
+  describe('increment', () => {
+    it('calls `increment` on the client', () => {
+      const increment = jest
+        .spyOn(StatsD.prototype, 'increment')
+        .mockImplementationOnce(jest.fn());
+      const stat = 'ironfish.test';
+      const value = 1;
+      const tags = { foo: 'bar ' };
+
+      datadogService.increment(stat, value, tags);
+
+      expect(increment).toHaveBeenCalledWith(stat, value, tags);
+    });
+  });
+});

--- a/src/datadog/datadog.service.ts
+++ b/src/datadog/datadog.service.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { StatsD, Tags } from 'hot-shots';
+import { ApiConfigService } from '../api-config/api-config.service';
+
+const DEFAULT_PORT = 8125;
+
+@Injectable()
+export class DatadogService implements OnModuleDestroy {
+  private datadogClient: StatsD;
+
+  constructor(private readonly config: ApiConfigService) {
+    this.datadogClient = new StatsD({
+      bufferFlushInterval: 1000,
+      globalTags: {
+        env: this.config.get<string>('NODE_ENV'),
+      },
+      host: this.config.get<string>('DATADOG_URL'),
+      port: DEFAULT_PORT,
+      prefix: 'api.',
+    });
+  }
+
+  timing(stat: string, value: number, tags?: Tags): void {
+    this.datadogClient.timing(stat, value, tags);
+  }
+
+  increment(stat: string, value: number, tags?: Tags): void {
+    this.datadogClient.increment(stat, value, tags);
+  }
+
+  onModuleDestroy(): void {
+    this.datadogClient.close();
+  }
+}

--- a/src/test/test-app.ts
+++ b/src/test/test-app.ts
@@ -10,6 +10,7 @@ import { JOBS_MODULES, REST_MODULES } from '../app.module';
 import { AuthModule } from '../auth/auth.module';
 import { BlocksModule } from '../blocks/blocks.module';
 import { BlocksTransactionsModule } from '../blocks-transactions/blocks-transactions.module';
+import { DatadogModule } from '../datadog/datadog.module';
 import { PostmarkService } from '../postmark/postmark.service';
 import { MockPostmarkService } from './mocks/mock-postmark.service';
 
@@ -26,6 +27,7 @@ export async function bootstrapTestApp(): Promise<INestApplication> {
           API_URL: joi.string().required(),
           BLOCK_EXPLORER_URL: joi.string().required(),
           DATABASE_URL: joi.string().required(),
+          DATADOG_URL: joi.string().required(),
           INCENTIVIZED_TESTNET_URL: joi.string().required(),
           IRONFISH_API_KEY: joi.string().required(),
           MAGIC_SECRET_KEY: joi.string().required(),
@@ -35,6 +37,7 @@ export async function bootstrapTestApp(): Promise<INestApplication> {
           POSTMARK_API_KEY: joi.string().required(),
         }),
       }),
+      DatadogModule,
       ...JOBS_MODULES,
       ...REST_MODULES,
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,6 +1358,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 blakejs@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
@@ -2588,6 +2595,11 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -2871,6 +2883,13 @@ hmac-drbg@^1.0.1:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hot-shots@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-9.0.0.tgz#b88421aa81c1ef37f4cc53ade7f1e3daaa584b5e"
+  integrity sha512-fpljto22PvfzDGznnzUpWgFMgccyZRtWo+fY8R4ktwipkv3ywDyeaTLijYaM629DEZvtnEDAN00yV6zxzivnpQ==
+  optionalDependencies:
+    unix-dgram "2.0.x"
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
@@ -4036,6 +4055,11 @@ multer@1.4.3:
     on-finished "^2.3.0"
     type-is "^1.6.4"
     xtend "^4.0.0"
+
+nan@^2.13.2:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -5345,6 +5369,14 @@ universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+unix-dgram@2.0.x:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/unix-dgram/-/unix-dgram-2.0.4.tgz#14d4fc21e539742b8fb027de16eccd4e5503a344"
+  integrity sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==
+  dependencies:
+    bindings "^1.3.0"
+    nan "^2.13.2"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This code change adds a module and interceptor for HTTP requests to collect metrics in Datadog. The interceptor is currently set up globally to count errors and store timings for successful requests.