### PR TITLE
fix(api): Fix off by 1 day bug for calculating Monday

### DIFF
--- a/src/common/utils/date.ts
+++ b/src/common/utils/date.ts
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export function getMondayFromDate(date: Date = new Date()): Date {
+  // Days are 0-based, so Monday is 1. On Tuesday (2) we
+  // want the offset to be 1, and Sunday we want the offset to be 6.
+  const dayOffset = (date.getUTCDay() + 6) % 7;
   const monday = new Date(
-    new Date(date).setUTCDate(date.getUTCDate() - date.getUTCDay()),
+    new Date(date).setUTCDate(date.getUTCDate() - dayOffset),
   );
   monday.setUTCHours(0, 0, 0, 0);
   return monday;


### PR DESCRIPTION
## Summary

We have an off by 1 bug in our API which is rolling over on Sunday midnight UTC instead of Monday midnight UTC. Users are reporting issues (ex. [here](https://github.com/iron-fish/website-testnet/issues/124#issuecomment-988507221)) for having a discrepancy between mined blocks and believe they are getting events with 0 points.

This code change fixes the computation of the rollover time.

## Testing Plan

Covered by existing unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```

With a different rollover, we need to reindex our mined block events. Running a backfill on existing events should update points accordingly with this new timestamp after [this PR](https://github.com/iron-fish/ironfish-api/pull/468) is deployed.
