### PR TITLE
feat(api): Add unique constraint to `users.email`

### DIFF
--- a/prisma/migrations/20211221214404_add_unique_email_constraint_to_users/migration.sql
+++ b/prisma/migrations/20211221214404_add_unique_email_constraint_to_users/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_users_on_email" ON "users"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,11 +17,10 @@ model Event {
   points      Int
   user_id     Int
   deleted_at  DateTime? @db.Timestamp(6)
-  block_id    Int?
+  block_id    Int?      @unique(map: "uq_events_on_block_id")
   block       Block?    @relation(fields: [block_id], references: [id])
   user        User      @relation(fields: [user_id], references: [id])
 
-  @@unique([block_id], name: "uq_events_on_block_id")
   @@index([block_id], name: "index_events_on_block_id")
   @@index([user_id], name: "index_events_on_user_id")
   @@map("events")
@@ -31,7 +30,7 @@ model User {
   id                  Int       @id @default(autoincrement())
   created_at          DateTime  @default(now()) @db.Timestamp(6)
   updated_at          DateTime  @default(now()) @updatedAt @db.Timestamp(6)
-  email               String    @db.VarChar
+  email               String    @db.VarChar @unique(map: "uq_users_on_email")
   graffiti            String    @db.VarChar @unique(map: "uq_users_on_graffiti")
   total_points        Int       @default(0)
   country_code        String    @db.VarChar
@@ -39,12 +38,11 @@ model User {
   last_login_at       DateTime? @db.Timestamp(6)
   discord             String?   @db.VarChar
   telegram            String?   @db.VarChar
-  confirmation_token  String    @db.VarChar
+  confirmation_token  String    @db.VarChar @unique(map: "uq_users_on_confirmation_token")
   confirmed_at        DateTime? @db.Timestamp(6)
   github              String?   @db.VarChar
   events              Event[]
 
-  @@unique([confirmation_token], name: "uq_users_on_confirmation_token")
   @@index([confirmation_token], name: "index_users_on_confirmation_token")
   @@index([email], name: "index_users_on_email")
   @@index([graffiti], name: "index_users_on_graffiti")
@@ -126,7 +124,7 @@ model BlockDaily {
   id                         Int      @id @default(autoincrement())
   created_at                 DateTime @default(now()) @db.Timestamp(6)
   updated_at                 DateTime @default(now()) @updatedAt @db.Timestamp(6)
-  date                       DateTime @db.Timestamp(6)
+  date                       DateTime @db.Timestamp(6) @unique(map: "uq_blocks_daily_on_date")
   unique_graffiti_count      Int
   average_block_time_ms      Int
   blocks_count               Int
@@ -136,7 +134,6 @@ model BlockDaily {
   average_difficulty_millis  BigInt
   chain_sequence             Int
 
-  @@unique([date], name: "uq_blocks_daily_on_date")
   @@index([date], map: "index_blocks_daily_on_date")
   @@map("blocks_daily")
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -172,14 +172,6 @@ describe('UsersService', () => {
     describe('with a valid email', () => {
       it('returns the confirmed record', async () => {
         const email = faker.internet.email();
-        await prisma.user.create({
-          data: {
-            confirmation_token: ulid(),
-            email,
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
-        });
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
@@ -208,14 +200,6 @@ describe('UsersService', () => {
     describe('with a valid email', () => {
       it('returns the confirmed record', async () => {
         const email = faker.internet.email();
-        await prisma.user.create({
-          data: {
-            confirmation_token: ulid(),
-            email,
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
-        });
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),


### PR DESCRIPTION
## Summary

This code change introduces a migration to enforce uniqueness at the DB level for user emails.

## Testing Plan

Updated unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```

Checking production database:

```sql
ironfish-api-production::DATABASE=> SELECT email, COUNT(*) FROM users GROUP BY email HAVING COUNT(*) > 1;
 email | count
-------+-------
(0 rows)
```
