### PR TITLE
Return NodeUptimes in user metrics

### DIFF
--- a/src/users/interfaces/serialized-user-metrics.ts
+++ b/src/users/interfaces/serialized-user-metrics.ts
@@ -20,4 +20,8 @@ export interface SerializedUserMetrics {
     main: SerializedEventMetrics;
     code: SerializedEventMetrics;
   };
+  node_uptime?: {
+    total_hours: number;
+    last_checked_in: string | null;
+  };
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -301,6 +301,10 @@ describe('UsersController', () => {
           user_id: user.id,
           granularity: MetricsGranularity.LIFETIME,
           points: expect.any(Number),
+          node_uptime: {
+            total_hours: 0,
+            last_checked_in: null,
+          },
           pools: {
             main: {
               rank: expect.any(Number),

--- a/src/users/users.rest.module.ts
+++ b/src/users/users.rest.module.ts
@@ -4,6 +4,7 @@
 import { Module } from '@nestjs/common';
 import { ApiConfigModule } from '../api-config/api-config.module';
 import { EventsModule } from '../events/events.module';
+import { NodeUptimesModule } from '../node-uptimes/node-uptimes.module';
 import { MeController } from './me.controller';
 import { UsersController } from './users.controller';
 import { UsersModule } from './users.module';
@@ -11,6 +12,12 @@ import { UsersUpdaterModule } from './users-updater.module';
 
 @Module({
   controllers: [MeController, UsersController],
-  imports: [ApiConfigModule, EventsModule, UsersModule, UsersUpdaterModule],
+  imports: [
+    ApiConfigModule,
+    EventsModule,
+    UsersModule,
+    UsersUpdaterModule,
+    NodeUptimesModule,
+  ],
 })
 export class UsersRestModule {}


### PR DESCRIPTION
## Summary

In user lifetime metrics, send back their NodeUptimes data now.

## Testing Plan

Adjusted tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
