### PR TITLE
fix(api): Add missing less than filter

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { EventType } from '.prisma/client';
 
+export const DAYS_IN_WEEK = 7;
 export const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 // Pagination limits

--- a/src/common/utils/date.ts
+++ b/src/common/utils/date.ts
@@ -13,5 +13,9 @@ export function getMondayFromDate(date: Date = new Date()): Date {
 }
 
 export function getNextDate(date: Date): Date {
-  return new Date(new Date(date).setDate(date.getDate() + 1));
+  return addDays(date, 1);
+}
+
+export function addDays(date: Date, days: number): Date {
+  return new Date(new Date(date).setDate(date.getDate() + days));
 }

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -8,9 +8,11 @@ import { ulid } from 'ulid';
 import { v4 as uuid } from 'uuid';
 import { ApiConfigService } from '../api-config/api-config.service';
 import {
+  DAYS_IN_WEEK,
   POINTS_PER_CATEGORY,
   WEEKLY_POINT_LIMITS_BY_EVENT_TYPE,
 } from '../common/constants';
+import { addDays } from '../common/utils/date';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { UsersService } from '../users/users.service';
@@ -578,6 +580,14 @@ describe('EventsService', () => {
               user_id: user.id,
             },
           });
+          await prisma.event.create({
+            data: {
+              occurred_at: addDays(new Date(), DAYS_IN_WEEK),
+              points: POINTS_PER_CATEGORY.BLOCK_MINED,
+              type: EventType.BLOCK_MINED,
+              user_id: user.id,
+            },
+          });
         }
 
         expect(event.points).toBe(POINTS_PER_CATEGORY.BLOCK_MINED);
@@ -604,6 +614,14 @@ describe('EventsService', () => {
           await prisma.event.create({
             data: {
               occurred_at: new Date(),
+              points: POINTS_PER_CATEGORY.BLOCK_MINED,
+              type: EventType.BLOCK_MINED,
+              user_id: user.id,
+            },
+          });
+          await prisma.event.create({
+            data: {
+              occurred_at: addDays(new Date(), DAYS_IN_WEEK),
               points: POINTS_PER_CATEGORY.BLOCK_MINED,
               type: EventType.BLOCK_MINED,
               user_id: user.id,

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -5,13 +5,14 @@ import { Injectable } from '@nestjs/common';
 import is from '@sindresorhus/is';
 import { ApiConfigService } from '../api-config/api-config.service';
 import {
+  DAYS_IN_WEEK,
   DEFAULT_LIMIT,
   MAX_LIMIT,
   POINTS_PER_CATEGORY,
   WEEKLY_POINT_LIMITS_BY_EVENT_TYPE,
 } from '../common/constants';
 import { SortOrder } from '../common/enums/sort-order';
-import { getMondayFromDate } from '../common/utils/date';
+import { addDays, getMondayFromDate } from '../common/utils/date';
 import { PrismaService } from '../prisma/prisma.service';
 import { BasePrismaClient } from '../prisma/types/base-prisma-client';
 import { CreateEventOptions } from './interfaces/create-event-options';
@@ -294,6 +295,7 @@ export class EventsService {
         user_id: userId,
         deleted_at: null,
         occurred_at: {
+          lt: addDays(startOfWeek, DAYS_IN_WEEK),
           gte: startOfWeek,
         },
       },


### PR DESCRIPTION
## Summary

We're incorrectly 0ing out previous events since we don't filter week by week based on the `occurred_at` timestamp. This code change fixes that.

## Testing Plan

Manually seed some events in a future week in an existing unit test to ensure those aren't caught in the aggregate.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
