### PR TITLE
Dont allow empty graffiti when updating user

### DIFF
--- a/src/users/__snapshots__/users.controller.spec.ts.snap
+++ b/src/users/__snapshots__/users.controller.spec.ts.snap
@@ -126,6 +126,7 @@ Object {
     "discord must be a string",
     "\\"discord\\", \\"graffiti\\", \\"telegram\\", or \\"country_code\\" required when updating",
     "graffiti must be a string",
+    "graffiti should not be empty",
     "\\"discord\\", \\"graffiti\\", \\"telegram\\", or \\"country_code\\" required when updating",
     "telegram must be a string",
   ],

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -4,6 +4,7 @@
 import {
   IsDefined,
   IsISO31661Alpha3,
+  IsNotEmpty,
   IsString,
   ValidateIf,
 } from 'class-validator';
@@ -45,6 +46,7 @@ export class UpdateUserDto {
   @IsDefined({
     message: UPDATE_USER_VALIDATION_MESSAGE,
   })
+  @IsNotEmpty()
   @IsString()
   readonly graffiti?: string;
 


### PR DESCRIPTION
## Summary
You cannot sign up for a user with an empty graffiti, so you should not be able to update to one either.

## Testing Plan
Tested locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
