### PR TITLE
feat(api): Enqueue daily snapshot sync jobs on upserts

### DIFF
--- a/src/blocks-daily/blocks-daily.service.spec.ts
+++ b/src/blocks-daily/blocks-daily.service.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
+import { getNextDate } from '../common/utils/date';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { BlocksDailyService } from './blocks-daily.service';
@@ -105,6 +106,26 @@ describe('BlocksDailyService', () => {
         transactions_count: options.transactionsCount,
         unique_graffiti_count: options.uniqueGraffiti,
       });
+    });
+  });
+
+  describe('getNextDateToSync', () => {
+    it('returns the next date from the last daily snapshot', async () => {
+      const options = {
+        averageBlockTimeMs: 0,
+        averageDifficultyMillis: 0,
+        blocksCount: 0,
+        blocksWithGraffitiCount: 0,
+        chainSequence: 0,
+        cumulativeUniqueGraffiti: 0,
+        date: new Date('3000-01-01'),
+        transactionsCount: 0,
+        uniqueGraffiti: 0,
+      };
+
+      const blockDaily = await blocksDailyService.upsert(prisma, options);
+      const nextSyncDate = await blocksDailyService.getNextDateToSync();
+      expect(nextSyncDate).toEqual(getNextDate(blockDaily.date));
     });
   });
 });

--- a/src/blocks-daily/blocks-daily.service.ts
+++ b/src/blocks-daily/blocks-daily.service.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable } from '@nestjs/common';
+import { getNextDate } from '../common/utils/date';
 import { PrismaService } from '../prisma/prisma.service';
 import { BasePrismaClient } from '../prisma/types/base-prisma-client';
 import { CreateBlocksDailyOptions } from './interfaces/create-blocks-daily-options';
@@ -52,5 +53,20 @@ export class BlocksDailyService {
         date: options.date,
       },
     });
+  }
+
+  async getNextDateToSync(): Promise<Date> {
+    const aggregate = await this.prisma.blockDaily.aggregate({
+      _max: {
+        date: true,
+      },
+    });
+    // 2021 December 1 12 AM UTC
+    const defaultStart = new Date(Date.UTC(2021, 11, 1, 0, 0, 0));
+    const latestDate = aggregate._max.date;
+    if (!latestDate) {
+      return defaultStart;
+    }
+    return getNextDate(latestDate);
   }
 }

--- a/src/blocks-transactions-loader/blocks-transactions-loader.module.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.module.ts
@@ -3,15 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
 import { BlocksModule } from '../blocks/blocks.module';
+import { BlocksDailyModule } from '../blocks-daily/blocks-daily.module';
 import { BlocksTransactionsModule } from '../blocks-transactions/blocks-transactions.module';
 import { GraphileWorkerModule } from '../graphile-worker/graphile-worker.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { TransactionsModule } from '../transactions/transactions.module';
-import { BlocksTransactionsLoader } from './block-transactions-loader';
+import { BlocksTransactionsLoader } from './blocks-transactions-loader';
 
 @Module({
   exports: [BlocksTransactionsLoader],
   imports: [
+    BlocksDailyModule,
     BlocksModule,
     BlocksTransactionsModule,
     GraphileWorkerModule,

--- a/src/blocks-transactions-loader/blocks-transactions-loader.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@nestjs/common';
 import { Block, Transaction } from '@prisma/client';
 import { BlocksService } from '../blocks/blocks.service';
 import { UpsertBlocksDto } from '../blocks/dto/upsert-blocks.dto';
+import { BlocksDailyService } from '../blocks-daily/blocks-daily.service';
 import { BlocksTransactionsService } from '../blocks-transactions/blocks-transactions.service';
 import { DeleteBlockMinedEventOptions } from '../events/interfaces/delete-block-mined-event-options';
 import { UpsertBlockMinedEventOptions } from '../events/interfaces/upsert-block-mined-event-options';
@@ -16,8 +17,9 @@ import { TransactionsService } from '../transactions/transactions.service';
 @Injectable()
 export class BlocksTransactionsLoader {
   constructor(
-    private readonly blocksTransactionsService: BlocksTransactionsService,
+    private readonly blocksDailyService: BlocksDailyService,
     private readonly blocksService: BlocksService,
+    private readonly blocksTransactionsService: BlocksTransactionsService,
     private readonly graphileWorkerService: GraphileWorkerService,
     private readonly prisma: PrismaService,
     private readonly transactionsService: TransactionsService,
@@ -86,6 +88,13 @@ export class BlocksTransactionsLoader {
         },
       );
     }
+
+    await this.graphileWorkerService.addJob(
+      GraphileWorkerPattern.SYNC_BLOCKS_DAILY,
+      {
+        date: await this.blocksDailyService.getNextDateToSync(),
+      },
+    );
 
     return response;
   }

--- a/src/blocks/blocks.controller.spec.ts
+++ b/src/blocks/blocks.controller.spec.ts
@@ -8,6 +8,7 @@ import request from 'supertest';
 import { v4 as uuid } from 'uuid';
 import { BlocksDailyService } from '../blocks-daily/blocks-daily.service';
 import { MetricsGranularity } from '../common/enums/metrics-granularity';
+import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { BlocksService } from './blocks.service';
@@ -21,12 +22,14 @@ describe('BlocksController', () => {
   let app: INestApplication;
   let blocksDailyService: BlocksDailyService;
   let blocksService: BlocksService;
+  let graphileWorkerService: GraphileWorkerService;
   let prisma: PrismaService;
 
   beforeAll(async () => {
     app = await bootstrapTestApp();
     blocksDailyService = app.get(BlocksDailyService);
     blocksService = app.get(BlocksService);
+    graphileWorkerService = app.get(GraphileWorkerService);
     prisma = app.get(PrismaService);
     await app.init();
   });
@@ -119,6 +122,9 @@ describe('BlocksController', () => {
 
     describe('with a valid payload', () => {
       it('upserts blocks', async () => {
+        jest
+          .spyOn(graphileWorkerService, 'addJob')
+          .mockImplementationOnce(jest.fn());
         const payload: UpsertBlocksDto = {
           blocks: [
             {

--- a/src/blocks/blocks.controller.ts
+++ b/src/blocks/blocks.controller.ts
@@ -18,7 +18,7 @@ import { ApiExcludeEndpoint, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { ApiKeyGuard } from '../auth/guards/api-key.guard';
 import { BlocksDailyService } from '../blocks-daily/blocks-daily.service';
-import { BlocksTransactionsLoader } from '../blocks-transactions-loader/block-transactions-loader';
+import { BlocksTransactionsLoader } from '../blocks-transactions-loader/blocks-transactions-loader';
 import { MS_PER_DAY } from '../common/constants';
 import { MetricsGranularity } from '../common/enums/metrics-granularity';
 import { List } from '../common/interfaces/list';


### PR DESCRIPTION
## Summary

Right now the charts are manually updated. This code change enqueues sync jobs every time we receive an upsert blocks payload.

## Testing Plan

Updated unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
