### PR TITLE
Ignore 0 point events in ranking last_occured_at

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -518,6 +518,7 @@ export class EventsService {
                   FROM
                     events
                   WHERE
+                    points != 0 AND
                     deleted_at IS NULL
                 ) filtered_events
               GROUP BY

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -251,6 +251,7 @@ export class UsersService {
                   FROM
                     events
                   WHERE
+                    points != 0 AND
                     deleted_at IS NULL AND
                     CASE WHEN $6::event_type IS NOT NULL
                       THEN
@@ -389,6 +390,7 @@ export class UsersService {
                   FROM
                     events
                   WHERE
+                    points != 0 AND
                     deleted_at IS NULL
                 ) filtered_events
               GROUP BY


### PR DESCRIPTION
## Summary

In our 3 ranking queries, we don't ignore events with 0 points when
trying to get the latest occuring event to rank users who earned
their points sooner.

## Testing Plan

Wrote tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
