### PR TITLE
feat(api): Add minimum telemetry version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/faker": "5.5.9",
     "@types/jest": "27.4.0",
     "@types/passport": "1.0.7",
+    "@types/semver": "7.3.9",
     "@types/supertest": "2.0.11",
     "@types/uuid": "8.3.4",
     "@typescript-eslint/eslint-plugin": "4.33.0",
@@ -82,6 +83,7 @@
     "pino": "7.8.0",
     "reflect-metadata": "0.1.13",
     "rxjs": "7.5.4",
+    "semver": "7.3.5",
     "swagger-ui-express": "4.3.0",
     "type-fest": "2.11.2",
     "ulid": "2.3.0"

--- a/src/telemetry/telemetry.controller.spec.ts
+++ b/src/telemetry/telemetry.controller.spec.ts
@@ -76,10 +76,10 @@ describe('TelemetryController', () => {
       });
     });
 
-    describe('with valid arguments', () => {
-      it('writes the point to InfluxDB', async () => {
-        const writePoint = jest
-          .spyOn(influxDbService, 'writePoints')
+    describe('with a version lower than the minimum telemetry version', () => {
+      it('does not write the points to InfluxDB', async () => {
+        const writePoints = jest
+          .spyOn(influxDbService, 'writePointss')
           .mockImplementationOnce(jest.fn());
         const fields = [
           {
@@ -104,7 +104,48 @@ describe('TelemetryController', () => {
           },
         ];
         const measurement = 'node';
-        const tags = [{ name: 'user_agent', value: '0.0.0' }];
+        const tags = [{ name: 'version', value: '0.0.0' }];
+
+        await request(app.getHttpServer())
+          .post('/telemetry')
+          .send({
+            points: [{ fields, measurement, tags, timestamp: new Date() }],
+          })
+          .expect(HttpStatus.CREATED);
+
+        expect(writePoints).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('with valid arguments', () => {
+      it('writes the point to InfluxDB', async () => {
+        const writePoints = jest
+          .spyOn(influxDbService, 'writePointss')
+          .mockImplementationOnce(jest.fn());
+        const fields = [
+          {
+            name: 'online',
+            type: 'boolean',
+            value: true,
+          },
+          {
+            name: 'memory',
+            type: 'float',
+            value: 1.23,
+          },
+          {
+            name: 'mempool',
+            type: 'integer',
+            value: 1,
+          },
+          {
+            name: 'name',
+            type: 'string',
+            value: 'howdy',
+          },
+        ];
+        const measurement = 'node';
+        const tags = [{ name: 'version', value: '0.1.23' }];
         const timestamp = new Date();
 
         await request(app.getHttpServer())
@@ -112,8 +153,8 @@ describe('TelemetryController', () => {
           .send({ points: [{ fields, measurement, tags, timestamp }] })
           .expect(HttpStatus.CREATED);
 
-        expect(writePoint).toHaveBeenCalledTimes(1);
-        expect(writePoint).toHaveBeenCalledWith([
+        expect(writePoints).toHaveBeenCalledTimes(1);
+        expect(writePoints).toHaveBeenCalledWith([
           {
             fields,
             measurement,

--- a/src/telemetry/telemetry.controller.spec.ts
+++ b/src/telemetry/telemetry.controller.spec.ts
@@ -79,7 +79,7 @@ describe('TelemetryController', () => {
     describe('with a version lower than the minimum telemetry version', () => {
       it('does not write the points to InfluxDB', async () => {
         const writePoints = jest
-          .spyOn(influxDbService, 'writePointss')
+          .spyOn(influxDbService, 'writePoints')
           .mockImplementationOnce(jest.fn());
         const fields = [
           {
@@ -120,7 +120,7 @@ describe('TelemetryController', () => {
     describe('with valid arguments', () => {
       it('writes the point to InfluxDB', async () => {
         const writePoints = jest
-          .spyOn(influxDbService, 'writePointss')
+          .spyOn(influxDbService, 'writePoints')
           .mockImplementationOnce(jest.fn());
         const fields = [
           {

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -9,11 +9,14 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { ApiExcludeEndpoint } from '@nestjs/swagger';
+import { gte, valid } from 'semver';
 import { InfluxDbService } from '../influxdb/influxdb.service';
 import { WriteTelemetryPointsDto } from './dto/write-telemetry-points.dto';
 
 @Controller('telemetry')
 export class TelemetryController {
+  private readonly MINIMUM_TELEMETRY_VERSION = '0.1.23';
+
   constructor(private readonly influxDbService: InfluxDbService) {}
 
   @ApiExcludeEndpoint()
@@ -29,6 +32,11 @@ export class TelemetryController {
   ): void {
     const options = [];
     for (const { fields, measurement, tags, timestamp } of points) {
+      const version = tags.find((tag) => tag.name === 'version');
+      if (!version || !this.isValidTelemetryVersion(version.value)) {
+        continue;
+      }
+
       options.push({
         fields,
         measurement,
@@ -37,6 +45,16 @@ export class TelemetryController {
       });
     }
 
-    this.influxDbService.writePoints(options);
+    if (options.length) {
+      this.influxDbService.writePoints(options);
+    }
+  }
+
+  private isValidTelemetryVersion(version: string): boolean {
+    const parsed = valid(version);
+    if (!parsed) {
+      return false;
+    }
+    return gte(parsed, this.MINIMUM_TELEMETRY_VERSION);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/semver@7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
@@ -5219,7 +5224,7 @@ secp256k1@^4.0.1:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
+semver@7.3.5, semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
## Summary

Since we hit high series cardinality on influx and changed the tags in the version 0.1.23, the API should have a minimum version check before writing any points.

## Testing Plan

Updated unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
