### PR TITLE
Add a test clean command to clear DB

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "start": "node build/main.js",
     "start:worker": "node build/worker.js",
     "test": "jest --runInBand",
+    "test:clean": "prisma migrate reset --force --skip-generate > /dev/null && jest --runInBand",
     "db:client:generate": "prisma generate",
     "db:migrate": "prisma migrate dev"
   },


### PR DESCRIPTION
## Summary

Since Prisma lacks a clean way to reset a test DB, this adds a `test:clean` command to wipe the DB before tests. This is a bit of a band-aid fix, ideally tests would clean up after themselves, or be idempotent in some way. I'm not in love with this, so if someone thinks it's better to avoid adding this, fine by me.

Apparently an open issue with Prisma with no solution in sight. Other solutions some people have implemented: https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/stdlib/prisma-utils.ts

This adds no measurable time to the test run _yet_. Ran with `time` a few times to compare, both ways took pretty close to exactly 40 seconds.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
