### PR TITLE
chore(api): Add script to default .env if not present

### DIFF
--- a/bin/check_for_dotenv.sh
+++ b/bin/check_for_dotenv.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(dirname $SCRIPT_DIR)
+
+if [[ $NODE_ENV != "staging" && $NODE_ENV != "production" && ! -e "$ROOT_DIR/.env" ]]; then
+  echo "'.env' does not exist. Creating one using '.env.template'"
+  cp -- "$ROOT_DIR/.env.template" "$ROOT_DIR/.env"
+fi

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "docker:stop": "docker-compose down",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "prestart": "bash bin/check_for_dotenv.sh",
     "start": "node build/main.js",
     "start:worker": "node build/worker.js",
     "test": "jest --runInBand",


### PR DESCRIPTION
## Summary

Makes setup a little easier for this repository by creating a default `.env` if one doesn't already exist. 

## Testing Plan

Tested manually

```sh
~/git/ironfish-api  feature/iro-1503 ✔                                                                                                                                                                            
▶ yarn start
yarn run v1.22.17
$ bash bin/check_for_dotenv.sh
'.env' does not exist. Creating one using '.env.template'
$ node build/main.js
Starting master process PID 94879
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
