### PR TITLE
refactor(api): Drop confirmation columns from `users`

### DIFF
--- a/prisma/migrations/20211223214755_remove_confirmation_from_users/migration.sql
+++ b/prisma/migrations/20211223214755_remove_confirmation_from_users/migration.sql
@@ -1,0 +1,9 @@
+-- DropIndex
+DROP INDEX "index_users_on_confirmation_token";
+
+-- DropIndex
+DROP INDEX "uq_users_on_confirmation_token";
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "confirmation_token",
+DROP COLUMN "confirmed_at";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,12 +38,9 @@ model User {
   last_login_at       DateTime? @db.Timestamp(6)
   discord             String?   @db.VarChar
   telegram            String?   @db.VarChar
-  confirmation_token  String    @db.VarChar @unique(map: "uq_users_on_confirmation_token")
-  confirmed_at        DateTime? @db.Timestamp(6)
   github              String?   @db.VarChar
   events              Event[]
 
-  @@index([confirmation_token], name: "index_users_on_confirmation_token")
   @@index([email], name: "index_users_on_email")
   @@index([graffiti], name: "index_users_on_graffiti")
   @@map("users")

--- a/src/events/events.controller.spec.ts
+++ b/src/events/events.controller.spec.ts
@@ -4,7 +4,6 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import faker from 'faker';
 import request from 'supertest';
-import { ulid } from 'ulid';
 import { v4 as uuid } from 'uuid';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -51,7 +50,6 @@ describe('EventsController', () => {
       it('returns events only for that user', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -146,7 +144,6 @@ describe('EventsController', () => {
       it('creates an event record', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -4,7 +4,6 @@
 import { INestApplication } from '@nestjs/common';
 import assert from 'assert';
 import faker from 'faker';
-import { ulid } from 'ulid';
 import { v4 as uuid } from 'uuid';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { serializedBlockFromRecord } from '../blocks/utils/block-translator';
@@ -62,7 +61,6 @@ describe('EventsService', () => {
     });
     const user = await prisma.user.create({
       data: {
-        confirmation_token: ulid(),
         email: faker.internet.email(),
         graffiti: uuid(),
         country_code: faker.address.countryCode('alpha-3'),
@@ -90,7 +88,6 @@ describe('EventsService', () => {
     const setup = async () => {
       const user = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -128,7 +125,6 @@ describe('EventsService', () => {
       it('returns no records', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -225,7 +221,6 @@ describe('EventsService', () => {
       };
       const user = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -266,7 +261,6 @@ describe('EventsService', () => {
       const now = new Date();
       const user = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -344,7 +338,6 @@ describe('EventsService', () => {
 
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -367,7 +360,6 @@ describe('EventsService', () => {
         const points = 1000;
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -393,7 +385,6 @@ describe('EventsService', () => {
         const points = 1000;
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -424,7 +415,6 @@ describe('EventsService', () => {
         const currentPointsThisWeek = 900;
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             total_points: currentPointsThisWeek,
@@ -453,7 +443,6 @@ describe('EventsService', () => {
         const currentPointsThisWeek = 900;
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -486,7 +475,6 @@ describe('EventsService', () => {
       it('defaults to the points specified in the registry', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -510,7 +498,6 @@ describe('EventsService', () => {
     it('increments the total points for a user', async () => {
       const user = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -531,7 +518,6 @@ describe('EventsService', () => {
     it('stores an event record', async () => {
       const user = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -727,7 +713,6 @@ describe('EventsService', () => {
         highestCommunityContributionAggregate._max.points || 0;
       const firstUser = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -735,7 +720,6 @@ describe('EventsService', () => {
       });
       const secondUser = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),

--- a/src/users/users-updater.spec.ts
+++ b/src/users/users-updater.spec.ts
@@ -48,7 +48,6 @@ describe('UsersUpdater', () => {
     });
     const user = await prisma.user.create({
       data: {
-        confirmation_token: ulid(),
         discord: faker.internet.userName(),
         email: faker.internet.email(),
         graffiti,
@@ -75,7 +74,6 @@ describe('UsersUpdater', () => {
         const { user: existingUser } = await setupBlockMined();
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: ulid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -94,7 +92,6 @@ describe('UsersUpdater', () => {
       it('throws an UnprocessableEntityException', async () => {
         const existingUser = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             discord: faker.internet.userName(),
             email: faker.internet.email(),
             graffiti: ulid(),
@@ -105,7 +102,6 @@ describe('UsersUpdater', () => {
         });
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: ulid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -124,7 +120,6 @@ describe('UsersUpdater', () => {
         const { user: existingUser } = await setupBlockMined();
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: ulid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -148,7 +143,6 @@ describe('UsersUpdater', () => {
         };
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: ulid(),
             country_code: faker.address.countryCode('alpha-3'),

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -4,7 +4,6 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import faker from 'faker';
 import request from 'supertest';
-import { ulid } from 'ulid';
 import { v4 as uuid } from 'uuid';
 import { MetricsGranularity } from '../common/enums/metrics-granularity';
 import { standardizeEmail } from '../common/utils/email';
@@ -38,7 +37,6 @@ describe('UsersController', () => {
       it('returns the user', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode(),
@@ -196,7 +194,6 @@ describe('UsersController', () => {
       it('returns the lifetime metrics for the user', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -243,7 +240,6 @@ describe('UsersController', () => {
       it('returns the total metrics for the user in the given range', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -415,7 +411,6 @@ describe('UsersController', () => {
       it('returns a 422', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -37,7 +37,6 @@ describe('UsersService', () => {
       it('returns the record', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -61,7 +60,6 @@ describe('UsersService', () => {
       it('returns the record', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -87,11 +85,9 @@ describe('UsersService', () => {
       it('returns the record', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
-            confirmed_at: new Date(),
           },
         });
         const record = await usersService.findByGraffiti(user.graffiti);
@@ -112,7 +108,6 @@ describe('UsersService', () => {
       it('returns the record', async () => {
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -147,7 +142,6 @@ describe('UsersService', () => {
         const email = faker.internet.email();
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email,
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -172,7 +166,6 @@ describe('UsersService', () => {
         const email = faker.internet.email();
         const user = await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email,
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -256,11 +249,9 @@ describe('UsersService', () => {
         const graffiti = uuid();
         await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             graffiti,
             country_code: faker.address.countryCode('alpha-3'),
-            confirmed_at: new Date(),
           },
         });
 
@@ -279,7 +270,6 @@ describe('UsersService', () => {
         const email = faker.internet.email();
         await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: standardizeEmail(email),
             graffiti: uuid(),
             country_code: faker.address.countryCode('alpha-3'),
@@ -301,7 +291,6 @@ describe('UsersService', () => {
         const github = faker.internet.userName();
         await prisma.user.create({
           data: {
-            confirmation_token: ulid(),
             email: faker.internet.email(),
             github,
             graffiti: uuid(),
@@ -366,7 +355,6 @@ describe('UsersService', () => {
       const totalPoints = currentMaxPoints + 2;
       const firstUser = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -375,7 +363,6 @@ describe('UsersService', () => {
       });
       const secondUser = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),
@@ -384,7 +371,6 @@ describe('UsersService', () => {
       });
       const thirdUser = await prisma.user.create({
         data: {
-          confirmation_token: ulid(),
           email: faker.internet.email(),
           graffiti: uuid(),
           country_code: faker.address.countryCode('alpha-3'),

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -7,7 +7,6 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import is from '@sindresorhus/is';
-import { ulid } from 'ulid';
 import { DEFAULT_LIMIT, MAX_LIMIT } from '../common/constants';
 import { SortOrder } from '../common/enums/sort-order';
 import { standardizeEmail } from '../common/utils/email';
@@ -123,7 +122,6 @@ export class UsersService {
           telegram,
           github,
           country_code: countryCode,
-          confirmation_token: ulid(),
         },
       }),
     ]);


### PR DESCRIPTION
## Summary

These columns are no longer used

## Testing Plan

Updated unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
