### PR TITLE
fix(api): Use `Min(0)` instead of `IsPositive` for telemetry fields

### DIFF
--- a/src/telemetry/__snapshots__/telemetry.controller.spec.ts.snap
+++ b/src/telemetry/__snapshots__/telemetry.controller.spec.ts.snap
@@ -6,9 +6,9 @@ Object {
   "message": Array [
     "points.0.fields.0.type must be one of the following values: boolean, float, integer, string",
     "points.0.fields.1.value must be a boolean value",
-    "points.0.fields.2.value must be a positive number",
+    "points.0.fields.2.value must not be less than 0",
     "points.0.fields.2.value must be a number conforming to the specified constraints",
-    "points.0.fields.3.value must be a positive number",
+    "points.0.fields.3.value must not be less than 0",
     "points.0.fields.3.value must be an integer number",
     "points.0.fields.4.value must be a string",
     "points.0.measurement should not be empty",

--- a/src/telemetry/dto/field.dto.ts
+++ b/src/telemetry/dto/field.dto.ts
@@ -9,8 +9,8 @@ import {
   IsInt,
   IsNotEmpty,
   IsNumber,
-  IsPositive,
   IsString,
+  Min,
 } from 'class-validator';
 
 export abstract class BaseFieldDto {
@@ -36,7 +36,7 @@ export class FloatFieldDto extends BaseFieldDto {
   readonly type!: 'float';
 
   @IsNumber()
-  @IsPositive()
+  @Min(0)
   @Type(() => Number)
   readonly value!: number;
 }
@@ -46,7 +46,7 @@ export class IntegerFieldDto extends BaseFieldDto {
   readonly type!: 'integer';
 
   @IsInt()
-  @IsPositive()
+  @Min(0)
   @Type(() => Number)
   readonly value!: number;
 }


### PR DESCRIPTION
## Summary

Allow 0 values to be written to the telemetry service.

## Testing Plan

Updated unit test snapshots.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
