### PR TITLE
Add NodeUptime table and migration

### DIFF
--- a/prisma/migrations/20220408160724_create_node_uptimes/migration.sql
+++ b/prisma/migrations/20220408160724_create_node_uptimes/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "node_uptimes" (
+    "user_id" INTEGER NOT NULL,
+    "total_hours" INTEGER NOT NULL DEFAULT 0,
+    "last_checked_in" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "node_uptimes_pkey" PRIMARY KEY ("user_id")
+);
+
+-- CreateIndex
+CREATE INDEX "index_node_uptime_on_user_id" ON "node_uptimes"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "node_uptimes" ADD CONSTRAINT "node_uptimes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20220408170514_create_node_uptimes/migration.sql
+++ b/prisma/migrations/20220408170514_create_node_uptimes/migration.sql
@@ -1,14 +1,18 @@
 -- CreateTable
 CREATE TABLE "node_uptimes" (
+    "id" SERIAL NOT NULL,
     "user_id" INTEGER NOT NULL,
     "total_hours" INTEGER NOT NULL DEFAULT 0,
     "last_checked_in" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    CONSTRAINT "node_uptimes_pkey" PRIMARY KEY ("user_id")
+    CONSTRAINT "node_uptimes_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
 CREATE INDEX "index_node_uptime_on_user_id" ON "node_uptimes"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "node_uptimes_user_id_key" ON "node_uptimes"("user_id");
 
 -- AddForeignKey
 ALTER TABLE "node_uptimes" ADD CONSTRAINT "node_uptimes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,23 +28,35 @@ model Event {
 }
 
 model User {
-  id                  Int       @id @default(autoincrement())
-  created_at          DateTime  @default(now()) @db.Timestamp(6)
-  updated_at          DateTime  @default(now()) @updatedAt @db.Timestamp(6)
-  email               String    @db.VarChar @unique(map: "uq_users_on_email")
-  graffiti            String    @db.VarChar @unique(map: "uq_users_on_graffiti")
-  total_points        Int       @default(0)
-  country_code        String    @db.VarChar
-  email_notifications Boolean   @default(false)
-  last_login_at       DateTime? @db.Timestamp(6)
-  discord             String?   @db.VarChar
-  telegram            String?   @db.VarChar
-  github              String?   @db.VarChar
+  id                  Int         @id @default(autoincrement())
+  created_at          DateTime    @default(now()) @db.Timestamp(6)
+  updated_at          DateTime    @default(now()) @updatedAt @db.Timestamp(6)
+  email               String      @db.VarChar @unique(map: "uq_users_on_email")
+  graffiti            String      @db.VarChar @unique(map: "uq_users_on_graffiti")
+  total_points        Int         @default(0)
+  country_code        String      @db.VarChar
+  email_notifications Boolean     @default(false)
+  last_login_at       DateTime?   @db.Timestamp(6)
+  discord             String?     @db.VarChar
+  telegram            String?     @db.VarChar
+  github              String?     @db.VarChar
   events              Event[]
+  node_uptime         NodeUptime?
 
   @@index([email], name: "index_users_on_email")
   @@index([graffiti], name: "index_users_on_graffiti")
   @@map("users")
+}
+
+model NodeUptime {
+  user            User     @relation(fields: [user_id], references: [id])
+  user_id         Int
+  total_hours     Int      @default(0)
+  last_checked_in DateTime @default(now()) @db.Timestamp(6)
+
+  @@id(user_id)
+  @@index([user_id], name: "index_node_uptime_on_user_id")
+  @@map("node_uptimes")
 }
 
 model Block {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,12 +49,12 @@ model User {
 }
 
 model NodeUptime {
+  id              Int      @id @default(autoincrement())
   user            User     @relation(fields: [user_id], references: [id])
   user_id         Int
   total_hours     Int      @default(0)
   last_checked_in DateTime @default(now()) @db.Timestamp(6)
 
-  @@id(user_id)
   @@index([user_id], name: "index_node_uptime_on_user_id")
   @@map("node_uptimes")
 }


### PR DESCRIPTION
## Summary

Preparation for upcoming changes. We'll have a graphile job check this periodically and update to 0 when the threshold has been hit, telemetry endpoint will update this when it receives a request with the extra graffiti parameter

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
