### PR TITLE
Implement NodeUptime tracking on telemetry endpoint

### DIFF
--- a/src/node-uptimes/node-uptimes.module.ts
+++ b/src/node-uptimes/node-uptimes.module.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { NodeUptimesService } from './node-uptimes.service';
+
+@Module({
+  exports: [NodeUptimesService],
+  imports: [PrismaModule],
+  providers: [NodeUptimesService],
+})
+export class NodeUptimesModule {}

--- a/src/node-uptimes/node-uptimes.service.spec.ts
+++ b/src/node-uptimes/node-uptimes.service.spec.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { INestApplication } from '@nestjs/common';
+import assert from 'assert';
+import faker from 'faker';
+import { v4 as uuid } from 'uuid';
+import { PrismaService } from '../prisma/prisma.service';
+import { bootstrapTestApp } from '../test/test-app';
+import { NodeUptimesService } from './node-uptimes.service';
+
+describe('NodeUptimesService', () => {
+  let app: INestApplication;
+  let nodeUptimesService: NodeUptimesService;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    app = await bootstrapTestApp();
+    nodeUptimesService = app.get(NodeUptimesService);
+    prisma = app.get(PrismaService);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const createUser = async () => {
+    return await prisma.user.create({
+      data: {
+        email: faker.internet.email(),
+        graffiti: uuid(),
+        country_code: faker.address.countryCode(),
+      },
+    });
+  };
+
+  describe('upsert', () => {
+    it('creates node uptime if not already created', async () => {
+      const now = new Date();
+      const user = await createUser();
+
+      const uptime = await nodeUptimesService.upsert(user);
+
+      expect(uptime).toMatchObject({
+        user_id: user.id,
+        last_checked_in: expect.any(Date),
+        total_hours: 0,
+      });
+      assert(uptime);
+      expect(uptime.last_checked_in.getTime()).toBeGreaterThanOrEqual(
+        now.getTime(),
+      );
+    });
+
+    it('updates an existing node uptime if enough time has passed', async () => {
+      const now = new Date();
+      const twoHoursAgo = new Date();
+      twoHoursAgo.setHours(now.getHours() - 2);
+      const user = await createUser();
+      await prisma.nodeUptime.create({
+        data: {
+          user_id: user.id,
+          last_checked_in: twoHoursAgo,
+          total_hours: 0,
+        },
+      });
+
+      const uptime = await nodeUptimesService.upsert(user);
+
+      expect(uptime).toMatchObject({
+        user_id: user.id,
+        last_checked_in: expect.any(Date),
+        total_hours: 1,
+      });
+      assert(uptime);
+      expect(uptime.last_checked_in.getTime()).toBeGreaterThanOrEqual(
+        now.getTime(),
+      );
+    });
+
+    it('does not update node uptime if enough time has not passed', async () => {
+      const now = new Date();
+      const user = await createUser();
+      await prisma.nodeUptime.create({
+        data: {
+          user_id: user.id,
+          last_checked_in: now,
+          total_hours: 0,
+        },
+      });
+
+      const uptime = await nodeUptimesService.upsert(user);
+      const dbUptime = await nodeUptimesService.get(user);
+
+      expect(uptime).toBeNull();
+
+      expect(dbUptime).toMatchObject({
+        user_id: user.id,
+        last_checked_in: now,
+        total_hours: 0,
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('returns null if not created', async () => {
+      const user = await createUser();
+
+      const result = await nodeUptimesService.get(user);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns node uptime if created', async () => {
+      const user = await createUser();
+
+      const uptime = await prisma.nodeUptime.create({
+        data: {
+          user_id: user.id,
+        },
+      });
+
+      const result = await nodeUptimesService.get(user);
+
+      expect(result).toEqual(uptime);
+    });
+  });
+});

--- a/src/node-uptimes/node-uptimes.service.spec.ts
+++ b/src/node-uptimes/node-uptimes.service.spec.ts
@@ -26,7 +26,7 @@ describe('NodeUptimesService', () => {
   });
 
   const createUser = async () => {
-    return await prisma.user.create({
+    return prisma.user.create({
       data: {
         email: faker.internet.email(),
         graffiti: uuid(),

--- a/src/node-uptimes/node-uptimes.service.ts
+++ b/src/node-uptimes/node-uptimes.service.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Injectable } from '@nestjs/common';
+import { User } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { NodeUptime } from '.prisma/client';
+
+@Injectable()
+export class NodeUptimesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async upsert(user: User): Promise<NodeUptime | null> {
+    const now = new Date();
+    const oneHourAgo = new Date();
+    oneHourAgo.setHours(now.getHours() - 1);
+
+    return this.prisma.$transaction(async (prisma) => {
+      const nodeUptime = await this.get(user);
+      if (nodeUptime && nodeUptime.last_checked_in >= oneHourAgo) {
+        return null;
+      }
+
+      return prisma.nodeUptime.upsert({
+        where: {
+          user_id: user.id,
+        },
+        update: {
+          last_checked_in: now.toISOString(),
+          total_hours: {
+            increment: 1,
+          },
+        },
+        create: {
+          user_id: user.id,
+          last_checked_in: now.toISOString(),
+          total_hours: 0,
+        },
+      });
+    });
+  }
+
+  async get(user: User): Promise<NodeUptime | null> {
+    return this.prisma.nodeUptime.findUnique({
+      where: {
+        user_id: user.id,
+      },
+    });
+  }
+}

--- a/src/telemetry/dto/write-telemetry-points.dto.ts
+++ b/src/telemetry/dto/write-telemetry-points.dto.ts
@@ -7,6 +7,7 @@ import {
   IsArray,
   IsDate,
   IsNotEmpty,
+  IsOptional,
   IsString,
   ValidateNested,
 } from 'class-validator';
@@ -68,4 +69,8 @@ export class WriteTelemetryPointsDto {
   @ValidateNested({ each: true })
   @Type(() => WriteTelemetryPointDto)
   readonly points!: WriteTelemetryPointDto[];
+
+  @IsOptional()
+  @IsString()
+  readonly graffiti?: string;
 }

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -62,10 +62,9 @@ export class TelemetryController {
 
     if (graffiti) {
       const user = await this.usersService.findByGraffiti(graffiti);
-      if (user == null) {
-        return;
+      if (user) {
+        await this.nodeUptimes.upsert(user);
       }
-      await this.nodeUptimes.upsert(user);
     }
   }
 

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -13,17 +13,23 @@ import { ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Request } from 'express';
 import { gte, valid } from 'semver';
 import { InfluxDbService } from '../influxdb/influxdb.service';
+import { NodeUptimesService } from '../node-uptimes/node-uptimes.service';
+import { UsersService } from '../users/users.service';
 import { WriteTelemetryPointsDto } from './dto/write-telemetry-points.dto';
 
 @Controller('telemetry')
 export class TelemetryController {
   private readonly MINIMUM_TELEMETRY_VERSION = '0.1.24';
 
-  constructor(private readonly influxDbService: InfluxDbService) {}
+  constructor(
+    private readonly influxDbService: InfluxDbService,
+    private readonly nodeUptimes: NodeUptimesService,
+    private readonly usersService: UsersService,
+  ) {}
 
   @ApiExcludeEndpoint()
   @Post()
-  write(
+  async write(
     @Req() request: Request,
     @Body(
       new ValidationPipe({
@@ -31,8 +37,8 @@ export class TelemetryController {
         transform: true,
       }),
     )
-    { points }: WriteTelemetryPointsDto,
-  ): void {
+    { points, graffiti }: WriteTelemetryPointsDto,
+  ): Promise<void> {
     const options = [];
     for (const { fields, measurement, tags, timestamp } of points) {
       const version = tags.find((tag) => tag.name === 'version');
@@ -53,6 +59,14 @@ export class TelemetryController {
     }
 
     this.submitIpWithoutNodeFieldsToTelemetry(request);
+
+    if (graffiti) {
+      const user = await this.usersService.findByGraffiti(graffiti);
+      if (user == null) {
+        return;
+      }
+      await this.nodeUptimes.upsert(user);
+    }
   }
 
   private isValidTelemetryVersion(version: string): boolean {

--- a/src/telemetry/telemetry.rest.module.ts
+++ b/src/telemetry/telemetry.rest.module.ts
@@ -3,10 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
 import { InfluxDbModule } from '../influxdb/influxdb.module';
+import { NodeUptimesModule } from '../node-uptimes/node-uptimes.module';
+import { UsersModule } from '../users/users.module';
 import { TelemetryController } from './telemetry.controller';
 
 @Module({
   controllers: [TelemetryController],
-  imports: [InfluxDbModule],
+  imports: [InfluxDbModule, NodeUptimesModule, UsersModule],
 })
 export class TelemetryRestModule {}


### PR DESCRIPTION
## Summary

When the API receives a telemetry write request, and the graffiti is included in the request payload, we want to track that as a NodeUptime "check-in" in the DB. We only want to up date the check-in count once per hour.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
