### PR TITLE
Remove no from breaking change in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,4 @@ what additional work is required, if any.
 
 ```
 [ ] Yes
-[ ] No
 ```


### PR DESCRIPTION
## Summary

This is an oppinionated change but I noticed the front end doesn't have
it, and I just have to check NO for every PR. It'll be nice not to have
to do that I think.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
