### PR TITLE
Remove last_login_at field from SerializedUser

### DIFF
--- a/src/users/interfaces/serialized-user.ts
+++ b/src/users/interfaces/serialized-user.ts
@@ -6,5 +6,4 @@ export interface SerializedUser {
   graffiti: string;
   total_points: number;
   country_code: string;
-  last_login_at: Date | null;
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -218,7 +218,6 @@ export class UsersService {
         graffiti,
         total_points,
         country_code,
-        last_login_at,
         rank
       FROM
         (
@@ -227,7 +226,6 @@ export class UsersService {
             graffiti,
             COALESCE(user_latest_events.total_points, 0) as total_points,
             country_code,
-            last_login_at,
             RANK () OVER ( 
               ORDER BY 
                 COALESCE(user_latest_events.total_points, 0) DESC,

--- a/src/users/utils/user-translator.ts
+++ b/src/users/utils/user-translator.ts
@@ -11,7 +11,6 @@ export function serializedUserFromRecord(user: User): SerializedUser {
     country_code: user.country_code,
     graffiti: user.graffiti,
     total_points: user.total_points,
-    last_login_at: user.last_login_at,
   };
 }
 
@@ -24,7 +23,6 @@ export function serializedUserFromRecordWithRank(
     country_code: user.country_code,
     graffiti: user.graffiti,
     total_points: user.total_points,
-    last_login_at: user.last_login_at,
     rank,
   };
 }


### PR DESCRIPTION
## Summary

This field doesn't have any use on the frontend as far as I can tell, so may as well remove it to save some bandwidth.

## Testing Plan

Tests should pass, login should still be possible.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```

Not as far as I can tell. It has potential to break things, but I couldn't find usages of it in website-testnet.