### PR TITLE
feat(api): Add `optimize_for_size` and `max_old_space_size` to Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: npx prisma migrate deploy && npx prisma generate
-web: cd build && node main.js
-worker: cd build && node worker.js
+web: cd build && node --optimize_for_size --max_old_space_size=$NODE_MAX_OLD_SPACE_SIZE main.js
+worker: cd build && node --optimize_for_size --max_old_space_size=$NODE_MAX_OLD_SPACE_SIZE worker.js


### PR DESCRIPTION
## Summary

Add flags to the Procfile to set the max memory size and reclaim RAM faster. `$NODE_MAX_OLD_SPACE_SIZE` has been set to 512 in staging and 2048 in production.

## Testing Plan

Manual testing on staging after a deploy.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
