### PR TITLE
fix(api): Fix pagination for getting previous chunks of users

### DIFF
--- a/src/blocks/__snapshots__/blocks.controller.spec.ts.snap
+++ b/src/blocks/__snapshots__/blocks.controller.spec.ts.snap
@@ -91,6 +91,16 @@ Object {
 }
 `;
 
+exports[`BlocksController POST /blocks with a valid payload upserts blocks 1`] = `
+Object {
+  "error": "Unprocessable Entity",
+  "message": Array [
+    "blocks must contain not more than 3000 elements",
+  ],
+  "statusCode": 422,
+}
+`;
+
 exports[`BlocksController POST /blocks with missing arguments returns a 422 1`] = `
 Object {
   "error": "Unprocessable Entity",

--- a/src/blocks/__snapshots__/blocks.controller.spec.ts.snap
+++ b/src/blocks/__snapshots__/blocks.controller.spec.ts.snap
@@ -91,16 +91,6 @@ Object {
 }
 `;
 
-exports[`BlocksController POST /blocks with a valid payload upserts blocks 1`] = `
-Object {
-  "error": "Unprocessable Entity",
-  "message": Array [
-    "blocks must contain not more than 3000 elements",
-  ],
-  "statusCode": 422,
-}
-`;
-
 exports[`BlocksController POST /blocks with missing arguments returns a 422 1`] = `
 Object {
   "error": "Unprocessable Entity",

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -277,8 +277,13 @@ export class UsersService {
           ELSE
             TRUE
         END
-      ORDER BY
-        rank ASC
+      ORDER BY 
+        CASE WHEN $2
+          THEN 
+            rank 
+          ELSE 
+            -rank 
+        END ASC
       LIMIT
         $4`;
 
@@ -291,6 +296,12 @@ export class UsersService {
       countryCode,
       eventType,
     );
+    // If fetching a previous page, the ranks are sorted in opposite order.
+    // Reverse the data so the returned chunk is in ascending order.
+    if (before !== undefined) {
+      data.reverse();
+    }
+
     return {
       data,
       ...(await this.getListWithRankMetadata(

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -298,7 +298,7 @@ export class UsersService {
     );
     // If fetching a previous page, the ranks are sorted in opposite order.
     // Reverse the data so the returned chunk is in ascending order.
-    if (before !== undefined) {
+    if (!before) {
       data.reverse();
     }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -298,7 +298,7 @@ export class UsersService {
     );
     // If fetching a previous page, the ranks are sorted in opposite order.
     // Reverse the data so the returned chunk is in ascending order.
-    if (!before) {
+    if (before !== undefined) {
       data.reverse();
     }
 


### PR DESCRIPTION
## Summary

Fix the previous page cursor in the ranking query to not return the top ranked users.

## Testing Plan

Manually tested

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
