### PR TITLE
refactor(api): Remove check for existing block graffitis

### DIFF
--- a/src/users/users-updater.spec.ts
+++ b/src/users/users-updater.spec.ts
@@ -71,45 +71,6 @@ describe('UsersUpdater', () => {
       });
     });
 
-    describe('if blocks with the new graffiti without a registered user exist on the main chain', () => {
-      it('throws an UnprocessableEntityException', async () => {
-        const hash = uuid();
-        const sequence = faker.datatype.number();
-        const graffiti = uuid();
-
-        const block = await prisma.block.create({
-          data: {
-            hash,
-            main: true,
-            sequence,
-            timestamp: new Date(),
-            transactions_count: 0,
-            graffiti,
-            previous_block_hash: uuid(),
-            network_version: 0,
-            size: faker.datatype.number(),
-            difficulty: faker.datatype.number(),
-          },
-        });
-        const user = await prisma.user.create({
-          data: {
-            confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
-            discord: faker.internet.userName(),
-            email: faker.internet.email(),
-            graffiti: ulid(),
-            country_code: faker.address.countryCode('alpha-3'),
-            telegram: faker.internet.userName(),
-            total_points: 0,
-          },
-        });
-
-        await expect(
-          usersUpdater.update(user, { graffiti: block.graffiti }),
-        ).rejects.toThrow(UnprocessableEntityException);
-      });
-    });
-
     describe('when a user exists for the new discord', () => {
       it('throws an UnprocessableEntityException', async () => {
         const { user: existingUser } = await setupBlockMined();

--- a/src/users/users-updater.ts
+++ b/src/users/users-updater.ts
@@ -29,15 +29,6 @@ export class UsersUpdater {
             message: `Current graffiti '${user.graffiti}' has already mined blocks`,
           });
         }
-
-        const minedBlocksForNewGraffiti =
-          await this.blocksService.countByGraffiti(graffiti, prisma);
-        if (minedBlocksForNewGraffiti > 0) {
-          throw new UnprocessableEntityException({
-            code: 'duplicate_block_graffiti',
-            message: `Blocks with '${graffiti}' already exist`,
-          });
-        }
       }
 
       const users = await this.usersService.findDuplicateUser(


### PR DESCRIPTION
## Summary

This code change deletes the check for updating a User's graffiti to one that has been currently used to mine blocks but is not associated with another User. We initially had this check in place to prevent claiming other points, but it seems like most users are making typos.

## Testing Plan

Removed unneeded unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
