### PR TITLE
fix(api): Add missing secondary sort on latest event `occurred_at`

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -466,7 +466,10 @@ export class EventsService {
             event_types.type,
             RANK () OVER ( 
               PARTITION BY event_types.type
-              ORDER BY COALESCE(user_event_points.points, 0) DESC, users.created_at ASC
+              ORDER BY
+                COALESCE(user_event_points.points, 0) DESC,
+                COALESCE(user_event_points.latest_event_occurred_at, NOW()) ASC,
+                users.created_at ASC
             ) AS rank 
           FROM
             users
@@ -480,12 +483,14 @@ export class EventsService {
               SELECT
                 user_id,
                 type,
-                SUM(points) AS points
+                SUM(points) AS points,
+                MAX(occurred_at) AS latest_event_occurred_at
               FROM
                 (
                   SELECT
                     user_id,
                     type,
+                    occurred_at,
                     points
                   FROM
                     events


### PR DESCRIPTION
## Summary

@dguenther reported that the ranking on our leaderboard is inconsistent with the values seen in the user details page. This is happening due to a mismatch in sort. This code change adds a secondary sort on the latest event timestamp for a given event type.

## Testing Plan

Manually tested.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
