### PR TITLE
feat(api): Create module to update users

### DIFF
--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -284,4 +284,39 @@ describe('BlocksService', () => {
       }
     });
   });
+
+  describe('countByGraffiti', () => {
+    it('returns the count of main blocks for a given graffiti', async () => {
+      const graffiti = uuid();
+      const count = 15;
+      for (let i = 0; i < count; i++) {
+        await blocksService.upsert(prisma, {
+          hash: uuid(),
+          sequence: faker.datatype.number(),
+          difficulty: faker.datatype.number(),
+          timestamp: new Date(),
+          transactionsCount: 1,
+          type: BlockOperation.CONNECTED,
+          graffiti,
+          previous_block_hash: uuid(),
+          size: faker.datatype.number(),
+        });
+
+        // Seed forks to make sure they are not counted
+        await blocksService.upsert(prisma, {
+          hash: uuid(),
+          sequence: faker.datatype.number(),
+          difficulty: faker.datatype.number(),
+          timestamp: new Date(),
+          transactionsCount: 1,
+          type: BlockOperation.DISCONNECTED,
+          graffiti,
+          previous_block_hash: uuid(),
+          size: faker.datatype.number(),
+        });
+      }
+
+      expect(await blocksService.countByGraffiti(graffiti, prisma)).toBe(count);
+    });
+  });
 });

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -501,4 +501,18 @@ export class BlocksService {
       }),
     ]);
   }
+
+  async countByGraffiti(
+    graffiti: string,
+    client: BasePrismaClient,
+  ): Promise<number> {
+    // Don't include a network version so we can account for points from
+    // previous resets
+    return client.block.count({
+      where: {
+        graffiti,
+        main: true,
+      },
+    });
+  }
 }

--- a/src/test/test-app.ts
+++ b/src/test/test-app.ts
@@ -12,6 +12,7 @@ import { BlocksModule } from '../blocks/blocks.module';
 import { BlocksTransactionsModule } from '../blocks-transactions/blocks-transactions.module';
 import { DatadogModule } from '../datadog/datadog.module';
 import { PostmarkService } from '../postmark/postmark.service';
+import { UsersUpdaterModule } from '../users/users-updater.module';
 import { MockPostmarkService } from './mocks/mock-postmark.service';
 
 export async function bootstrapTestApp(): Promise<INestApplication> {
@@ -38,6 +39,7 @@ export async function bootstrapTestApp(): Promise<INestApplication> {
         }),
       }),
       DatadogModule,
+      UsersUpdaterModule,
       ...JOBS_MODULES,
       ...REST_MODULES,
     ],

--- a/src/users/interfaces/update-user-options.ts
+++ b/src/users/interfaces/update-user-options.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export interface UpdateUserOptions {
+  discord?: string;
+  graffiti?: string;
+  telegram?: string;
+}

--- a/src/users/users-updater.module.ts
+++ b/src/users/users-updater.module.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Module } from '@nestjs/common';
+import { BlocksModule } from '../blocks/blocks.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { UsersModule } from './users.module';
+import { UsersUpdater } from './users-updater';
+
+@Module({
+  exports: [UsersUpdater],
+  imports: [BlocksModule, PrismaModule, UsersModule],
+  providers: [UsersUpdater],
+})
+export class UsersUpdaterModule {}

