### PR TITLE
refactor(api): Wrap Block find with service method

### DIFF
--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -3,12 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
 import { ApiConfigModule } from '../api-config/api-config.module';
+import { BlocksModule } from '../blocks/blocks.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { EventsService } from './events.service';
 
 @Module({
   exports: [EventsService],
-  imports: [ApiConfigModule, PrismaModule],
+  imports: [ApiConfigModule, BlocksModule, PrismaModule],
   providers: [EventsService],
 })
 export class EventsModule {}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
-import { EventsModule } from '../events/events.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { UsersService } from './users.service';
 
 @Module({
   exports: [UsersService],
-  imports: [EventsModule, PrismaModule],
+  imports: [PrismaModule],
   providers: [UsersService],
 })
 export class UsersModule {}


### PR DESCRIPTION
## Summary

Now that dependencies are a bit cleaned up, use the encapsulated `BlocksService` method instead of the ORM client directly.

## Testing Plan

N/A - Behavior is unchanged

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
