### PR TITLE
feat(api): Temporarily remove `created_at` check for resync

### DIFF
--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -97,7 +97,7 @@ export class BlocksService {
     });
 
     const user = await this.usersService.findByGraffiti(graffiti, prisma);
-    if (user && timestamp > user.created_at) {
+    if (user) {
       if (main) {
         upsertBlockMinedOptions = { block_id: block.id, user_id: user.id };
       } else {


### PR DESCRIPTION
## Summary

Remove the creation check when upserting blocks for the chain re-sync.

## Testing Plan

Manually tested.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
