### PR TITLE
Send back node uptime in user metrics

### DIFF
--- a/src/users/interfaces/serialized-user-metrics.ts
+++ b/src/users/interfaces/serialized-user-metrics.ts
@@ -14,6 +14,7 @@ export interface SerializedUserMetrics {
     community_contributions: SerializedEventMetrics;
     pull_requests_merged: SerializedEventMetrics;
     social_media_contributions: SerializedEventMetrics;
+    node_uptime: SerializedEventMetrics;
   };
   pools?: {
     main: SerializedEventMetrics;

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -315,24 +315,28 @@ describe('UsersController', () => {
           },
           metrics: {
             blocks_mined: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 0,
+              points: 0,
             },
             bugs_caught: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 1,
+              points: 100,
             },
             community_contributions: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 0,
+              points: 0,
             },
             pull_requests_merged: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 1,
+              points: 500,
             },
             social_media_contributions: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 0,
+              points: 0,
+            },
+            node_uptime: {
+              count: 0,
+              points: 0,
             },
           },
         });
@@ -348,6 +352,7 @@ describe('UsersController', () => {
             country_code: faker.address.countryCode('alpha-3'),
           },
         });
+
         const start = new Date(Date.now() - 1).toISOString();
         const end = new Date().toISOString();
         const granularity = MetricsGranularity.TOTAL;
@@ -359,30 +364,35 @@ describe('UsersController', () => {
             start,
             end,
           });
+
         expect(body).toMatchObject({
           user_id: user.id,
           granularity,
-          points: expect.any(Number),
+          points: 0,
           metrics: {
             blocks_mined: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 0,
+              points: 0,
             },
             bugs_caught: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 0,
+              points: 0,
             },
             community_contributions: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 0,
+              points: 0,
             },
             pull_requests_merged: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 0,
+              points: 0,
             },
             social_media_contributions: {
-              count: expect.any(Number),
-              points: expect.any(Number),
+              count: 0,
+              points: 0,
+            },
+            node_uptime: {
+              count: 0,
+              points: 0,
             },
           },
         });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -175,6 +175,7 @@ export class UsersController {
         pull_requests_merged: eventMetrics[EventType.PULL_REQUEST_MERGED],
         social_media_contributions:
           eventMetrics[EventType.SOCIAL_MEDIA_PROMOTION],
+        node_uptime: eventMetrics[EventType.NODE_UPTIME],
       },
     };
   }


### PR DESCRIPTION
## Summary

They just weren't being sent back, but now they are. I also fixed tests to actually test for the 0 points because it should be 0.

## Testing Plan
Ran tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
