### PR TITLE
fix(api): Use `event.occurred_at` when checking for cumulative sum

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -8,11 +8,9 @@ import { ulid } from 'ulid';
 import { v4 as uuid } from 'uuid';
 import { ApiConfigService } from '../api-config/api-config.service';
 import {
-  DAYS_IN_WEEK,
   POINTS_PER_CATEGORY,
   WEEKLY_POINT_LIMITS_BY_EVENT_TYPE,
 } from '../common/constants';
-import { addDays } from '../common/utils/date';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { UsersService } from '../users/users.service';
@@ -564,7 +562,7 @@ describe('EventsService', () => {
 
     describe('when a block exists and points need to be removed', () => {
       it('removes points from the existing record', async () => {
-        const { block, event, user } = await setupBlockMinedWithEvent();
+        const { user } = await setupBlockMinedWithEvent();
         for (
           let i = 0;
           i <
@@ -580,15 +578,8 @@ describe('EventsService', () => {
               user_id: user.id,
             },
           });
-          await prisma.event.create({
-            data: {
-              occurred_at: addDays(new Date(), DAYS_IN_WEEK),
-              points: POINTS_PER_CATEGORY.BLOCK_MINED,
-              type: EventType.BLOCK_MINED,
-              user_id: user.id,
-            },
-          });
         }
+        const { block, event } = await setupBlockMinedWithEvent();
 
         expect(event.points).toBe(POINTS_PER_CATEGORY.BLOCK_MINED);
         const record = await eventsService.upsertBlockMined(
@@ -603,7 +594,7 @@ describe('EventsService', () => {
       });
 
       it('removes points from the user', async () => {
-        const { block, user } = await setupBlockMinedWithEvent();
+        const { user } = await setupBlockMinedWithEvent();
         for (
           let i = 0;
           i <
@@ -619,15 +610,8 @@ describe('EventsService', () => {
               user_id: user.id,
             },
           });
-          await prisma.event.create({
-            data: {
-              occurred_at: addDays(new Date(), DAYS_IN_WEEK),
-              points: POINTS_PER_CATEGORY.BLOCK_MINED,
-              type: EventType.BLOCK_MINED,
-              user_id: user.id,
-            },
-          });
         }
+        const { block } = await setupBlockMinedWithEvent();
 
         expect(user.total_points).toBe(POINTS_PER_CATEGORY.BLOCK_MINED);
         await eventsService.upsertBlockMined(block, user, prisma);

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -5,14 +5,13 @@ import { Injectable } from '@nestjs/common';
 import is from '@sindresorhus/is';
 import { ApiConfigService } from '../api-config/api-config.service';
 import {
-  DAYS_IN_WEEK,
   DEFAULT_LIMIT,
   MAX_LIMIT,
   POINTS_PER_CATEGORY,
   WEEKLY_POINT_LIMITS_BY_EVENT_TYPE,
 } from '../common/constants';
 import { SortOrder } from '../common/enums/sort-order';
-import { addDays, getMondayFromDate } from '../common/utils/date';
+import { getMondayFromDate } from '../common/utils/date';
 import { PrismaService } from '../prisma/prisma.service';
 import { BasePrismaClient } from '../prisma/types/base-prisma-client';
 import { CreateEventOptions } from './interfaces/create-event-options';
@@ -295,7 +294,7 @@ export class EventsService {
         user_id: userId,
         deleted_at: null,
         occurred_at: {
-          lt: addDays(startOfWeek, DAYS_IN_WEEK),
+          lt: occurredAt,
           gte: startOfWeek,
         },
       },


### PR DESCRIPTION
## Summary

We should only be checking running totals up until the current event's `occurred_at` timestamp when adjusting points.

## Testing Plan

Updated unit test.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
