### PR TITLE
feat(api): Add delete service method for EventsService

### DIFF
--- a/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
@@ -147,7 +147,7 @@ describe('BlocksTransactionsLoader', () => {
               difficulty: faker.datatype.number(),
               timestamp: new Date(),
               type: BlockOperation.DISCONNECTED,
-              graffiti,
+              graffiti: user.graffiti,
               previous_block_hash: uuid(),
               size: faker.datatype.number(),
               transactions: [],
@@ -160,7 +160,6 @@ describe('BlocksTransactionsLoader', () => {
           GraphileWorkerPattern.DELETE_BLOCK_MINED_EVENT,
           {
             block_id: blocks[0].id,
-            user_id: user.id,
           },
           expect.anything(),
         );

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -101,7 +101,7 @@ export class BlocksService {
       if (main) {
         upsertBlockMinedOptions = { block_id: block.id, user_id: user.id };
       } else {
-        deleteBlockMinedOptions = { block_id: block.id, user_id: user.id };
+        deleteBlockMinedOptions = { block_id: block.id };
       }
     }
 

--- a/src/events/events.jobs.controller.spec.ts
+++ b/src/events/events.jobs.controller.spec.ts
@@ -167,7 +167,6 @@ describe('EventsJobsController', () => {
       it('logs an error', async () => {
         await eventsJobsController.deleteBlockMinedEvent({
           block_id: 12345,
-          user_id: 12345,
         });
 
         expect(logError).toHaveBeenCalledTimes(1);
@@ -176,7 +175,6 @@ describe('EventsJobsController', () => {
       it('does not requeue', async () => {
         const { requeue } = await eventsJobsController.deleteBlockMinedEvent({
           block_id: 12345,
-          user_id: 12345,
         });
 
         expect(requeue).toBe(false);
@@ -185,30 +183,16 @@ describe('EventsJobsController', () => {
 
     describe('with a missing block', () => {
       it('logs an error', async () => {
-        const user = await usersService.create({
-          email: faker.internet.email(),
-          graffiti: ulid(),
-          country_code: faker.address.countryCode('alpha-3'),
-        });
-
         await eventsJobsController.deleteBlockMinedEvent({
           block_id: 12345,
-          user_id: user.id,
         });
 
         expect(logError).toHaveBeenCalledTimes(1);
       });
 
       it('does not requeue', async () => {
-        const user = await usersService.create({
-          email: faker.internet.email(),
-          graffiti: ulid(),
-          country_code: faker.address.countryCode('alpha-3'),
-        });
-
         const { requeue } = await eventsJobsController.deleteBlockMinedEvent({
           block_id: 12345,
-          user_id: user.id,
         });
 
         expect(requeue).toBe(false);
@@ -228,15 +212,9 @@ describe('EventsJobsController', () => {
           previousBlockHash: ulid(),
           size: faker.datatype.number(),
         });
-        const user = await usersService.create({
-          email: faker.internet.email(),
-          graffiti: ulid(),
-          country_code: faker.address.countryCode('alpha-3'),
-        });
 
         const { requeue } = await eventsJobsController.deleteBlockMinedEvent({
           block_id: block.id,
-          user_id: user.id,
         });
 
         expect(requeue).toBe(false);
@@ -254,22 +232,15 @@ describe('EventsJobsController', () => {
           previousBlockHash: ulid(),
           size: faker.datatype.number(),
         });
-        const user = await usersService.create({
-          email: faker.internet.email(),
-          graffiti: ulid(),
-          country_code: faker.address.countryCode('alpha-3'),
-        });
 
         const deleteBlockMined = jest.spyOn(eventsService, 'deleteBlockMined');
         await eventsJobsController.deleteBlockMinedEvent({
           block_id: block.id,
-          user_id: user.id,
         });
 
         expect(deleteBlockMined).toHaveBeenCalledTimes(1);
         assert.ok(deleteBlockMined.mock.calls);
         expect(deleteBlockMined.mock.calls[0][0].id).toBe(block.id);
-        expect(deleteBlockMined.mock.calls[0][1].id).toBe(user.id);
       });
     });
   });

--- a/src/events/events.jobs.controller.ts
+++ b/src/events/events.jobs.controller.ts
@@ -45,21 +45,14 @@ export class EventsJobsController {
   @MessagePattern(GraphileWorkerPattern.DELETE_BLOCK_MINED_EVENT)
   async deleteBlockMinedEvent({
     block_id: blockId,
-    user_id: userId,
   }: DeleteBlockMinedEventOptions): Promise<GraphileWorkerHandlerResponse> {
-    const user = await this.usersService.find(userId);
-    if (!user) {
-      this.loggerService.error(`No user found for '${userId}'`, '');
-      return { requeue: false };
-    }
-
     const block = await this.blocksService.find(blockId);
     if (!block) {
       this.loggerService.error(`No block found for '${blockId}'`, '');
       return { requeue: false };
     }
 
-    await this.eventsService.deleteBlockMined(block, user);
+    await this.eventsService.deleteBlockMined(block);
     return { requeue: false };
   }
 }

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -724,15 +724,15 @@ describe('EventsService', () => {
   describe('deleteBlockMined', () => {
     describe('when the event does not exist', () => {
       it('returns null', async () => {
-        const { block, user } = await setupBlockMined();
-        expect(await eventsService.deleteBlockMined(block, user)).toBeNull();
+        const { block } = await setupBlockMined();
+        expect(await eventsService.deleteBlockMined(block)).toBeNull();
       });
     });
 
     describe('when the event exists', () => {
       it('deletes the record', async () => {
-        const { block, event, user } = await setupBlockMinedWithEvent();
-        const record = await eventsService.deleteBlockMined(block, user);
+        const { block, event } = await setupBlockMinedWithEvent();
+        const record = await eventsService.deleteBlockMined(block);
         expect(record).toMatchObject({
           ...event,
           deleted_at: expect.any(Date),
@@ -743,10 +743,30 @@ describe('EventsService', () => {
 
       it('subtracts points from the user total points', async () => {
         const { block, event, user } = await setupBlockMinedWithEvent();
-        await eventsService.deleteBlockMined(block, user);
+        await eventsService.deleteBlockMined(block);
         const updatedUser = await usersService.findOrThrow(user.id);
         expect(updatedUser.total_points).toBe(user.total_points - event.points);
       });
+    });
+  });
+
+  describe('delete', () => {
+    it('sets `deleted_at` for the record', async () => {
+      const { event } = await setupBlockMinedWithEvent();
+      const record = await eventsService.delete(event);
+      expect(record).toMatchObject({
+        ...event,
+        deleted_at: expect.any(Date),
+        updated_at: expect.any(Date),
+        points: 0,
+      });
+    });
+
+    it('subtracts points from the user total points', async () => {
+      const { event, user } = await setupBlockMinedWithEvent();
+      await eventsService.delete(event);
+      const updatedUser = await usersService.findOrThrow(event.user_id);
+      expect(updatedUser.total_points).toBe(user.total_points - event.points);
     });
   });
 

--- a/src/events/interfaces/delete-block-mined-event-options.ts
+++ b/src/events/interfaces/delete-block-mined-event-options.ts
@@ -3,5 +3,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export interface DeleteBlockMinedEventOptions {
   block_id: number;
-  user_id: number;
 }


### PR DESCRIPTION
## Summary

Add a method to set the `deleted_at` timestamp on the Events Service and refactor the graphile job to ignore the user id.

## Testing Plan

Updated unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
