### PR TITLE
feat(api): Remove confirmation check when assigning points

### DIFF
--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -95,10 +95,7 @@ export class BlocksService {
       },
     });
 
-    const user = await this.usersService.findConfirmedByGraffiti(
-      graffiti,
-      prisma,
-    );
+    const user = await this.usersService.findByGraffiti(graffiti, prisma);
     if (user && timestamp > user.created_at) {
       if (main) {
         upsertBlockMinedOptions = { block_id: block.id, user_id: user.id };

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -68,9 +68,7 @@ export class EventsController {
     )
     { graffiti, points, type, occurred_at: occurredAt }: CreateEventDto,
   ): Promise<SerializedEvent | null> {
-    const user = await this.usersService.findConfirmedByGraffitiOrThrow(
-      graffiti,
-    );
+    const user = await this.usersService.findByGraffitiOrThrow(graffiti);
     const event = await this.eventsService.create({
       type,
       points,

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -87,7 +87,7 @@ describe('UsersService', () => {
     });
   });
 
-  describe('findConfirmedByGraffiti', () => {
+  describe('findByGraffiti', () => {
     describe('with a valid graffiti', () => {
       it('returns the record', async () => {
         const user = await prisma.user.create({
@@ -99,39 +99,20 @@ describe('UsersService', () => {
             confirmed_at: new Date(),
           },
         });
-        const record = await usersService.findConfirmedByGraffiti(
-          user.graffiti,
-        );
+        const record = await usersService.findByGraffiti(user.graffiti);
         expect(record).not.toBeNull();
         expect(record).toMatchObject(user);
       });
     });
 
-    describe('with a user not logged in yet', () => {
+    describe('with a missing graffiti', () => {
       it('returns null', async () => {
-        const user = await prisma.user.create({
-          data: {
-            confirmation_token: ulid(),
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
-        });
-        const record = await usersService.findConfirmedByGraffiti(
-          user.graffiti,
-        );
-        expect(record).toBeNull();
-      });
-    });
-
-    describe('with a missing id', () => {
-      it('returns null', async () => {
-        expect(await usersService.findConfirmedByGraffiti('1337')).toBeNull();
+        expect(await usersService.findByGraffiti('1337')).toBeNull();
       });
     });
   });
 
-  describe('findConfirmedByGraffitiOrThrow', () => {
+  describe('findByGraffitiOrThrow', () => {
     describe('with a valid graffiti', () => {
       it('returns the record', async () => {
         const user = await prisma.user.create({
@@ -143,9 +124,7 @@ describe('UsersService', () => {
             country_code: faker.address.countryCode('alpha-3'),
           },
         });
-        const record = await usersService.findConfirmedByGraffitiOrThrow(
-          user.graffiti,
-        );
+        const record = await usersService.findByGraffitiOrThrow(user.graffiti);
         expect(record).not.toBeNull();
         expect(record).toMatchObject(user);
       });
@@ -154,7 +133,7 @@ describe('UsersService', () => {
     describe('with a missing graffiti', () => {
       it('throws an exception', async () => {
         await expect(
-          usersService.findConfirmedByGraffitiOrThrow('1337'),
+          usersService.findByGraffitiOrThrow('1337'),
         ).rejects.toThrow(NotFoundException);
       });
     });
@@ -172,14 +151,6 @@ describe('UsersService', () => {
     describe('with a valid email', () => {
       it('returns the confirmed record', async () => {
         const email = faker.internet.email();
-        await prisma.user.create({
-          data: {
-            confirmation_token: ulid(),
-            email,
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
-        });
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
@@ -208,14 +179,6 @@ describe('UsersService', () => {
     describe('with a valid email', () => {
       it('returns the confirmed record', async () => {
         const email = faker.internet.email();
-        await prisma.user.create({
-          data: {
-            confirmation_token: ulid(),
-            email,
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
-        });
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -48,7 +48,7 @@ export class UsersService {
     return record;
   }
 
-  async findConfirmedByGraffiti(
+  async findByGraffiti(
     graffiti: string,
     prisma?: BasePrismaClient,
   ): Promise<User | null> {
@@ -56,15 +56,12 @@ export class UsersService {
     return client.user.findFirst({
       where: {
         graffiti,
-        confirmed_at: {
-          not: null,
-        },
       },
     });
   }
 
-  async findConfirmedByGraffitiOrThrow(graffiti: string): Promise<User> {
-    const record = await this.findConfirmedByGraffiti(graffiti);
+  async findByGraffitiOrThrow(graffiti: string): Promise<User> {
+    const record = await this.findByGraffiti(graffiti);
     if (!record) {
       throw new NotFoundException();
     }


### PR DESCRIPTION
## Summary

As part of removing confirmation emails, we should remove confirmation timestamp checks when assigning points.

## Testing Plan

Updated unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
