### PR TITLE
feat(api): Sort events by `occurred_at` instead of `id`

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -141,11 +141,20 @@ describe('EventsService', () => {
 
     describe('with a user with events', () => {
       describe('with no limit', () => {
-        it('returns all the available records', async () => {
+        it('returns all the available records sorted by `occurred_at`', async () => {
           const { events, user } = await setup();
           const { data: records } = await eventsService.list({
             userId: user.id,
           });
+
+          for (let i = 1; i < records.length; i++) {
+            expect(
+              records[i - 1].occurred_at.getUTCMilliseconds(),
+            ).toBeGreaterThanOrEqual(
+              records[i].occurred_at.getUTCMilliseconds(),
+            );
+          }
+
           const eventIds = new Set(events.map((event) => event.id));
           const recordIds = new Set(records.map((record) => record.id));
           expect(eventIds).toEqual(recordIds);

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -12,7 +12,6 @@ import {
   POINTS_PER_CATEGORY,
   WEEKLY_POINT_LIMITS_BY_EVENT_TYPE,
 } from '../common/constants';
-import { SortOrder } from '../common/enums/sort-order';
 import { getMondayFromDate } from '../common/utils/date';
 import { PrismaService } from '../prisma/prisma.service';
 import { BasePrismaClient } from '../prisma/types/base-prisma-client';
@@ -41,7 +40,7 @@ export class EventsService {
     const limit =
       direction * Math.min(MAX_LIMIT, options.limit || DEFAULT_LIMIT);
     const orderBy = {
-      id: SortOrder.DESC,
+      occurred_at: Prisma.SortOrder.desc,
     };
     const skip = cursor ? 1 : 0;
     const where = {


### PR DESCRIPTION
## Summary

Fetch the events sorted by the time they occurred by default.

## Testing Plan

Updated unit test.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
