### PR TITLE
feat(api): Add `github` as an option when updating users

### DIFF
--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -18,6 +18,10 @@ export class UpdateUserDto {
   readonly discord?: string;
 
   @IsOptional()
+  @IsString()
+  readonly github?: string;
+
+  @IsOptional()
   @IsNotEmpty()
   @IsString()
   readonly graffiti?: string;

--- a/src/users/interfaces/update-user-options.ts
+++ b/src/users/interfaces/update-user-options.ts
@@ -4,6 +4,7 @@
 export interface UpdateUserOptions {
   countryCode?: string;
   discord?: string;
+  github?: string;
   graffiti?: string;
   telegram?: string;
 }

--- a/src/users/users-updater.ts
+++ b/src/users/users-updater.ts
@@ -18,7 +18,7 @@ export class UsersUpdater {
 
   async update(user: User, options: UpdateUserOptions): Promise<User> {
     return this.prisma.$transaction(async (prisma) => {
-      const { discord, graffiti, telegram } = options;
+      const { discord, github, graffiti, telegram } = options;
 
       if (graffiti && user.graffiti !== graffiti) {
         await prisma.$executeRawUnsafe(
@@ -48,6 +48,11 @@ export class UsersUpdater {
           error = {
             code: 'duplicate_user_discord',
             message: `User with Discord '${discord}' already exists`,
+          };
+        } else if (github && github === duplicateUser.github) {
+          error = {
+            code: 'duplicate_user_github',
+            message: `User with github '${github}' already exists`,
           };
         } else if (graffiti && graffiti === duplicateUser.graffiti) {
           error = {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -278,6 +278,7 @@ export class UsersController {
     return this.usersUpdater.update(user, {
       countryCode: dto.country_code,
       discord: dto.discord,
+      github: dto.github,
       graffiti: dto.graffiti,
       telegram: dto.telegram,
     });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -522,6 +522,33 @@ describe('UsersService', () => {
       });
     });
 
+    describe('with a duplicate github', () => {
+      it('returns the duplicate records', async () => {
+        const user = await usersService.create({
+          country_code: faker.address.countryCode('alpha-3'),
+          email: faker.internet.email(),
+          github: faker.internet.email(),
+          graffiti: uuid(),
+        });
+        const duplicateUser = await usersService.create({
+          country_code: faker.address.countryCode('alpha-3'),
+          email: faker.internet.email(),
+          github: faker.internet.email(),
+          graffiti: uuid(),
+        });
+
+        assert.ok(duplicateUser.github);
+        const duplicateUsers = await usersService.findDuplicateUser(
+          user,
+          { github: duplicateUser.github },
+          prisma,
+        );
+        expect(duplicateUsers).toHaveLength(1);
+        assert.ok(duplicateUsers[0]);
+        expect(duplicateUsers[0].id).toBe(duplicateUser.id);
+      });
+    });
+
     describe('with a duplicate graffiti', () => {
       it('returns the duplicate records', async () => {
         const user = await usersService.create({
@@ -606,6 +633,7 @@ describe('UsersService', () => {
       const options = {
         countryCode: faker.address.countryCode('alpha-3'),
         discord: ulid(),
+        github: ulid(),
         graffiti: ulid(),
         telegram: ulid(),
       };
@@ -621,6 +649,7 @@ describe('UsersService', () => {
         id: user.id,
         country_code: options.countryCode,
         discord: options.discord,
+        github: options.github,
         graffiti: options.graffiti,
         telegram: options.telegram,
       });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -420,11 +420,14 @@ export class UsersService {
     options: UpdateUserOptions,
     client: BasePrismaClient,
   ): Promise<User[]> {
-    const { discord, graffiti, telegram } = options;
+    const { discord, github, graffiti, telegram } = options;
 
     const filters = [];
     if (discord) {
       filters.push({ discord });
+    }
+    if (github) {
+      filters.push({ github });
     }
     if (graffiti) {
       filters.push({ graffiti });
@@ -448,11 +451,12 @@ export class UsersService {
     options: UpdateUserOptions,
     client: BasePrismaClient,
   ): Promise<User> {
-    const { countryCode, discord, graffiti, telegram } = options;
+    const { countryCode, discord, github, graffiti, telegram } = options;
     return client.user.update({
       data: {
         country_code: countryCode,
         discord,
+        github,
         graffiti,
         telegram,
       },


### PR DESCRIPTION
## Summary

Allow updates for user GitHub fields.

## Testing Plan

Updated unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
