### PR TITLE
feat(api): Add unique constraint on graffiti

### DIFF
--- a/prisma/migrations/20211220233419_add_unique_graffiti_constraint_to_users/migration.sql
+++ b/prisma/migrations/20211220233419_add_unique_graffiti_constraint_to_users/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_users_on_graffiti" ON "users"("graffiti");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,7 +32,7 @@ model User {
   created_at          DateTime  @default(now()) @db.Timestamp(6)
   updated_at          DateTime  @default(now()) @updatedAt @db.Timestamp(6)
   email               String    @db.VarChar
-  graffiti            String    @db.VarChar
+  graffiti            String    @db.VarChar @unique(map: "uq_users_on_graffiti")
   total_points        Int       @default(0)
   country_code        String    @db.VarChar
   email_notifications Boolean   @default(false)

--- a/src/users/registration.controller.spec.ts
+++ b/src/users/registration.controller.spec.ts
@@ -63,36 +63,6 @@ describe('RegistrationController', () => {
       });
     });
 
-    describe('with a confirmed user for a different token', () => {
-      it('redirects with an error toast', async () => {
-        const message = 'User already confirmed';
-        const email = faker.internet.email();
-        const user = await usersService.create({
-          email,
-          graffiti: uuid(),
-          country_code: faker.address.countryCode('alpha-3'),
-        });
-        const userFromSecondRegistration = await usersService.create({
-          email,
-          graffiti: uuid(),
-          country_code: faker.address.countryCode('alpha-3'),
-        });
-        await usersService.confirm(user);
-
-        const { header } = await request(app.getHttpServer())
-          .get(
-            `/registration/${userFromSecondRegistration.confirmation_token}/confirm`,
-          )
-          .expect(HttpStatus.FOUND);
-
-        expect((header as Record<string, unknown>).location).toBe(
-          `${config.get<string>(
-            'INCENTIVIZED_TESTNET_URL',
-          )}/login?toast=${Buffer.from(message).toString('base64')}`,
-        );
-      });
-    });
-
     describe('with a valid token and unconfirmed user', () => {
       it('redirects to the login page of the incentivized testnet', async () => {
         const user = await usersService.create({

--- a/src/users/registration.controller.ts
+++ b/src/users/registration.controller.ts
@@ -31,23 +31,11 @@ export class RegistrationController {
       return;
     }
 
-    const existingUser = await this.usersService.findConfirmedByEmail(
-      user.email,
+    await this.usersService.confirm(user);
+    res.redirect(
+      `${this.config.get<string>(
+        'INCENTIVIZED_TESTNET_URL',
+      )}/login?confirmed=true`,
     );
-    if (existingUser) {
-      const message = 'User already confirmed';
-      res.redirect(
-        `${this.config.get<string>(
-          'INCENTIVIZED_TESTNET_URL',
-        )}/login?toast=${Buffer.from(message).toString('base64')}`,
-      );
-    } else {
-      await this.usersService.confirm(user);
-      res.redirect(
-        `${this.config.get<string>(
-          'INCENTIVIZED_TESTNET_URL',
-        )}/login?confirmed=true`,
-      );
-    }
   }
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -258,17 +258,13 @@ describe('UsersService', () => {
   describe('listByEmail', () => {
     it('returns a list of matching users by email', async () => {
       const email = faker.internet.email();
-      const numRecords = 10;
-      for (let i = 0; i < numRecords; i++) {
-        await usersService.create({
-          email,
-          graffiti: uuid(),
-          country_code: faker.address.countryCode('alpha-3'),
-        });
-      }
+      await usersService.create({
+        email,
+        graffiti: uuid(),
+        country_code: faker.address.countryCode('alpha-3'),
+      });
 
       const records = await usersService.listByEmail(email);
-      expect(records).toHaveLength(numRecords);
       for (const record of records) {
         expect(record.email).toBe(standardizeEmail(email));
       }
@@ -326,162 +322,73 @@ describe('UsersService', () => {
 
   describe('create', () => {
     describe('with a duplicate graffiti', () => {
-      describe('with a previously confirmed user', () => {
-        it('throws an exception', async () => {
-          const graffiti = uuid();
-          await prisma.user.create({
-            data: {
-              confirmation_token: ulid(),
-              email: faker.internet.email(),
-              graffiti,
-              country_code: faker.address.countryCode('alpha-3'),
-              confirmed_at: new Date(),
-            },
-          });
-
-          await expect(
-            usersService.create({
-              email: faker.internet.email(),
-              graffiti,
-              country_code: faker.address.countryCode('alpha-3'),
-            }),
-          ).rejects.toThrow(UnprocessableEntityException);
-        });
-      });
-
-      describe('with a user that has not been confirmed', () => {
-        it('creates a record', async () => {
-          const graffiti = uuid();
-          await prisma.user.create({
-            data: {
-              confirmation_token: ulid(),
-              email: faker.internet.email(),
-              graffiti,
-              country_code: faker.address.countryCode('alpha-3'),
-            },
-          });
-
-          const email = faker.internet.email();
-          const user = await usersService.create({
-            email,
+      it('throws an exception', async () => {
+        const graffiti = uuid();
+        await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
+            email: faker.internet.email(),
             graffiti,
             country_code: faker.address.countryCode('alpha-3'),
-          });
-
-          expect(user).toMatchObject({
-            id: expect.any(Number),
-            email: standardizeEmail(email),
-            graffiti,
-          });
+            confirmed_at: new Date(),
+          },
         });
+
+        await expect(
+          usersService.create({
+            email: faker.internet.email(),
+            graffiti,
+            country_code: faker.address.countryCode('alpha-3'),
+          }),
+        ).rejects.toThrow(UnprocessableEntityException);
       });
     });
 
     describe('with a duplicate email', () => {
-      describe('with a previously confirmed user', () => {
-        it('throws an exception', async () => {
-          const email = faker.internet.email();
-          await prisma.user.create({
-            data: {
-              confirmation_token: ulid(),
-              email: standardizeEmail(email),
-              graffiti: uuid(),
-              country_code: faker.address.countryCode('alpha-3'),
-              confirmed_at: new Date(),
-            },
-          });
-
-          await expect(
-            usersService.create({
-              email,
-              graffiti: uuid(),
-              country_code: faker.address.countryCode('alpha-3'),
-            }),
-          ).rejects.toThrow(UnprocessableEntityException);
-        });
-      });
-
-      describe('with a user that has not been confirmed', () => {
-        it('creates a record', async () => {
-          const email = faker.internet.email();
-          await prisma.user.create({
-            data: {
-              confirmation_token: ulid(),
-              email,
-              graffiti: uuid(),
-              country_code: faker.address.countryCode('alpha-3'),
-            },
-          });
-
-          const graffiti = uuid();
-          const user = await usersService.create({
-            email,
-            graffiti,
-            country_code: faker.address.countryCode('alpha-3'),
-          });
-
-          expect(user).toMatchObject({
-            id: expect.any(Number),
+      it('throws an exception', async () => {
+        const email = faker.internet.email();
+        await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
             email: standardizeEmail(email),
-            graffiti,
-          });
+            graffiti: uuid(),
+            country_code: faker.address.countryCode('alpha-3'),
+            confirmed_at: new Date(),
+          },
         });
+
+        await expect(
+          usersService.create({
+            email,
+            graffiti: uuid(),
+            country_code: faker.address.countryCode('alpha-3'),
+          }),
+        ).rejects.toThrow(UnprocessableEntityException);
       });
     });
 
     describe('with a duplicate github', () => {
-      describe('with a previously confirmed user', () => {
-        it('throws an exception', async () => {
-          const github = faker.internet.userName();
-          await prisma.user.create({
-            data: {
-              confirmation_token: ulid(),
-              email: faker.internet.email(),
-              github,
-              graffiti: uuid(),
-              country_code: faker.address.countryCode('alpha-3'),
-              confirmed_at: new Date(),
-            },
-          });
-
-          await expect(
-            usersService.create({
-              email: faker.internet.email(),
-              graffiti: uuid(),
-              github,
-              country_code: faker.address.countryCode('alpha-3'),
-            }),
-          ).rejects.toThrow(UnprocessableEntityException);
-        });
-      });
-
-      describe('with a user that has not been confirmed', () => {
-        it('creates a record', async () => {
-          const github = faker.internet.userName();
-          await prisma.user.create({
-            data: {
-              confirmation_token: ulid(),
-              email: faker.internet.email(),
-              graffiti: uuid(),
-              github,
-              country_code: faker.address.countryCode('alpha-3'),
-            },
-          });
-
-          const email = faker.internet.email();
-          const user = await usersService.create({
-            email,
+      it('throws an exception', async () => {
+        const github = faker.internet.userName();
+        await prisma.user.create({
+          data: {
+            confirmation_token: ulid(),
+            email: faker.internet.email(),
             github,
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
-          });
-
-          expect(user).toMatchObject({
-            id: expect.any(Number),
-            email: standardizeEmail(email),
-            github,
-          });
+            confirmed_at: new Date(),
+          },
         });
+
+        await expect(
+          usersService.create({
+            email: faker.internet.email(),
+            graffiti: uuid(),
+            github,
+            country_code: faker.address.countryCode('alpha-3'),
+          }),
+        ).rejects.toThrow(UnprocessableEntityException);
       });
     });
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -118,9 +118,6 @@ export class UsersService {
     email = standardizeEmail(email);
     const existingRecord = await this.prisma.user.findFirst({
       where: {
-        confirmed_at: {
-          not: null,
-        },
         OR: [
           {
             email,


### PR DESCRIPTION
## Summary

This code change introduces a migration to enforce uniqueness at the DB level for user graffitis. We can start to add these constraints since the UI has user settings in development and adhoc update requests have died down. I think we should remove confirmation checks and begin to use duplicate checks, and we do manual updates for users if needed.

This code change also removes the existing email check from the registration controller.

## Testing Plan

Cleaned up irrelevant old unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```

This migration will fail if there are duplicate rows for a given `graffiti`. Duplicate rows have been merged. Production DB check: 

```sql
ironfish-api-production::DATABASE=> SELECT graffiti, COUNT(*) FROM users GROUP BY graffiti HAVING COUNT(*) > 1;
 graffiti | count
----------+-------
(0 rows)
```