### PR TITLE
Merge getListWithRankMetadata into listWithRank

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -377,12 +377,12 @@ export class UsersService {
         (
           SELECT
             id,
-            RANK () OVER ( 
-              ORDER BY 
+            RANK () OVER (
+              ORDER BY
                 total_points DESC,
                 COALESCE(latest_event_occurred_at, NOW()) ASC,
                 created_at ASC
-            ) AS rank 
+            ) AS rank
           FROM
             users
           LEFT JOIN

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -310,53 +310,39 @@ export class UsersService {
       countryCode,
       eventType,
     );
+
     // If fetching a previous page, the ranks are sorted in opposite order.
     // Reverse the data so the returned chunk is in ascending order.
     if (before !== undefined) {
       data.reverse();
     }
 
-    return {
-      data,
-      ...(await this.getListWithRankMetadata(
-        data,
-        query,
-        searchFilter,
-        countryCode,
-        eventType,
-      )),
-    };
-  }
-
-  private async getListWithRankMetadata(
-    data: SerializedUserWithRank[],
-    query: string,
-    searchFilter: string,
-    countryCode?: string,
-    eventType?: string,
-  ): Promise<{ hasNext: boolean; hasPrevious: boolean }> {
-    const { length } = data;
-    if (length === 0) {
+    if (data.length === 0) {
       return {
+        data: [],
         hasNext: false,
         hasPrevious: false,
       };
     }
+
     const nextRecords = await this.prisma.$queryRawUnsafe<
       SerializedUserWithRank[]
     >(
       query,
       searchFilter,
       true,
-      data[length - 1].rank,
+      data[data.length - 1].rank,
       1,
       countryCode,
       eventType,
     );
+
     const previousRecords = await this.prisma.$queryRawUnsafe<
       SerializedUserWithRank[]
     >(query, searchFilter, false, data[0].rank, 1, countryCode, eventType);
+
     return {
+      data: data,
       hasNext: nextRecords.length > 0,
       hasPrevious: previousRecords.length > 0,
     };


### PR DESCRIPTION
## Summary

listWithRank is the only method that uses this, and the metadata isn't
some extra thing, it's the basic pagination data. Also I think these
queries can be removed entirely in Postgres using count() queries or
just basic assumption about leaderboard containing all users.

## Testing Plan

Run same tests, no code change.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
