### PR TITLE
Disable login if DISABLE_LOGIN env is set

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -57,6 +57,7 @@ export const REST_MODULES = [
         DATABASE_CONNECTION_POOL_URL: joi.string().required(),
         DATABASE_URL: joi.string().required(),
         DATADOG_URL: joi.string().required(),
+        DISABLE_LOGIN: joi.boolean().default(false),
         INCENTIVIZED_TESTNET_URL: joi.string().required(),
         INFLUXDB_API_TOKEN: joi.string().required(),
         INFLUXDB_BUCKET: joi.string().required(),

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -11,12 +11,14 @@ import {
 } from '@nestjs/common';
 import { ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Request, Response } from 'express';
+import { ApiConfigService } from '../api-config/api-config.service';
 import { MagicLinkService } from '../magic-link/magic-link.service';
 import { UsersService } from '../users/users.service';
 
 @Controller()
 export class AuthController {
   constructor(
+    private readonly config: ApiConfigService,
     private readonly magicLinkService: MagicLinkService,
     private readonly usersService: UsersService,
   ) {}
@@ -24,6 +26,10 @@ export class AuthController {
   @ApiExcludeEndpoint()
   @Post('login')
   async login(@Req() req: Request, @Res() res: Response): Promise<void> {
+    if (this.config.get<boolean>('DISABLE_LOGIN')) {
+      throw new UnauthorizedException();
+    }
+
     let email;
 
     const { authorization } = req.headers;

--- a/src/auth/strategies/magic-link.strategy.ts
+++ b/src/auth/strategies/magic-link.strategy.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Request } from 'express';
 import { Strategy } from 'passport';
+import { ApiConfigService } from '../../api-config/api-config.service';
 import { MagicLinkContext } from '../../common/interfaces/magic-link-context';
 import { MagicLinkService } from '../../magic-link/magic-link.service';
 import { UsersService } from '../../users/users.service';
@@ -15,6 +16,7 @@ export class MagicLinkStrategy extends PassportStrategy(
   'magic-link',
 ) {
   constructor(
+    private readonly config: ApiConfigService,
     private readonly magicLinkService: MagicLinkService,
     private readonly usersService: UsersService,
   ) {
@@ -26,6 +28,11 @@ export class MagicLinkStrategy extends PassportStrategy(
     if (!authorization) {
       return this.fail();
     }
+
+    if (this.config.get('DISABLE_LOGIN')) {
+      return this.fail();
+    }
+
     try {
       const email = await this.magicLinkService.getEmailFromHeader(
         authorization,

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -298,11 +298,11 @@ export class BlocksService {
       SELECT
         COUNT(*) AS cumulative_unique_graffiti
       FROM (
-        SELECT 
-          DISTINCT graffiti 
-        FROM 
-          blocks 
-        WHERE 
+        SELECT
+          DISTINCT graffiti
+        FROM
+          blocks
+        WHERE
           timestamp < '${end.toISOString()}' AND
           main = true AND
           network_version = $1

--- a/src/test/test-app.ts
+++ b/src/test/test-app.ts
@@ -23,6 +23,7 @@ export async function bootstrapTestApp(): Promise<INestApplication> {
           DATABASE_CONNECTION_POOL_URL: joi.string().required(),
           DATABASE_URL: joi.string().required(),
           DATADOG_URL: joi.string().required(),
+          DISABLE_LOGIN: joi.boolean().default(false),
           INCENTIVIZED_TESTNET_URL: joi.string().required(),
           INFLUXDB_API_TOKEN: joi.string().required(),
           INFLUXDB_BUCKET: joi.string().required(),


### PR DESCRIPTION
## Summary

This allows us to disable logins and auth in the case that we we set an
environment variable called DISABLE_LOGIN. This is useful to help make
phase1 readonly.

https://linear.app/ironfish/issue/IRO-1752/prevent-logging-into-phase-1-api

## Testing Plan
Write test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
