### PR TITLE
fix(api): Send over update options and return a 403

### DIFF
--- a/src/users/__snapshots__/users.controller.spec.ts.snap
+++ b/src/users/__snapshots__/users.controller.spec.ts.snap
@@ -109,6 +109,13 @@ Object {
 }
 `;
 
+exports[`UsersController PUT /users/:id with a mismatch in id returns a 403 1`] = `
+Object {
+  "message": "Forbidden",
+  "statusCode": 403,
+}
+`;
+
 exports[`UsersController PUT /users/:id with missing fields returns a 422 1`] = `
 Object {
   "error": "Unprocessable Entity",

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -468,6 +468,29 @@ describe('UsersController', () => {
       });
     });
 
+    describe('with a mismatch in id', () => {
+      it('returns a 403', async () => {
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
+        });
+        await usersService.confirm(user);
+
+        jest
+          .spyOn(magicLinkService, 'getEmailFromHeader')
+          .mockImplementationOnce(() => Promise.resolve(user.email));
+
+        const { body } = await request(app.getHttpServer())
+          .put('/users/0')
+          .set('Authorization', 'token')
+          .send({ discord: 'foo' })
+          .expect(HttpStatus.FORBIDDEN);
+
+        expect(body).toMatchSnapshot();
+      });
+    });
+
     describe('with missing fields', () => {
       it('returns a 422', async () => {
         const user = await usersService.create({

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -4,6 +4,7 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   HttpStatus,
   Param,
@@ -256,6 +257,13 @@ export class UsersController {
   @UseGuards(MagicLinkGuard)
   async update(
     @Context() { user }: MagicLinkContext,
+    @Param(
+      'id',
+      new ParseIntPipe({
+        errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      }),
+    )
+    id: number,
     @Body(
       new ValidationPipe({
         errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
@@ -264,6 +272,14 @@ export class UsersController {
     )
     dto: UpdateUserDto,
   ): Promise<User> {
-    return this.usersUpdater.update(user, dto);
+    if (id !== user.id) {
+      throw new ForbiddenException();
+    }
+    return this.usersUpdater.update(user, {
+      countryCode: dto.country_code,
+      discord: dto.discord,
+      graffiti: dto.graffiti,
+      telegram: dto.telegram,
+    });
   }
 }


### PR DESCRIPTION
## Summary

Explicitly convert DTO to options and check that URL parameter matches the Magic Link user from context

## Testing Plan

Added unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
