### PR TITLE
Change Leaderboard query to take event types

### DIFF
--- a/src/common/utils/enums.ts
+++ b/src/common/utils/enums.ts
@@ -17,5 +17,5 @@ export function isInStrEnum<T extends StrEnum<T>>(
   value: unknown,
   enumType: T,
 ): boolean {
-  return getEnumStrValues(enumType).filter((enumValue) => enumValue === value);
+  return !!getEnumStrValues(enumType).find((enumValue) => enumValue === value);
 }

--- a/src/common/utils/enums.ts
+++ b/src/common/utils/enums.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export type StrEnumValue<T> = T[keyof T];
+export type StrEnum<T> = Record<keyof T, string>;
+
+function getEnumStrValues<T extends StrEnum<T>>(
+  enumType: T,
+): Array<StrEnumValue<T>> {
+  return Object.values(enumType)
+    .filter((v) => typeof v === 'string')
+    .map((v) => v as StrEnumValue<T>);
+}
+
+export function isInStrEnum<T extends StrEnum<T>>(
+  value: unknown,
+  enumType: T,
+): boolean {
+  for (const enumValue of getEnumStrValues(enumType)) {
+    if (enumValue === value) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/common/utils/enums.ts
+++ b/src/common/utils/enums.ts
@@ -17,10 +17,5 @@ export function isInStrEnum<T extends StrEnum<T>>(
   value: unknown,
   enumType: T,
 ): boolean {
-  for (const enumValue of getEnumStrValues(enumType)) {
-    if (enumValue === value) {
-      return true;
-    }
-  }
-  return false;
+  return getEnumStrValues(enumType).filter((enumValue) => enumValue === value);
 }

--- a/src/users/dto/users-query.dto.ts
+++ b/src/users/dto/users-query.dto.ts
@@ -2,14 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, TransformFnParams } from 'class-transformer';
 import {
   Equals,
-  IsEnum,
   IsISO31661Alpha3,
   IsOptional,
   IsString,
+  Validate,
 } from 'class-validator';
 import { PaginationArgsDto } from '../../common/dto/pagination-args.dto';
+import { IsEventTypesArray } from './validators';
 import { EventType } from '.prisma/client';
 
 export class UsersQueryDto extends PaginationArgsDto {
@@ -32,8 +34,11 @@ export class UsersQueryDto extends PaginationArgsDto {
   @IsString()
   readonly search?: string;
 
-  @ApiPropertyOptional({ description: 'Event type filter', enum: EventType })
+  @ApiPropertyOptional({ description: 'Event types filter', enum: EventType })
   @IsOptional()
-  @IsEnum(EventType)
-  readonly event_type?: EventType;
+  @Transform(({ value }: TransformFnParams): unknown[] => {
+    return Array.isArray(value) ? (value as unknown[]) : [value];
+  })
+  @Validate(IsEventTypesArray)
+  readonly event_type?: EventType[];
 }

--- a/src/users/dto/validators.ts
+++ b/src/users/dto/validators.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { EventType } from '@prisma/client';
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { isInStrEnum } from '../../common/utils/enums';
+
+@ValidatorConstraint()
+export class IsEventTypesArray implements ValidatorConstraintInterface {
+  validate(data: unknown): boolean {
+    return Array.isArray(data) && data.every((v) => isInStrEnum(v, EventType));
+  }
+
+  defaultMessage(): string {
+    return 'Value was not an array of EventType enum values';
+  }
+}

--- a/src/users/interfaces/list-by-rank-options.ts
+++ b/src/users/interfaces/list-by-rank-options.ts
@@ -7,5 +7,5 @@ import { EventType } from '.prisma/client';
 export interface ListUsersWithRankOptions extends PaginationOptions {
   search?: string;
   countryCode?: string;
-  eventType?: EventType;
+  eventTypes?: EventType[];
 }

--- a/src/users/interfaces/list-users-options.ts
+++ b/src/users/interfaces/list-users-options.ts
@@ -8,5 +8,5 @@ export interface ListUsersOptions extends PaginationOptions {
   orderBy?: 'rank';
   search?: string;
   countryCode?: string;
-  eventType?: EventType;
+  eventTypes?: EventType[];
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -239,7 +239,7 @@ export class UsersController {
       limit,
       order_by: orderBy,
       country_code: countryCode,
-      event_type: eventType,
+      event_type: eventTypes,
       search,
     }: UsersQueryDto,
   ): Promise<PaginatedList<SerializedUser | SerializedUserWithRank>> {
@@ -251,8 +251,9 @@ export class UsersController {
           limit: Math.min(MAX_LIMIT, limit || DEFAULT_LIMIT),
           search,
           countryCode,
-          eventType,
+          eventTypes,
         });
+
       return {
         object: 'list',
         data,
@@ -262,14 +263,16 @@ export class UsersController {
         },
       };
     }
+
     const { data, hasNext, hasPrevious } = await this.usersService.list({
       after,
       before,
       limit,
       search,
       countryCode,
-      eventType,
+      eventTypes,
     });
+
     return {
       object: 'list',
       data: data.map((user) => serializedUserFromRecord(user)),

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -221,7 +221,9 @@ describe('UsersService', () => {
         limit,
         search: '7',
       });
+
       expect(records.length).toBeLessThanOrEqual(limit);
+
       for (const record of records) {
         expect(record).toMatchObject({
           id: expect.any(Number),
@@ -290,7 +292,7 @@ describe('UsersService', () => {
       });
 
       const { data: records } = await usersService.listWithRank({
-        eventType: 'BUG_CAUGHT',
+        eventTypes: ['BUG_CAUGHT'],
         search: graffiti,
         limit: 3,
       });
@@ -301,6 +303,10 @@ describe('UsersService', () => {
       expect(records[0].graffiti).toEqual(userB.graffiti);
       expect(records[1].graffiti).toEqual(userA.graffiti);
       expect(records[2].graffiti).toEqual(userC.graffiti);
+      expect(records[0].total_points).toBe(1);
+      expect(records[1].total_points).toBe(1);
+      expect(records[2].total_points).toBe(0);
+
       expect(records[0].rank).toBeLessThan(records[1].rank);
       expect(records[1].rank).toBeLessThan(records[2].rank);
     });
@@ -308,8 +314,9 @@ describe('UsersService', () => {
     describe(`when 'event_type' is provided`, () => {
       it('returns a chunk of users by event when specified', async () => {
         const { data: records } = await usersService.listWithRank({
-          eventType: 'BUG_CAUGHT',
+          eventTypes: ['BUG_CAUGHT'],
         });
+
         records.map((record) =>
           expect(record).toMatchObject({
             id: expect.any(Number),

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -18,7 +18,7 @@ import { ListUsersWithRankOptions } from './interfaces/list-by-rank-options';
 import { ListUsersOptions } from './interfaces/list-users-options';
 import { SerializedUserWithRank } from './interfaces/serialized-user-with-rank';
 import { UpdateUserOptions } from './interfaces/update-user-options';
-import { EventType, Prisma, User } from '.prisma/client';
+import { Prisma, User } from '.prisma/client';
 
 @Injectable()
 export class UsersService {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -220,7 +220,9 @@ export class UsersService {
 
     const searchFilter = `%${search ?? ''}%`;
 
-    const eventsFilter = eventTypes
+    const useEventFiltering = !!eventTypes?.length;
+
+    const eventsFilter = useEventFiltering
       ? eventTypes.map((e) => `'${String(e)}'::event_type`).join(',')
       : 'NULL';
 
@@ -313,7 +315,7 @@ export class UsersService {
       rankCursor,
       limit,
       countryCode,
-      !!eventTypes?.length,
+      useEventFiltering,
     );
 
     // If fetching a previous page, the ranks are sorted in opposite order.
@@ -339,7 +341,7 @@ export class UsersService {
       data[data.length - 1].rank,
       1,
       countryCode,
-      !!eventTypes?.length,
+      useEventFiltering,
     );
 
     const previousRecords = await this.prisma.$queryRawUnsafe<
@@ -351,7 +353,7 @@ export class UsersService {
       data[0].rank,
       1,
       countryCode,
-      !!eventTypes?.length,
+      useEventFiltering,
     );
 
     return {


### PR DESCRIPTION
## Summary

The old leaderboard only took 1 single event type, now it takes multiple
event types which it then filters the leaderboard on. I'm not sure if this is
the only place this needs to be changed, but the user metrics was also
changed to reflect this.

## Testing Plan

TODO: Run and adjust leaderboard test.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
