### PR TITLE
feat(api): Return entire user object in `/me`

### DIFF
--- a/src/users/me.controller.spec.ts
+++ b/src/users/me.controller.spec.ts
@@ -57,7 +57,10 @@ describe('MeController', () => {
         expect(body).toMatchObject({
           id: user.id,
           country_code: user.country_code,
+          discord: user.discord,
+          email: user.email,
           graffiti: user.graffiti,
+          telegram: user.telegram,
         });
       });
     });

--- a/src/users/me.controller.ts
+++ b/src/users/me.controller.ts
@@ -6,15 +6,14 @@ import { ApiExcludeController } from '@nestjs/swagger';
 import { MagicLinkGuard } from '../auth/guards/magic-link.guard';
 import { Context } from '../common/decorators/context';
 import { MagicLinkContext } from '../common/interfaces/magic-link-context';
-import { SerializedUser } from './interfaces/serialized-user';
-import { serializedUserFromRecord } from './utils/user-translator';
+import { User } from '.prisma/client';
 
 @ApiExcludeController()
 @Controller('me')
 export class MeController {
   @Get()
   @UseGuards(MagicLinkGuard)
-  me(@Context() { user }: MagicLinkContext): SerializedUser {
-    return serializedUserFromRecord(user);
+  me(@Context() { user }: MagicLinkContext): User {
+    return user;
   }
 }


### PR DESCRIPTION
## Summary

Update `/me` to return entire user object to render details in profile page

## Testing Plan

Updated unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
