### PR TITLE
fix(api): Add explicit `main` filter when searching by sequence

### DIFF
--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -241,6 +241,7 @@ describe('BlocksService', () => {
           sequence: testBlockSequence,
         });
         expect(block).toMatchObject(record as Block);
+        expect(block.main).toBe(true);
       });
     });
 

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -490,6 +490,7 @@ export class BlocksService {
       const block = await this.prisma.block.findFirst({
         where: {
           sequence: options.sequence,
+          main: true,
           network_version: networkVersion,
         },
       });

--- a/src/blocks/dto/block-query.dto.ts
+++ b/src/blocks/dto/block-query.dto.ts
@@ -22,7 +22,10 @@ export class BlockQueryDto {
   @IsString()
   readonly hash?: string;
 
-  @ApiPropertyOptional({ description: 'Block sequence' })
+  @ApiPropertyOptional({
+    description:
+      'Block sequence. Will only return blocks on the main chain if provided',
+  })
   @ValidateIf((o: BlockQueryDto) => o.hash === undefined)
   @IsDefined({
     message: '"hash" or "sequence" required to query for single block',


### PR DESCRIPTION
## Summary

Right now, the `/blocks/find` endpoint does not have a `main` filter for `hash` or `sequence`. This filter adds an explicit `main: true` filter for sequence so we only return main blocks by sequence. 

## Testing Plan

Updated unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
