### PR TITLE
refactor(api): Remove unused `confirmed_at` checks

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -81,7 +81,6 @@ describe('AuthController', () => {
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         const updateLastLoginAt = jest.spyOn(usersService, 'updateLastLoginAt');
         jest

--- a/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
@@ -109,7 +109,6 @@ describe('BlocksTransactionsLoader', () => {
           graffiti,
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
         const blocks = await blocksTransactionsLoader.bulkUpsert({
           blocks: [
             {
@@ -144,7 +143,6 @@ describe('BlocksTransactionsLoader', () => {
           graffiti,
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
         const blocks = await blocksTransactionsLoader.bulkUpsert({
           blocks: [
             {

--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -89,7 +89,6 @@ describe('BlocksService', () => {
         graffiti,
         country_code: faker.address.countryCode('alpha-3'),
       });
-      await usersService.confirm(user);
       const options = {
         hash: uuid(),
         sequence: faker.datatype.number(),

--- a/src/events/events.controller.spec.ts
+++ b/src/events/events.controller.spec.ts
@@ -150,7 +150,6 @@ describe('EventsController', () => {
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
-            confirmed_at: new Date(),
           },
         });
         const occurredAt = new Date().toISOString();

--- a/src/events/events.jobs.controller.spec.ts
+++ b/src/events/events.jobs.controller.spec.ts
@@ -78,7 +78,6 @@ describe('EventsJobsController', () => {
           graffiti: ulid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         await eventsJobsController.upsertBlockMinedEvent({
           block_id: 12345,
@@ -94,7 +93,6 @@ describe('EventsJobsController', () => {
           graffiti: ulid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         const { requeue } = await eventsJobsController.upsertBlockMinedEvent({
           block_id: 12345,
@@ -123,7 +121,6 @@ describe('EventsJobsController', () => {
           graffiti: ulid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         const { requeue } = await eventsJobsController.upsertBlockMinedEvent({
           block_id: block.id,
@@ -150,7 +147,6 @@ describe('EventsJobsController', () => {
           graffiti: ulid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         const upsertBlockMined = jest.spyOn(eventsService, 'upsertBlockMined');
         await eventsJobsController.upsertBlockMinedEvent({
@@ -194,7 +190,6 @@ describe('EventsJobsController', () => {
           graffiti: ulid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         await eventsJobsController.deleteBlockMinedEvent({
           block_id: 12345,
@@ -210,7 +205,6 @@ describe('EventsJobsController', () => {
           graffiti: ulid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         const { requeue } = await eventsJobsController.deleteBlockMinedEvent({
           block_id: 12345,
@@ -239,7 +233,6 @@ describe('EventsJobsController', () => {
           graffiti: ulid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         const { requeue } = await eventsJobsController.deleteBlockMinedEvent({
           block_id: block.id,
@@ -266,7 +259,6 @@ describe('EventsJobsController', () => {
           graffiti: ulid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         const deleteBlockMined = jest.spyOn(eventsService, 'deleteBlockMined');
         await eventsJobsController.deleteBlockMinedEvent({

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -63,7 +63,6 @@ describe('EventsService', () => {
     const user = await prisma.user.create({
       data: {
         confirmation_token: ulid(),
-        confirmed_at: new Date().toISOString(),
         email: faker.internet.email(),
         graffiti: uuid(),
         country_code: faker.address.countryCode('alpha-3'),
@@ -346,7 +345,6 @@ describe('EventsService', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -370,7 +368,6 @@ describe('EventsService', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -428,7 +425,6 @@ describe('EventsService', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             total_points: currentPointsThisWeek,
@@ -515,7 +511,6 @@ describe('EventsService', () => {
       const user = await prisma.user.create({
         data: {
           confirmation_token: ulid(),
-          confirmed_at: new Date().toISOString(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),

--- a/src/users/me.controller.spec.ts
+++ b/src/users/me.controller.spec.ts
@@ -43,7 +43,6 @@ describe('MeController', () => {
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         jest
           .spyOn(magicLinkService, 'getEmailFromHeader')

--- a/src/users/users-updater.spec.ts
+++ b/src/users/users-updater.spec.ts
@@ -49,7 +49,6 @@ describe('UsersUpdater', () => {
     const user = await prisma.user.create({
       data: {
         confirmation_token: ulid(),
-        confirmed_at: new Date().toISOString(),
         discord: faker.internet.userName(),
         email: faker.internet.email(),
         graffiti,
@@ -77,7 +76,6 @@ describe('UsersUpdater', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: ulid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -97,7 +95,6 @@ describe('UsersUpdater', () => {
         const existingUser = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             discord: faker.internet.userName(),
             email: faker.internet.email(),
             graffiti: ulid(),
@@ -109,7 +106,6 @@ describe('UsersUpdater', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: ulid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -129,7 +125,6 @@ describe('UsersUpdater', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: ulid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -154,7 +149,6 @@ describe('UsersUpdater', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: ulid(),
             country_code: faker.address.countryCode('alpha-3'),

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -39,7 +39,6 @@ describe('UsersController', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode(),
@@ -198,7 +197,6 @@ describe('UsersController', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -246,7 +244,6 @@ describe('UsersController', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -475,7 +472,6 @@ describe('UsersController', () => {
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         jest
           .spyOn(magicLinkService, 'getEmailFromHeader')
@@ -498,7 +494,6 @@ describe('UsersController', () => {
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         jest
           .spyOn(magicLinkService, 'getEmailFromHeader')
@@ -520,7 +515,6 @@ describe('UsersController', () => {
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
         });
-        await usersService.confirm(user);
 
         jest
           .spyOn(magicLinkService, 'getEmailFromHeader')

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -38,7 +38,6 @@ describe('UsersService', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -63,7 +62,6 @@ describe('UsersService', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -115,7 +113,6 @@ describe('UsersService', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -151,7 +148,6 @@ describe('UsersService', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email,
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -177,7 +173,6 @@ describe('UsersService', () => {
         const user = await prisma.user.create({
           data: {
             confirmation_token: ulid(),
-            confirmed_at: new Date().toISOString(),
             email,
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -288,7 +283,6 @@ describe('UsersService', () => {
             email: standardizeEmail(email),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
-            confirmed_at: new Date(),
           },
         });
 
@@ -312,7 +306,6 @@ describe('UsersService', () => {
             github,
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
-            confirmed_at: new Date(),
           },
         });
 
@@ -374,7 +367,6 @@ describe('UsersService', () => {
       const firstUser = await prisma.user.create({
         data: {
           confirmation_token: ulid(),
-          confirmed_at: new Date().toISOString(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -384,7 +376,6 @@ describe('UsersService', () => {
       const secondUser = await prisma.user.create({
         data: {
           confirmation_token: ulid(),
-          confirmed_at: new Date().toISOString(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -394,7 +385,6 @@ describe('UsersService', () => {
       const thirdUser = await prisma.user.create({
         data: {
           confirmation_token: ulid(),
-          confirmed_at: new Date().toISOString(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -424,20 +414,6 @@ describe('UsersService', () => {
     });
   });
 
-  describe('confirm', () => {
-    it('updates the confirmation timestamp', async () => {
-      const user = await usersService.create({
-        email: faker.internet.email(),
-        graffiti: uuid(),
-        country_code: faker.address.countryCode('alpha-3'),
-      });
-      expect(user.confirmed_at).toBeNull();
-
-      const updatedUser = await usersService.confirm(user);
-      expect(updatedUser.confirmed_at).not.toBeNull();
-    });
-  });
-
   describe('findDuplicateUser', () => {
     describe('with a duplicate discord', () => {
       it('returns the duplicate records', async () => {
@@ -453,7 +429,6 @@ describe('UsersService', () => {
           email: faker.internet.email(),
           graffiti: uuid(),
         });
-        await usersService.confirm(duplicateUser);
 
         assert.ok(duplicateUser.discord);
         const duplicateUsers = await usersService.findDuplicateUser(
@@ -479,7 +454,6 @@ describe('UsersService', () => {
           email: faker.internet.email(),
           graffiti: uuid(),
         });
-        await usersService.confirm(duplicateUser);
 
         const duplicateUsers = await usersService.findDuplicateUser(
           user,
@@ -506,7 +480,6 @@ describe('UsersService', () => {
           graffiti: uuid(),
           telegram: ulid(),
         });
-        await usersService.confirm(duplicateUser);
 
         assert.ok(duplicateUser.telegram);
         const duplicateUsers = await usersService.findDuplicateUser(

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -147,9 +147,6 @@ export class UsersService {
       graffiti: {
         contains: options.search,
       },
-      confirmed_at: {
-        not: null,
-      },
     };
     const data = await this.prisma.user.findMany({
       cursor,
@@ -269,8 +266,6 @@ export class UsersService {
             ) user_latest_events
           ON
             user_latest_events.user_id = users.id
-          WHERE
-            confirmed_at IS NOT NULL
         ) user_ranks
       WHERE
         graffiti ILIKE $1 AND
@@ -403,8 +398,6 @@ export class UsersService {
             ) user_latest_events
           ON
             user_latest_events.user_id = users.id
-          WHERE
-            users.confirmed_at IS NOT NULL
         ) user_ranks
       WHERE
         id = $1`,
@@ -422,19 +415,6 @@ export class UsersService {
     return rankResponse[0].rank;
   }
 
-  async confirm(user: User): Promise<User> {
-    return this.prisma.$transaction(async (prisma) => {
-      return prisma.user.update({
-        where: {
-          id: user.id,
-        },
-        data: {
-          confirmed_at: new Date().toISOString(),
-        },
-      });
-    });
-  }
-
   async findDuplicateUser(
     user: User,
     options: UpdateUserOptions,
@@ -443,9 +423,6 @@ export class UsersService {
     const { discord, graffiti, telegram } = options;
     return client.user.findMany({
       where: {
-        confirmed_at: {
-          not: null,
-        },
         OR: [{ discord }, { graffiti }, { telegram }],
         NOT: {
           id: user.id,


### PR DESCRIPTION
## Summary

These confirmation checks are not needed and unused.

## Testing Plan

Cleaned up irrelevant unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
