### PR TITLE
feat(api): Add `CHECK_USER_CREATED_AT` when upserting block mined events

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 API_URL=http://localhost:8003
 BLOCK_EXPLORER_URL=http://localhost:3000
+CHECK_USER_CREATED_AT=true
 DATABASE_CONNECTION_POOL_URL=postgres://postgres:password@localhost:5432/ironfish_api_development
 DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_development
 DATADOG_URL=127.0.0.1

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 API_URL=http://localhost:8003
 BLOCK_EXPLORER_URL=test
+CHECK_USER_CREATED_AT=true
 DATABASE_CONNECTION_POOL_URL=postgres://postgres:password@localhost:5432/ironfish_api_development
 DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_test
 DATADOG_URL=127.0.0.1

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -54,6 +54,7 @@ export const REST_MODULES = [
       validationSchema: joi.object({
         API_URL: joi.string().required(),
         BLOCK_EXPLORER_URL: joi.string().required(),
+        CHECK_USER_CREATED_AT: joi.boolean().default(true),
         DATABASE_CONNECTION_POOL_URL: joi.string().required(),
         DATABASE_URL: joi.string().required(),
         DATADOG_URL: joi.string().required(),

--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -140,6 +140,41 @@ describe('BlocksService', () => {
         previous_block_hash: standardizeHash(previousBlockHash),
       });
     });
+
+    describe('if CHECK_USER_CREATED_AT is disabled', () => {
+      it('upserts records with timestamps before created_at', async () => {
+        const graffiti = uuid();
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti,
+          country_code: faker.address.countryCode('alpha-3'),
+        });
+        const options = {
+          hash: uuid(),
+          sequence: faker.datatype.number(),
+          difficulty: faker.datatype.number(),
+          timestamp: new Date('2000-01-01T00:00:00Z'),
+          transactionsCount: 1,
+          type: BlockOperation.CONNECTED,
+          graffiti,
+          previousBlockHash: uuid(),
+          size: faker.datatype.number(),
+        };
+
+        jest
+          .spyOn(config, 'get')
+          .mockImplementationOnce(() => 0)
+          .mockImplementationOnce(() => false);
+        const { block, upsertBlockMinedOptions } = await blocksService.upsert(
+          prisma,
+          options,
+        );
+        expect(upsertBlockMinedOptions).toEqual({
+          block_id: block.id,
+          user_id: user.id,
+        });
+      });
+    });
   });
 
   describe('head', () => {

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -97,7 +97,10 @@ export class BlocksService {
     });
 
     const user = await this.usersService.findByGraffiti(graffiti, prisma);
-    if (user && timestamp > user.created_at) {
+    const checkUserCreatedAt = this.config.get<boolean>(
+      'CHECK_USER_CREATED_AT',
+    );
+    if (user && (!checkUserCreatedAt || timestamp > user.created_at)) {
       if (main) {
         upsertBlockMinedOptions = { block_id: block.id, user_id: user.id };
       } else {

--- a/src/test/test-app.ts
+++ b/src/test/test-app.ts
@@ -20,6 +20,7 @@ export async function bootstrapTestApp(): Promise<INestApplication> {
         validationSchema: joi.object({
           API_URL: joi.string().required(),
           BLOCK_EXPLORER_URL: joi.string().required(),
+          CHECK_USER_CREATED_AT: joi.boolean().default(true),
           DATABASE_CONNECTION_POOL_URL: joi.string().required(),
           DATABASE_URL: joi.string().required(),
           DATADOG_URL: joi.string().required(),


### PR DESCRIPTION
## Summary

We check for user creation timestamps with block mined events. This PR wraps that check with an environment variable to make re-syncs easier.

## Testing Plan

Added unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
