### PR TITLE
Allow staging.testnet.ironfish.network in staging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ async function bootstrap(): Promise<void> {
         /localhost/,
         /block-explorer.*\.vercel\.app/,
         /website-testnet.*\.vercel\.app/,
+        'https://staging.testnet.ironfish.network',
       ]
     : defaultOrigins;
 


### PR DESCRIPTION
## Summary
Adds staging.testnet.ironfish.network to cors so you can hit the staging API from there

## Testing Plan
Test on staging environment

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
