### PR TITLE
feat(api): Do not create any events after the end of phase one sequence

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -738,6 +738,15 @@ describe('EventsService', () => {
         });
       });
     });
+
+    describe('when the sequence is after the end of phase one', () => {
+      it('returns null', async () => {
+        const { block, user } = await setupBlockMined();
+        block.sequence = 150001;
+        const event = await eventsService.upsertBlockMined(block, user);
+        expect(event).toBeNull();
+      });
+    });
   });
 
   describe('deleteBlockMined', () => {

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -313,7 +313,7 @@ export class EventsService {
     });
   }
 
-  async createWithClient(
+  private async createWithClient(
     { blockId, occurredAt, points, type, userId, url }: CreateEventOptions,
     client: BasePrismaClient,
   ): Promise<EventWithMetadata | null> {
@@ -441,6 +441,11 @@ export class EventsService {
   }
 
   async upsertBlockMined(block: Block, user: User): Promise<Event | null> {
+    // https://ironfish.network/blog/2022/03/07/incentivized-testnet-roadmap
+    const endOfPhaseOneSequence = 150000;
+    if (block.sequence > endOfPhaseOneSequence) {
+      return null;
+    }
     return this.create({
       blockId: block.id,
       occurredAt: block.timestamp,


### PR DESCRIPTION
## Summary

Do not create any block mined events after sequence 150000.

## Testing Plan

Added unit test.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
