### PR TITLE
/versions POST: use body instead of query param

### DIFF
--- a/src/versions/versions.controller.spec.ts
+++ b/src/versions/versions.controller.spec.ts
@@ -54,7 +54,7 @@ describe('VersionsController', () => {
       });
     });
 
-    describe('with a missing version query param', () => {
+    describe('with a missing version', () => {
       it('returns a 422 status code', async () => {
         await request(app.getHttpServer())
           .post('/versions')
@@ -63,21 +63,21 @@ describe('VersionsController', () => {
       });
     });
 
-    describe('with an incorrectly formatted version query param', () => {
+    describe('with an incorrectly formatted version', () => {
       it('returns a 422 status code', async () => {
         await request(app.getHttpServer())
           .post('/versions')
-          .query({ version: '123' })
+          .send({ version: '123' })
           .set('Authorization', `Bearer ${API_KEY}`)
           .expect(HttpStatus.UNPROCESSABLE_ENTITY);
       });
     });
 
-    describe('with a valid version query param', () => {
+    describe('with a valid version', () => {
       it('returns a 201 status code and created version', async () => {
         const { body } = await request(app.getHttpServer())
           .post('/versions')
-          .query({ version: '0.12.345' })
+          .send({ version: '0.12.345' })
           .set('Authorization', `Bearer ${API_KEY}`)
           .expect(HttpStatus.CREATED);
         expect(body).toMatchObject({

--- a/src/versions/versions.controller.ts
+++ b/src/versions/versions.controller.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
+  Body,
   Controller,
   Get,
   HttpStatus,
   Post,
-  Query,
   UseGuards,
   UsePipes,
   ValidationPipe,
@@ -45,7 +45,7 @@ export class VersionsController {
   )
   @Post()
   async updateVersion(
-    @Query()
+    @Body()
     { version }: CreateVersionDto,
   ): Promise<SerializedVersion> {
     return serializedVersionFromRecord(


### PR DESCRIPTION
## Summary

Forgot to update this guy when I was first getting things functional

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
