### PR TITLE
feat(api): Add advisory lock to graffiti when updating

### DIFF
--- a/src/users/users-updater.ts
+++ b/src/users/users-updater.ts
@@ -21,6 +21,10 @@ export class UsersUpdater {
       const { discord, graffiti, telegram } = options;
 
       if (graffiti && user.graffiti !== graffiti) {
+        await prisma.$executeRawUnsafe(
+          'SELECT pg_advisory_xact_lock(HASHTEXT($1));',
+          graffiti,
+        );
         const minedBlocksForCurrentGraffiti =
           await this.blocksService.countByGraffiti(user.graffiti, prisma);
         if (minedBlocksForCurrentGraffiti > 0) {


### PR DESCRIPTION
## Summary

Hash the graffiti and grab an advisory lock when updating users.

## Testing Plan

Added a unit test which spawns two update requests at the same time (where one of them has a manual sleep as a hack to ensure the second update starts before the first transaction completes).

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