--- a/src/users/users-updater.spec.ts
+++ b/src/users/users-updater.spec.ts
@@ -1,0 +1,214 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { INestApplication, UnprocessableEntityException } from '@nestjs/common';
+import assert from 'assert';
+import faker from 'faker';
+import { ulid } from 'ulid';
+import { v4 as uuid } from 'uuid';
+import { POINTS_PER_CATEGORY } from '../common/constants';
+import { PrismaService } from '../prisma/prisma.service';
+import { bootstrapTestApp } from '../test/test-app';
+import { UsersUpdater } from './users-updater';
+
+describe('UsersUpdater', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let usersUpdater: UsersUpdater;
+
+  beforeAll(async () => {
+    app = await bootstrapTestApp();
+    prisma = app.get(PrismaService);
+    usersUpdater = app.get(UsersUpdater);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const setupBlockMined = async (points?: number) => {
+    const hash = uuid();
+    const sequence = faker.datatype.number();
+    const graffiti = uuid();
+
+    const block = await prisma.block.create({
+      data: {
+        hash,
+        main: true,
+        sequence,
+        timestamp: new Date(),
+        transactions_count: 0,
+        graffiti,
+        previous_block_hash: uuid(),
+        network_version: 0,
+        size: faker.datatype.number(),
+        difficulty: faker.datatype.number(),
+      },
+    });
+    const user = await prisma.user.create({
+      data: {
+        confirmation_token: ulid(),
+        confirmed_at: new Date().toISOString(),
+        discord: faker.internet.userName(),
+        email: faker.internet.email(),
+        graffiti,
+        country_code: faker.address.countryCode('alpha-3'),
+        telegram: faker.internet.userName(),
+        total_points: points ?? POINTS_PER_CATEGORY.BLOCK_MINED,
+      },
+    });
+    return { block, user };
+  };
+
+  describe('update', () => {
+    describe("when the user's current graffiti has already mined blocks on the main chain", () => {
+      it('throws an UnprocessableEntityException', async () => {
+        const { user } = await setupBlockMined();
+        await expect(
+          usersUpdater.update(user, { graffiti: 'foo' }),
+        ).rejects.toThrow(UnprocessableEntityException);
+      });
+    });
+
+    describe('if blocks with the new graffiti without a registered user exist on the main chain', () => {
+      it('throws an UnprocessableEntityException', async () => {
+        const hash = uuid();
+        const sequence = faker.datatype.number();
+        const graffiti = uuid();
+
+        const block = await prisma.block.create({
+          data: {
+            hash,
+            main: true,
+            sequence,
+            timestamp: new Date(),
+            transactions_count: 0,
+            graffiti,
+            previous_block_hash: uuid(),
+            network_version: 0,
+            size: faker.datatype.number(),
+            difficulty: faker.datatype.number(),
+          },
+        });
+        const user = await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
+            confirmed_at: new Date().toISOString(),
+            discord: faker.internet.userName(),
+            email: faker.internet.email(),
+            graffiti: ulid(),
+            country_code: faker.address.countryCode('alpha-3'),
+            telegram: faker.internet.userName(),
+            total_points: 0,
+          },
+        });
+
+        await expect(
+          usersUpdater.update(user, { graffiti: block.graffiti }),
+        ).rejects.toThrow(UnprocessableEntityException);
+      });
+    });
+
+    describe('when a user exists for the new discord', () => {
+      it('throws an UnprocessableEntityException', async () => {
+        const { user: existingUser } = await setupBlockMined();
+        const user = await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
+            confirmed_at: new Date().toISOString(),
+            email: faker.internet.email(),
+            graffiti: ulid(),
+            country_code: faker.address.countryCode('alpha-3'),
+            total_points: 0,
+          },
+        });
+
+        assert.ok(existingUser.discord);
+        await expect(
+          usersUpdater.update(user, { discord: existingUser.discord }),
+        ).rejects.toThrow(UnprocessableEntityException);
+      });
+    });
+
+    describe('when a user exists for the new graffiti without blocks mined', () => {
+      it('throws an UnprocessableEntityException', async () => {
+        const existingUser = await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
+            confirmed_at: new Date().toISOString(),
+            discord: faker.internet.userName(),
+            email: faker.internet.email(),
+            graffiti: ulid(),
+            country_code: faker.address.countryCode('alpha-3'),
+            telegram: faker.internet.userName(),
+            total_points: 0,
+          },
+        });
+        const user = await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
+            confirmed_at: new Date().toISOString(),
+            email: faker.internet.email(),
+            graffiti: ulid(),
+            country_code: faker.address.countryCode('alpha-3'),
+            total_points: 0,
+          },
+        });
+
+        await expect(
+          usersUpdater.update(user, { graffiti: existingUser.graffiti }),
+        ).rejects.toThrow(UnprocessableEntityException);
+      });
+    });
+
+    describe('when a user exists for the new telegram', () => {
+      it('throws an UnprocessableEntityException', async () => {
+        const { user: existingUser } = await setupBlockMined();
+        const user = await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
+            confirmed_at: new Date().toISOString(),
+            email: faker.internet.email(),
+            graffiti: ulid(),
+            country_code: faker.address.countryCode('alpha-3'),
+            total_points: 0,
+          },
+        });
+
+        assert.ok(existingUser.telegram);
+        await expect(
+          usersUpdater.update(user, { telegram: existingUser.telegram }),
+        ).rejects.toThrow(UnprocessableEntityException);
+      });
+    });
+
+    describe('with no duplicates or existing blocks', () => {
+      it('updates the user', async () => {
+        const options = {
+          discord: ulid(),
+          graffiti: ulid(),
+          telegram: ulid(),
+        };
+        const user = await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
+            confirmed_at: new Date().toISOString(),
+            email: faker.internet.email(),
+            graffiti: ulid(),
+            country_code: faker.address.countryCode('alpha-3'),
+            total_points: 0,
+          },
+        });
+
+        const updatedUser = await usersUpdater.update(user, options);
+        expect(updatedUser).toMatchObject({
+          id: user.id,
+          discord: options.discord,
+          graffiti: options.graffiti,
+          telegram: options.telegram,
+        });
+      });
+    });
+  });
+});

