### PR TITLE
Revert "chore(deps): Bump dd-trace from 2.2.0 to 2.2.1 (#673)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "class-validator": "0.13.2",
     "cluster": "0.7.7",
     "compression": "1.7.4",
-    "dd-trace": "2.2.1",
+    "dd-trace": "2.2.0",
     "express": "4.17.3",
     "graphile-worker": "0.12.2",
     "helmet": "5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1541,6 +1541,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+atob@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
 atomic-sleep@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
@@ -2173,10 +2178,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dd-trace@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-2.2.1.tgz#311627428c45b948ce6ba9f77862333fa5a6c345"
-  integrity sha512-0ynPHrA4++cOaLWYTKNY2lVeQJ8uT69GoYAFn1JtIADBTMPGs3gdcy+AAId4lkVzq3LTaXAqX6ZqPvd6OgiN8g==
+dd-trace@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-2.2.0.tgz#414b02a05c2ea8f6a9304f267d92834fb00cc7ce"
+  integrity sha512-PEYucl6bQoyz4CF6kCu1LBbJ9p8qec7sl6cbnfV+wZoMgdQrf30q/iV+5YbyzVCZVnkY5xsFqR8f08/V/ygIBw==
   dependencies:
     "@datadog/native-appsec" "^0.8.1"
     "@datadog/native-metrics" "^1.1.0"
@@ -2186,7 +2191,7 @@ dd-trace@2.2.1:
     crypto-randomuuid "^1.0.0"
     diagnostics_channel "^1.1.0"
     form-data "^3.0.0"
-    import-in-the-middle "^1.2.1"
+    import-in-the-middle "^1.1.2"
     koalas "^1.0.2"
     limiter "^1.1.4"
     lodash.kebabcase "^4.1.1"
@@ -2201,6 +2206,8 @@ dd-trace@2.2.1:
     performance-now "^2.1.0"
     retry "^0.10.1"
     semver "^5.5.0"
+    source-map "^0.7.3"
+    source-map-resolve "^0.6.0"
 
 debug@2.6.9:
   version "2.6.9"
@@ -2220,6 +2227,11 @@ decimal.js@^10.2.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -3364,10 +3376,10 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.2.1.tgz#30d4e98be7329eee0d284943dd0df092cc422b3c"
-  integrity sha512-KdYqCJbJWBOU9740nr9lrmCDhW7htxY1dHmbP4iUEeCaxupj2fKFhyHixsly2WmxMbRIsxzSWSJMfGNEU7el+w==
+import-in-the-middle@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.2.0.tgz#203a910e08e7e3db8a0cb3abb85d919459162cbf"
+  integrity sha512-i2OrkKW2UH/W4asmzQztA5qjYxMFLh5BaOUEWLv6Ra0MDT+5v7P/7x5/ESZgG9LOaKijYjXnMfupzzy66tfcyA==
   dependencies:
     module-details-from-path "^1.0.3"
 
@@ -5379,6 +5391,14 @@ sonic-boom@^2.2.1:
   integrity sha512-WgtVLfGl347/zS1oTuLaOAvVD5zijgjphAJHgbbnBJGgexnr+C1ULSj0j7ftoGxpuxR4PaV635NkwFemG8m/5w==
   dependencies:
     atomic-sleep "^1.0.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.6:
   version "0.5.19"


### PR DESCRIPTION
## Summary

This reverts commit ab2f6f175e18aad4658b0a84f5216c5a4bac73fe.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
