### PR TITLE
feat(api): Return `created_at` for users

### DIFF
--- a/src/users/interfaces/serialized-user.ts
+++ b/src/users/interfaces/serialized-user.ts
@@ -6,4 +6,5 @@ export interface SerializedUser {
   graffiti: string;
   total_points: number;
   country_code: string;
+  created_at: string;
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -50,6 +50,7 @@ describe('UsersController', () => {
           id: user.id,
           graffiti: user.graffiti,
           total_points: expect.any(Number),
+          created_at: user.created_at.toISOString(),
         });
       });
     });
@@ -324,6 +325,7 @@ describe('UsersController', () => {
         expect((data as unknown[])[0]).toMatchObject({
           id: expect.any(Number),
           graffiti: expect.any(String),
+          created_at: expect.any(String),
         });
       });
     });
@@ -341,6 +343,7 @@ describe('UsersController', () => {
           id: expect.any(Number),
           graffiti: expect.any(String),
           rank: expect.any(Number),
+          created_at: expect.any(String),
         });
       });
     });
@@ -439,9 +442,11 @@ describe('UsersController', () => {
             country_code: faker.address.countryCode('alpha-3'),
           })
           .expect(HttpStatus.CREATED);
+
         expect(body).toMatchObject({
           id: expect.any(Number),
           email: standardizeEmail(email),
+          created_at: expect.any(String),
           graffiti,
           discord,
         });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -218,6 +218,7 @@ export class UsersService {
         graffiti,
         total_points,
         country_code,
+        created_at,
         rank
       FROM
         (
@@ -226,6 +227,7 @@ export class UsersService {
             graffiti,
             COALESCE(user_latest_events.total_points, 0) as total_points,
             country_code,
+            created_at,
             RANK () OVER ( 
               ORDER BY 
                 COALESCE(user_latest_events.total_points, 0) DESC,

--- a/src/users/utils/user-translator.ts
+++ b/src/users/utils/user-translator.ts
@@ -11,6 +11,7 @@ export function serializedUserFromRecord(user: User): SerializedUser {
     country_code: user.country_code,
     graffiti: user.graffiti,
     total_points: user.total_points,
+    created_at: user.created_at.toISOString(),
   };
 }
 
@@ -23,6 +24,7 @@ export function serializedUserFromRecordWithRank(
     country_code: user.country_code,
     graffiti: user.graffiti,
     total_points: user.total_points,
+    created_at: user.created_at.toISOString(),
     rank,
   };
 }


### PR DESCRIPTION
## Summary

Return when users were created from API endpoints.

## Testing Plan

Updated unit tests for get and list endpoints.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
