### PR TITLE
feat(api): Support different point types in telemetry

### DIFF
--- a/src/influxdb/influxdb.service.spec.ts
+++ b/src/influxdb/influxdb.service.spec.ts
@@ -39,11 +39,10 @@ describe('InfluxDbService', () => {
   describe('writePoint', () => {
     it('writes the data to InfluxDB', () => {
       const options: CreatePointOptions = {
+        fields: [{ name: 'memory', type: 'float', value: 1 }],
         measurement: 'node',
-        name: 'memory',
         tags: [{ name: 'user_agent', value: '0.0.0' }],
         timestamp: new Date(),
-        value: 1,
       };
       influxDbService.writePoints([options]);
 

--- a/src/influxdb/influxdb.service.ts
+++ b/src/influxdb/influxdb.service.ts
@@ -28,13 +28,26 @@ export class InfluxDbService implements OnModuleDestroy {
     const points = [];
 
     for (const option of options) {
-      const { measurement, name, tags, timestamp, value } = option;
-      const point = new Point(measurement)
-        .floatField(name, value)
-        .timestamp(timestamp);
+      const { fields, measurement, tags, timestamp } = option;
+      const point = new Point(measurement).timestamp(timestamp.toISOString());
+
+      for (const field of fields) {
+        const { name } = field;
+        if (field.type === 'boolean') {
+          point.booleanField(name, field.value);
+        } else if (field.type === 'float') {
+          point.floatField(name, field.value);
+        } else if (field.type === 'integer') {
+          point.intField(name, field.value);
+        } else {
+          point.stringField(name, field.value);
+        }
+      }
+
       for (const tag of tags) {
         point.tag(tag.name, tag.value);
       }
+
       points.push(point);
     }
 

--- a/src/influxdb/influxdb.service.ts
+++ b/src/influxdb/influxdb.service.ts
@@ -29,7 +29,7 @@ export class InfluxDbService implements OnModuleDestroy {
 
     for (const option of options) {
       const { fields, measurement, tags, timestamp } = option;
-      const point = new Point(measurement).timestamp(timestamp.toISOString());
+      const point = new Point(measurement).timestamp(timestamp);
 
       for (const field of fields) {
         const { name } = field;

--- a/src/influxdb/interfaces/create-point-options.ts
+++ b/src/influxdb/interfaces/create-point-options.ts
@@ -1,12 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Field } from './field';
 import { Tag } from './tag';
 
 export interface CreatePointOptions {
+  fields: Field[];
   measurement: string;
-  name: string;
   tags: Tag[];
   timestamp: Date;
-  value: number;
 }

--- a/src/influxdb/interfaces/field.ts
+++ b/src/influxdb/interfaces/field.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+interface BooleanField {
+  name: string;
+  type: 'boolean';
+  value: boolean;
+}
+
+interface FloatField {
+  name: string;
+  type: 'float';
+  value: number;
+}
+
+interface IntegerField {
+  name: string;
+  type: 'integer';
+  value: number;
+}
+
+interface StringField {
+  name: string;
+  type: 'string';
+  value: string;
+}
+
+export type Field = BooleanField | FloatField | IntegerField | StringField;

--- a/src/telemetry/__snapshots__/telemetry.controller.spec.ts.snap
+++ b/src/telemetry/__snapshots__/telemetry.controller.spec.ts.snap
@@ -4,13 +4,19 @@ exports[`TelemetryController POST /telemetry with empty or invalid arguments ret
 Object {
   "error": "Unprocessable Entity",
   "message": Array [
+    "points.0.fields.0.type must be one of the following values: boolean, float, integer, string",
+    "points.0.fields.1.value must be a boolean value",
+    "points.0.fields.2.value must be a positive number",
+    "points.0.fields.2.value must be a number conforming to the specified constraints",
+    "points.0.fields.3.value must be a positive number",
+    "points.0.fields.3.value must be an integer number",
+    "points.0.fields.4.value must be a string",
     "points.0.measurement should not be empty",
-    "points.0.name should not be empty",
+    "points.0.timestamp must be a Date instance",
     "points.0.tags.0.name must be a string",
     "points.0.tags.0.name should not be empty",
     "points.0.tags.0.value must be a string",
     "points.0.tags.0.value should not be empty",
-    "points.0.value must be a positive number",
   ],
   "statusCode": 422,
 }

--- a/src/telemetry/dto/field.dto.ts
+++ b/src/telemetry/dto/field.dto.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Type } from 'class-transformer';
+import {
+  Equals,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsPositive,
+  IsString,
+} from 'class-validator';
+
+export abstract class BaseFieldDto {
+  @IsIn(['boolean', 'float', 'integer', 'string'])
+  readonly type!: 'boolean' | 'float' | 'integer' | 'string';
+
+  @IsNotEmpty()
+  @IsString()
+  readonly name!: string;
+}
+
+export class BooleanFieldDto extends BaseFieldDto {
+  @Equals('boolean')
+  readonly type!: 'boolean';
+
+  @IsBoolean()
+  @Type(() => Boolean)
+  readonly value!: boolean;
+}
+
+export class FloatFieldDto extends BaseFieldDto {
+  @Equals('float')
+  readonly type!: 'float';
+
+  @IsNumber()
+  @IsPositive()
+  @Type(() => Number)
+  readonly value!: number;
+}
+
+export class IntegerFieldDto extends BaseFieldDto {
+  @Equals('integer')
+  readonly type!: 'integer';
+
+  @IsInt()
+  @IsPositive()
+  @Type(() => Number)
+  readonly value!: number;
+}
+
+export class StringFieldDto extends BaseFieldDto {
+  @Equals('string')
+  readonly type!: 'string';
+
+  @IsNotEmpty()
+  @IsString()
+  readonly value!: string;
+}
+
+export type FieldDto =
+  | BooleanFieldDto
+  | FloatFieldDto
+  | IntegerFieldDto
+  | StringFieldDto;

--- a/src/telemetry/dto/write-telemetry-points.dto.ts
+++ b/src/telemetry/dto/write-telemetry-points.dto.ts
@@ -5,12 +5,19 @@ import { Type } from 'class-transformer';
 import {
   ArrayMaxSize,
   IsArray,
+  IsDate,
   IsNotEmpty,
-  IsNumber,
-  IsPositive,
   IsString,
   ValidateNested,
 } from 'class-validator';
+import {
+  BaseFieldDto,
+  BooleanFieldDto,
+  FieldDto,
+  FloatFieldDto,
+  IntegerFieldDto,
+  StringFieldDto,
+} from './field.dto';
 
 class TagDto {
   @IsNotEmpty()
@@ -23,24 +30,36 @@ class TagDto {
 }
 
 class WriteTelemetryPointDto {
+  @IsArray()
+  @ArrayMaxSize(3000)
+  @ValidateNested({ each: true })
+  @Type(() => BaseFieldDto, {
+    keepDiscriminatorProperty: true,
+    discriminator: {
+      property: 'type',
+      subTypes: [
+        { name: 'boolean', value: BooleanFieldDto },
+        { name: 'float', value: FloatFieldDto },
+        { name: 'integer', value: IntegerFieldDto },
+        { name: 'string', value: StringFieldDto },
+      ],
+    },
+  })
+  readonly fields!: FieldDto[];
+
   @IsNotEmpty()
   @IsString()
   readonly measurement!: string;
 
-  @IsNotEmpty()
-  @IsString()
-  readonly name!: string;
+  @IsDate()
+  @Type(() => Date)
+  readonly timestamp!: Date;
 
   @IsArray()
   @ArrayMaxSize(3000)
   @ValidateNested({ each: true })
   @Type(() => TagDto)
   readonly tags!: TagDto[];
-
-  @IsPositive()
-  @IsNumber()
-  @Type(() => Number)
-  readonly value!: number;
 }
 
 export class WriteTelemetryPointsDto {

--- a/src/telemetry/telemetry.controller.spec.ts
+++ b/src/telemetry/telemetry.controller.spec.ts
@@ -105,7 +105,7 @@ describe('TelemetryController', () => {
         ];
         const measurement = 'node';
         const tags = [{ name: 'user_agent', value: '0.0.0' }];
-        const timestamp = new Date().toISOString();
+        const timestamp = new Date();
 
         await request(app.getHttpServer())
           .post('/telemetry')
@@ -118,7 +118,7 @@ describe('TelemetryController', () => {
             fields,
             measurement,
             tags,
-            timestamp: new Date(timestamp),
+            timestamp,
           },
         ]);
       });

--- a/src/telemetry/telemetry.controller.spec.ts
+++ b/src/telemetry/telemetry.controller.spec.ts
@@ -38,8 +38,33 @@ describe('TelemetryController', () => {
           .send({
             points: [
               {
+                fields: [
+                  {
+                    name: 'foo',
+                    type: 'missing-type',
+                    value: 'howdy',
+                  },
+                  {
+                    name: 'foo',
+                    type: 'boolean',
+                  },
+                  {
+                    name: 'foo',
+                    type: 'float',
+                    value: 'ironfish',
+                  },
+                  {
+                    name: 'foo',
+                    type: 'integer',
+                    value: 'hello',
+                  },
+                  {
+                    name: 'foo',
+                    type: 'string',
+                    value: 123,
+                  },
+                ],
                 measurement: '',
-                name: '',
                 tags: [{ foo: 'bar' }],
                 value: -1,
               },
@@ -56,24 +81,44 @@ describe('TelemetryController', () => {
         const writePoint = jest
           .spyOn(influxDbService, 'writePoints')
           .mockImplementationOnce(jest.fn());
+        const fields = [
+          {
+            name: 'online',
+            type: 'boolean',
+            value: true,
+          },
+          {
+            name: 'memory',
+            type: 'float',
+            value: 1.23,
+          },
+          {
+            name: 'mempool',
+            type: 'integer',
+            value: 1,
+          },
+          {
+            name: 'name',
+            type: 'string',
+            value: 'howdy',
+          },
+        ];
         const measurement = 'node';
-        const name = 'memory';
         const tags = [{ name: 'user_agent', value: '0.0.0' }];
-        const value = 1;
+        const timestamp = new Date().toISOString();
 
         await request(app.getHttpServer())
           .post('/telemetry')
-          .send({ points: [{ measurement, name, tags, value }] })
+          .send({ points: [{ fields, measurement, tags, timestamp }] })
           .expect(HttpStatus.CREATED);
 
         expect(writePoint).toHaveBeenCalledTimes(1);
         expect(writePoint).toHaveBeenCalledWith([
           {
+            fields,
             measurement,
-            name,
             tags,
-            timestamp: expect.any(Date),
-            value,
+            timestamp: new Date(timestamp),
           },
         ]);
       });

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { ApiExcludeEndpoint } from '@nestjs/swagger';
 import { InfluxDbService } from '../influxdb/influxdb.service';
-import { WriteTelemetryPointsDto } from './dto/write-telemetry-point.dto';
+import { WriteTelemetryPointsDto } from './dto/write-telemetry-points.dto';
 
 @Controller('telemetry')
 export class TelemetryController {
@@ -28,13 +28,12 @@ export class TelemetryController {
     { points }: WriteTelemetryPointsDto,
   ): void {
     const options = [];
-    for (const { measurement, name, tags, value } of points) {
+    for (const { fields, measurement, tags, timestamp } of points) {
       options.push({
+        fields,
         measurement,
-        name,
         tags,
-        value,
-        timestamp: new Date(),
+        timestamp,
       });
     }
 


### PR DESCRIPTION
## Summary

This code change extends the telemetry endpoint to accept several types (booleans, floats, integers, and strings) to more closely match what was done in the [node](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/telemetry/index.ts#L19-L23)

## Testing Plan

Updated unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
