### PR TITLE
Add pool ranks to metrics endpoint

### DIFF
--- a/src/common/enums/metrics-pool.ts
+++ b/src/common/enums/metrics-pool.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export enum MetricsPool {
+  MAIN = 'main',
+  CODE = 'code',
+}

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -81,9 +81,11 @@ export class EventsController {
       userId: user.id,
       url,
     });
+
     if (!event) {
       return null;
     }
+
     return serializedEventFromRecordWithMetadata(event);
   }
 

--- a/src/users/interfaces/serialized-user-metrics.ts
+++ b/src/users/interfaces/serialized-user-metrics.ts
@@ -15,4 +15,8 @@ export interface SerializedUserMetrics {
     pull_requests_merged: SerializedEventMetrics;
     social_media_contributions: SerializedEventMetrics;
   };
+  pools?: {
+    main: SerializedEventMetrics;
+    code: SerializedEventMetrics;
+  };
 }


### PR DESCRIPTION
## Summary

This adds new pool ranks based off of the pool categories the pool
ranks.

## Testing Plan
Wrote tests and checked the API using prod data

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
