### PR TITLE
Update the PR points limit to 5000

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -15,7 +15,7 @@ export const WEEKLY_POINT_LIMITS_BY_EVENT_TYPE: Record<EventType, number> = {
   [EventType.BLOCK_MINED]: 1000,
   [EventType.BUG_CAUGHT]: 1000,
   [EventType.COMMUNITY_CONTRIBUTION]: 1000,
-  [EventType.PULL_REQUEST_MERGED]: 1000,
+  [EventType.PULL_REQUEST_MERGED]: 5000,
   [EventType.SOCIAL_MEDIA_PROMOTION]: 1000,
 };
 

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -357,7 +357,7 @@ describe('EventsService', () => {
 
     describe('when the user has hit the weekly limit', () => {
       it('does not increment the total points for a user', async () => {
-        const points = 1000;
+        const points = 5000;
         const user = await prisma.user.create({
           data: {
             email: faker.internet.email(),
@@ -382,7 +382,7 @@ describe('EventsService', () => {
       });
 
       it('updates the event points to 0', async () => {
-        const points = 1000;
+        const points = 5000;
         const user = await prisma.user.create({
           data: {
             email: faker.internet.email(),
@@ -412,7 +412,7 @@ describe('EventsService', () => {
 
     describe('when the user will surpass the weekly limit', () => {
       it('increments the total points to not go above weekly limits', async () => {
-        const currentPointsThisWeek = 900;
+        const currentPointsThisWeek = 4900;
         const user = await prisma.user.create({
           data: {
             email: faker.internet.email(),
@@ -440,7 +440,7 @@ describe('EventsService', () => {
       });
 
       it('adjusts the points for the event', async () => {
-        const currentPointsThisWeek = 900;
+        const currentPointsThisWeek = 4900;
         const user = await prisma.user.create({
           data: {
             email: faker.internet.email(),


### PR DESCRIPTION
## Summary

We mentioned in Discord that we were going to update the PR points limit to 5k, so this bumps up the weekly limit.

## Testing Plan

Points limit should show differently on user pages on the testnet website.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```

This should not be breaking.
