### PR TITLE
feat(api): Revert `created_at` timestamp check for block upserts

### DIFF
--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -97,7 +97,7 @@ export class BlocksService {
     });
 
     const user = await this.usersService.findByGraffiti(graffiti, prisma);
-    if (user) {
+    if (user && timestamp > user.created_at) {
       if (main) {
         upsertBlockMinedOptions = { block_id: block.id, user_id: user.id };
       } else {


### PR DESCRIPTION
## Summary

Reverts 0c91431d4d60eabf2ccff04d79af171cdbeee05f

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
