### PR TITLE
Add query parameter to next() on FaucetTransactions

### DIFF
--- a/src/faucet-transactions/dto/next-faucet-transactions.dto.ts
+++ b/src/faucet-transactions/dto/next-faucet-transactions.dto.ts
@@ -9,5 +9,5 @@ export class NextFaucetTransactionsDto {
   @IsOptional()
   @IsInt()
   @Type(() => Number)
-  readonly num?: number;
+  readonly count?: number;
 }

--- a/src/faucet-transactions/faucet-transactions.controller.spec.ts
+++ b/src/faucet-transactions/faucet-transactions.controller.spec.ts
@@ -117,7 +117,7 @@ describe('FaucetTransactionsController', () => {
     });
 
     describe('when multiple FaucetTransactions are requested', () => {
-      it('returns the record', async () => {
+      it('returns the records', async () => {
         jest.spyOn(faucetTransactionsService, 'next').mockResolvedValueOnce([
           {
             id: 0,
@@ -149,16 +149,19 @@ describe('FaucetTransactionsController', () => {
           .query({ num: 2 })
           .expect(HttpStatus.OK);
 
-        expect(body).toMatchObject([
+        const { data } = body;
+        expect(data as unknown[]).toMatchObject([
           {
             object: 'faucet_transaction',
             id: expect.any(Number),
             public_key: expect.any(String),
+            completed_at: null,
           },
           {
             object: 'faucet_transaction',
             id: expect.any(Number),
             public_key: expect.any(String),
+            completed_at: null,
           },
         ]);
       });

--- a/src/faucet-transactions/faucet-transactions.controller.ts
+++ b/src/faucet-transactions/faucet-transactions.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '@nestjs/swagger';
 import is from '@sindresorhus/is';
 import { ApiKeyGuard } from '../auth/guards/api-key.guard';
+import { List } from '../common/interfaces/list';
 import { CompleteFaucetTransactionDto } from './dto/complete-faucet-transaction.dto';
 import { CreateFaucetTransactionDto } from './dto/create-faucet-transaction.dto';
 import { NextFaucetTransactionsDto } from './dto/next-faucet-transactions.dto';
@@ -63,10 +64,10 @@ export class FaucetTransactionsController {
         transform: true,
       }),
     )
-    { num }: NextFaucetTransactionsDto,
-  ): Promise<SerializedFaucetTransaction | SerializedFaucetTransaction[]> {
+    { count }: NextFaucetTransactionsDto,
+  ): Promise<SerializedFaucetTransaction | List<SerializedFaucetTransaction>> {
     const nextFaucetTransactions = await this.faucetTransactionsService.next({
-      num,
+      count,
     });
     if (!nextFaucetTransactions) {
       throw new NotFoundException();
@@ -75,9 +76,12 @@ export class FaucetTransactionsController {
     // TODO: This is temporary measure to avoid downtime in the faucet
     // before we change the faucet service to expect arrays - deekerno
     if (is.array(nextFaucetTransactions)) {
-      return nextFaucetTransactions.map((nextFaucetTransaction) =>
-        serializedFaucetTransactionFromRecord(nextFaucetTransaction),
-      );
+      return {
+        object: 'list',
+        data: nextFaucetTransactions.map((nextFaucetTransaction) =>
+          serializedFaucetTransactionFromRecord(nextFaucetTransaction),
+        ),
+      };
     }
     return serializedFaucetTransactionFromRecord(nextFaucetTransactions);
   }

--- a/src/faucet-transactions/faucet-transactions.service.spec.ts
+++ b/src/faucet-transactions/faucet-transactions.service.spec.ts
@@ -115,9 +115,9 @@ describe('FaucetTransactionService', () => {
           .spyOn(prisma.faucetTransaction, 'findFirst')
           .mockResolvedValueOnce(runningFaucetTransaction);
 
-        expect(
-          await faucetTransactionsService.next({ num: undefined }),
-        ).toMatchObject(runningFaucetTransaction);
+        expect(await faucetTransactionsService.next({})).toMatchObject(
+          runningFaucetTransaction,
+        );
       });
     });
 
@@ -141,9 +141,9 @@ describe('FaucetTransactionService', () => {
           // Waiting to run FaucetTransaction
           .mockResolvedValueOnce(pendingFaucetTransaction);
 
-        expect(
-          await faucetTransactionsService.next({ num: undefined }),
-        ).toMatchObject(pendingFaucetTransaction);
+        expect(await faucetTransactionsService.next({})).toMatchObject(
+          pendingFaucetTransaction,
+        );
       });
     });
 
@@ -180,7 +180,7 @@ describe('FaucetTransactionService', () => {
             ]);
 
           expect(
-            await faucetTransactionsService.next({ num: 2 }),
+            await faucetTransactionsService.next({ count: 2 }),
           ).toMatchObject([
             runningFaucetTransaction1,
             runningFaucetTransaction2,
@@ -232,7 +232,7 @@ describe('FaucetTransactionService', () => {
             ]);
 
           expect(
-            await faucetTransactionsService.next({ num: 3 }),
+            await faucetTransactionsService.next({ count: 3 }),
           ).toMatchObject([
             runningFaucetTransaction1,
             runningFaucetTransaction2,

--- a/src/faucet-transactions/faucet-transactions.service.ts
+++ b/src/faucet-transactions/faucet-transactions.service.ts
@@ -64,10 +64,10 @@ export class FaucetTransactionsService {
   async next(
     options: NextFaucetTransactionsOptions,
   ): Promise<FaucetTransaction | FaucetTransaction[] | null> {
-    const limit = options.num ?? 1;
+    const count = options.count ?? 1;
     // TODO: This is temporary measure to avoid downtime in the faucet
     // before we change the faucet service to expect arrays - deekerno
-    if (limit === 1) {
+    if (count === 1) {
       return this.prisma.$transaction(async (prisma) => {
         const currentlyRunningFaucetTransaction =
           await prisma.faucetTransaction.findFirst({
@@ -108,10 +108,10 @@ export class FaucetTransactionsService {
           orderBy: {
             created_at: Prisma.SortOrder.asc,
           },
-          take: limit,
+          take: count,
         });
-      if (currentlyRunningFaucetTransactions.length < limit) {
-        const diff = limit - currentlyRunningFaucetTransactions.length;
+      if (currentlyRunningFaucetTransactions.length < count) {
+        const diff = count - currentlyRunningFaucetTransactions.length;
         const unfulfilledFaucetTransactions =
           await prisma.faucetTransaction.findMany({
             where: {

--- a/src/faucet-transactions/interfaces/next-faucet-transactions-options.ts
+++ b/src/faucet-transactions/interfaces/next-faucet-transactions-options.ts
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export interface NextFaucetTransactionsOptions {
-  num?: number;
+  count?: number;
 }


### PR DESCRIPTION
## Summary
Add a query parameter to return multiple faucet requests. This should allow for bulk faucet transactions.

## Testing Plan
Added new tests.

## Breaking Change

- [ ] Yes
- [x] No

