### PR TITLE
refactor(api): Remove confirmed check for upsert/delete block mined

### DIFF
--- a/src/events/events.jobs.controller.ts
+++ b/src/events/events.jobs.controller.ts
@@ -26,7 +26,7 @@ export class EventsJobsController {
     block_id: blockId,
     user_id: userId,
   }: UpsertBlockMinedEventOptions): Promise<GraphileWorkerHandlerResponse> {
-    const user = await this.usersService.findConfirmed(userId);
+    const user = await this.usersService.find(userId);
     if (!user) {
       this.loggerService.error(`No user found for '${userId}'`, '');
       return { requeue: false };
@@ -47,7 +47,7 @@ export class EventsJobsController {
     block_id: blockId,
     user_id: userId,
   }: DeleteBlockMinedEventOptions): Promise<GraphileWorkerHandlerResponse> {
-    const user = await this.usersService.findConfirmed(userId);
+    const user = await this.usersService.find(userId);
     if (!user) {
       this.loggerService.error(`No user found for '${userId}'`, '');
       return { requeue: false };

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -32,7 +32,7 @@ describe('UsersService', () => {
     await app.close();
   });
 
-  describe('findConfirmed', () => {
+  describe('find', () => {
     describe('with a valid id', () => {
       it('returns the record', async () => {
         const user = await prisma.user.create({
@@ -44,7 +44,7 @@ describe('UsersService', () => {
             country_code: faker.address.countryCode('alpha-3'),
           },
         });
-        const record = await usersService.findConfirmed(user.id);
+        const record = await usersService.find(user.id);
         expect(record).not.toBeNull();
         expect(record).toMatchObject(user);
       });
@@ -52,7 +52,7 @@ describe('UsersService', () => {
 
     describe('with a missing id', () => {
       it('returns null', async () => {
-        expect(await usersService.findConfirmed(100000)).toBeNull();
+        expect(await usersService.find(100000)).toBeNull();
       });
     });
   });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -24,18 +24,14 @@ import { Prisma, User } from '.prisma/client';
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findConfirmed(id: number): Promise<User | null> {
-    const record = await this.prisma.user.findUnique({
+  async find(id: number): Promise<User | null> {
+    return this.prisma.user.findUnique({
       where: { id },
     });
-    if (record === null || record.confirmed_at === null) {
-      return null;
-    }
-    return record;
   }
 
   async findOrThrow(id: number): Promise<User> {
-    const record = await this.findConfirmed(id);
+    const record = await this.find(id);
     if (record === null) {
       throw new NotFoundException();
     }


### PR DESCRIPTION
## Summary

Don't check for a confirmation flag when upserting and deleting events for blocks mined.

## Testing Plan

Updated unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
