### PR TITLE
Generate a clean migration to sync expected DB state

### DIFF
--- a/prisma/migrations/20220121212448_sync_db_state/migration.sql
+++ b/prisma/migrations/20220121212448_sync_db_state/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "events" DROP CONSTRAINT "FK__events__block_id";
+
+-- DropForeignKey
+ALTER TABLE "events" DROP CONSTRAINT "FK__events__user_id";
+
+-- AddForeignKey
+ALTER TABLE "events" ADD CONSTRAINT "events_block_id_fkey" FOREIGN KEY ("block_id") REFERENCES "blocks"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "events" ADD CONSTRAINT "events_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,7 +65,7 @@ model Block {
   blocks_transactions      BlockTransaction[]
   event                    Event?
 
-  @@unique([hash, network_version], name: "uq_blocks_on_hash_and_network_version")
+  @@unique([hash, network_version], name: "uq_blocks_on_hash_and_network_version", map: "uq_blocks_on_hash_and_network_version")
   @@index([hash], name: "index_blocks_on_hash")
   @@index([hash, network_version], name: "index_blocks_on_hash_and_network_version")
   @@index([sequence, network_version], name: "index_blocks_on_sequence_and_network_version")
@@ -84,7 +84,7 @@ model Transaction {
   spends              Json
   blocks_transactions BlockTransaction[]
 
-  @@unique([hash, network_version], name: "uq_transactions_on_hash_and_network_version")
+  @@unique([hash, network_version], name: "uq_transactions_on_hash_and_network_version", map: "uq_transactions_on_hash_and_network_version")
   @@index([hash], name: "index_transactions_on_hash")
   @@index([hash, network_version], name: "index_transactions_on_hash_and_network_version")
   @@map("transactions")


### PR DESCRIPTION
## Summary

Create a migration to sync the FK names from the events table, which is
just drift from Prisma version upgrades.

Add `map` argument to `@@unique` to keep the unique constraint name in
the database as expected. This is needed due to naming constraint
changes in Prisma.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
