### PR TITLE
chore(api): Add Github action to promote staging to production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,15 @@
+name: Deploy Production API
+on: workflow_dispatch
+
+jobs:
+  deploy:
+    name: Deploy Production API
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Promote Staging
+        uses: tiltshift/heroku-promote-app@v1
+        with:
+          heroku_app_name: ${{ secrets.HEROKU_APP_NAME_STAGING }}
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,4 +1,4 @@
-name: Deploy HTTP API
+name: Deploy Staging API
 on:
   push:
     branches:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    name: Staging API Deploy
+    name: Deploy Staging API
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Adds a new workflow to be manually run that will promote the staging application in Heroku.

## Testing Plan

Manually tested.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