--- a/src/users/users-updater.ts
+++ b/src/users/users-updater.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { BlocksService } from '../blocks/blocks.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpdateUserOptions } from './interfaces/update-user-options';
+import { UsersService } from './users.service';
+import { User } from '.prisma/client';
+
+@Injectable()
+export class UsersUpdater {
+  constructor(
+    private readonly blocksService: BlocksService,
+    private readonly prisma: PrismaService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async update(user: User, options: UpdateUserOptions): Promise<User> {
+    return this.prisma.$transaction(async (prisma) => {
+      const { discord, graffiti, telegram } = options;
+
+      if (graffiti && user.graffiti !== graffiti) {
+        const minedBlocksForCurrentGraffiti =
+          await this.blocksService.countByGraffiti(user.graffiti, prisma);
+        if (minedBlocksForCurrentGraffiti > 0) {
+          throw new UnprocessableEntityException({
+            code: 'user_graffiti_already_used',
+            message: `Current graffiti '${user.graffiti}' has already mined blocks`,
+          });
+        }
+
+        const minedBlocksForNewGraffiti =
+          await this.blocksService.countByGraffiti(graffiti, prisma);
+        if (minedBlocksForNewGraffiti > 0) {
+          throw new UnprocessableEntityException({
+            code: 'duplicate_block_graffiti',
+            message: `Blocks with '${graffiti}' already exist`,
+          });
+        }
+      }
+
+      const users = await this.usersService.findDuplicateUser(
+        user,
+        options,
+        prisma,
+      );
+      if (users.length) {
+        const duplicateUser = users[0];
+        let error;
+
+        if (discord && discord === duplicateUser.discord) {
+          error = {
+            code: 'duplicate_user_discord',
+            message: `User with Discord '${discord}' already exists`,
+          };
+        } else if (graffiti && graffiti === duplicateUser.graffiti) {
+          error = {
+            code: 'duplicate_user_graffiti',
+            message: `User with graffiti '${graffiti}' already exists`,
+          };
+        } else if (telegram && telegram === duplicateUser.telegram) {
+          error = {
+            code: 'duplicate_user_telegram',
+            message: `User with Telegram '${telegram}' already exists`,
+          };
+        } else {
+          throw new Error('Unexpected database response');
+        }
+
+        throw new UnprocessableEntityException(error);
+      }
+
+      return this.usersService.update(user, options, prisma);
+    });
+  }
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -18,6 +18,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { ListUsersWithRankOptions } from './interfaces/list-by-rank-options';
 import { ListUsersOptions } from './interfaces/list-users-options';
 import { SerializedUserWithRank } from './interfaces/serialized-user-with-rank';
+import { UpdateUserOptions } from './interfaces/update-user-options';
 import { Prisma, User } from '.prisma/client';
 
 @Injectable()
@@ -457,6 +458,43 @@ export class UsersService {
           confirmed_at: new Date().toISOString(),
         },
       });
+    });
+  }
+
+  async findDuplicateUser(
+    user: User,
+    options: UpdateUserOptions,
+    client: BasePrismaClient,
+  ): Promise<User[]> {
+    const { discord, graffiti, telegram } = options;
+    return client.user.findMany({
+      where: {
+        confirmed_at: {
+          not: null,
+        },
+        OR: [{ discord }, { graffiti }, { telegram }],
+        NOT: {
+          id: user.id,
+        },
+      },
+    });
+  }
+
+  async update(
+    user: User,
+    options: UpdateUserOptions,
+    client: BasePrismaClient,
+  ): Promise<User> {
+    const { discord, graffiti, telegram } = options;
+    return client.user.update({
+      data: {
+        discord,
+        graffiti,
+        telegram,
+      },
+      where: {
+        id: user.id,
+      },
     });
   }
 }


### PR DESCRIPTION
## Summary

This code change introduces a new module to enable updates to User records from the Testnet website. There are a few conditions in which this will fail:
* If the user's current graffiti has already mined blocks on the main chain for any network version
* If the new graffiti has mined blocks on the main chain for any network version (does not have to be associated with a previously registered user to prevent catching points on a reindex of points)
* If a duplicate user exists for a given discord
* If a duplicate user exists for a given graffiti (blocks don't need to be mined)
* If a duplicate user exists for a given telegram

## Testing Plan

Added unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
