### PR TITLE
Make all fields optional on UpdateUserDTO

### DIFF
--- a/src/users/__snapshots__/users.controller.spec.ts.snap
+++ b/src/users/__snapshots__/users.controller.spec.ts.snap
@@ -116,24 +116,6 @@ Object {
 }
 `;
 
-exports[`UsersController PUT /users/:id with missing fields returns a 422 1`] = `
-Object {
-  "error": "Unprocessable Entity",
-  "message": Array [
-    "\\"discord\\", \\"graffiti\\", \\"telegram\\", or \\"country_code\\" required when updating",
-    "country_code must be a valid ISO31661 Alpha3 code",
-    "\\"discord\\", \\"graffiti\\", \\"telegram\\", or \\"country_code\\" required when updating",
-    "discord must be a string",
-    "\\"discord\\", \\"graffiti\\", \\"telegram\\", or \\"country_code\\" required when updating",
-    "graffiti must be a string",
-    "graffiti should not be empty",
-    "\\"discord\\", \\"graffiti\\", \\"telegram\\", or \\"country_code\\" required when updating",
-    "telegram must be a string",
-  ],
-  "statusCode": 422,
-}
-`;
-
 exports[`UsersController PUT /users/:id with no logged in user returns a 401 1`] = `
 Object {
   "message": "Unauthorized",

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -2,63 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
-  IsDefined,
   IsISO31661Alpha3,
   IsNotEmpty,
+  IsOptional,
   IsString,
-  ValidateIf,
 } from 'class-validator';
 
-const UPDATE_USER_VALIDATION_MESSAGE =
-  '"discord", "graffiti", "telegram", or "country_code" required when updating';
-
 export class UpdateUserDto {
-  @ValidateIf(
-    (o: UpdateUserDto) =>
-      o.discord === undefined &&
-      o.graffiti === undefined &&
-      o.telegram === undefined,
-  )
-  @IsDefined({
-    message: UPDATE_USER_VALIDATION_MESSAGE,
-  })
+  @IsOptional()
   @IsISO31661Alpha3()
   readonly country_code?: string;
 
-  @ValidateIf(
-    (o: UpdateUserDto) =>
-      o.country_code === undefined &&
-      o.graffiti === undefined &&
-      o.telegram === undefined,
-  )
-  @IsDefined({
-    message: UPDATE_USER_VALIDATION_MESSAGE,
-  })
+  @IsOptional()
   @IsString()
   readonly discord?: string;
 
-  @ValidateIf(
-    (o: UpdateUserDto) =>
-      o.country_code === undefined &&
-      o.discord === undefined &&
-      o.telegram === undefined,
-  )
-  @IsDefined({
-    message: UPDATE_USER_VALIDATION_MESSAGE,
-  })
+  @IsOptional()
   @IsNotEmpty()
   @IsString()
   readonly graffiti?: string;
 
-  @ValidateIf(
-    (o: UpdateUserDto) =>
-      o.country_code === undefined &&
-      o.discord === undefined &&
-      o.graffiti === undefined,
-  )
-  @IsDefined({
-    message: UPDATE_USER_VALIDATION_MESSAGE,
-  })
+  @IsOptional()
   @IsString()
   readonly telegram?: string;
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -482,7 +482,7 @@ describe('UsersController', () => {
       });
     });
 
-    describe('with missing fields', () => {
+    describe('with an empty string graffiti', () => {
       it('returns a 422', async () => {
         const user = await usersService.create({
           email: faker.internet.email(),
@@ -497,9 +497,16 @@ describe('UsersController', () => {
         const { body } = await request(app.getHttpServer())
           .put(`/users/${user.id}`)
           .set('Authorization', 'token')
+          .send({
+            graffiti: '',
+          })
           .expect(HttpStatus.UNPROCESSABLE_ENTITY);
 
-        expect(body).toMatchSnapshot();
+        expect(body).toEqual({
+          error: 'Unprocessable Entity',
+          message: ['graffiti should not be empty'],
+          statusCode: 422,
+        });
       });
     });
 


### PR DESCRIPTION
## Summary

I think the validation doesn't seem to be working correctly when updating users -- it seems like it's canceling validation unless three of the other fields are undefined. I'm trying out making them all optional for now -- it does have the side effect of allowing updates with empty objects, but I think that could be fixed separately.

## Testing Plan

New API tests should pass.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
