### PR TITLE
Make payload in addJob() optional

### DIFF
--- a/src/graphile-worker/graphile-worker.service.ts
+++ b/src/graphile-worker/graphile-worker.service.ts
@@ -17,7 +17,7 @@ export class GraphileWorkerService {
 
   async addJob<T = unknown>(
     pattern: GraphileWorkerPattern,
-    payload: T,
+    payload?: T,
     { queueName, runAt }: GraphileWorkerJobOptions = {},
   ): Promise<Job> {
     if (!this.workerUtils) {

--- a/src/user-points/user-points.controller.spec.ts
+++ b/src/user-points/user-points.controller.spec.ts
@@ -46,7 +46,6 @@ describe('UserPointsController', () => {
 
       expect(addJob).toHaveBeenCalledWith(
         GraphileWorkerPattern.REFRESH_USERS_POINTS,
-        undefined,
       );
     });
   });

--- a/src/user-points/user-points.controller.ts
+++ b/src/user-points/user-points.controller.ts
@@ -18,7 +18,6 @@ export class UserPointsController {
   async refresh(): Promise<void> {
     await this.graphileWorkerService.addJob(
       GraphileWorkerPattern.REFRESH_USERS_POINTS,
-      undefined,
     );
   }
 }

--- a/src/user-points/user-points.jobs.controller.spec.ts
+++ b/src/user-points/user-points.jobs.controller.spec.ts
@@ -25,7 +25,7 @@ describe('UserPointsJobsController', () => {
 
   let addJob: jest.SpyInstance<
     Promise<Job>,
-    [GraphileWorkerPattern, unknown, GraphileWorkerJobOptions?]
+    [GraphileWorkerPattern, unknown?, GraphileWorkerJobOptions?]
   >;
 
   beforeAll(async () => {


### PR DESCRIPTION
## Summary

Some jobs have no payloads, and we shouldn't need to pass undefined as
not passing anything is the same as passing undefined bound to that
variable.

## Testing Plan
Ran tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
