### PR TITLE
Convert hash to lowercase in find

### DIFF
--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -67,6 +67,26 @@ describe('BlocksService', () => {
         const block = await blocksService.find({ hash: testBlockHash });
         expect(block).toMatchObject(testBlock);
       });
+
+      it('returns the block with the mismatched hash cases', async () => {
+        const testBlockHash = 'aaa';
+        const blocks = await blocksService.upsert(prisma, {
+          hash: testBlockHash,
+          sequence: faker.datatype.number(),
+          difficulty: faker.datatype.number(),
+          timestamp: new Date(),
+          transactionsCount: 1,
+          type: BlockOperation.CONNECTED,
+          graffiti: uuid(),
+          previous_block_hash: uuid(),
+          size: faker.datatype.number(),
+        });
+        const testBlock = blocks;
+        const block = await blocksService.find({
+          hash: testBlockHash.toUpperCase(),
+        });
+        expect(block).toMatchObject(testBlock);
+      });
     });
 
     describe('with a valid sequence index', () => {

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -453,7 +453,7 @@ export class BlocksService {
     if (options.hash !== undefined) {
       const block = await this.prisma.block.findFirst({
         where: {
-          hash: options.hash,
+          hash: options.hash.toLowerCase(),
           network_version: networkVersion,
         },
       });


### PR DESCRIPTION
## Summary

I noticed this PR in the ironfish repository: https://github.com/iron-fish/ironfish/pull/673 and I thought it'd be nice to fix it on the API side to take case-agnostic hashes. There might be a more comprehensive fix here, like creating a common util like `formatHashForDatabase` and calling that everywhere we query the database for block hashes, because I'm pretty sure we've run into something similar on transaction details page for those hashes.

I haven't done much work in this repository so feel free to tell me to refactor everything if I put things in the wrong place :P

## Testing Plan

Added a unit test for this, but should be able to load the block explorer's /blocks/000...dc page with both lower and uppercase hashes.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
