### PR TITLE
Fix crediting user on first telemetry

### DIFF
--- a/src/node-uptimes/node-uptimes.service.spec.ts
+++ b/src/node-uptimes/node-uptimes.service.spec.ts
@@ -45,9 +45,9 @@ describe('NodeUptimesService', () => {
       expect(uptime).toMatchObject({
         user_id: user.id,
         last_checked_in: expect.any(Date),
-        total_hours: 0,
+        total_hours: 1,
       });
-      assert(uptime);
+
       expect(uptime.last_checked_in.getTime()).toBeGreaterThanOrEqual(
         now.getTime(),
       );

--- a/src/node-uptimes/node-uptimes.service.ts
+++ b/src/node-uptimes/node-uptimes.service.ts
@@ -26,6 +26,7 @@ export class NodeUptimesService {
         `SELECT pg_advisory_xact_lock(HASHTEXT($1));`,
         user.id,
       );
+
       const nodeUptime = await this.getWithClient(user, prisma);
       if (nodeUptime && nodeUptime.last_checked_in >= lastCheckinCutoff) {
         return null;
@@ -44,7 +45,7 @@ export class NodeUptimesService {
         create: {
           user_id: user.id,
           last_checked_in: now.toISOString(),
-          total_hours: 0,
+          total_hours: 1,
         },
       });
     });

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -68,8 +68,10 @@ export class TelemetryController {
 
     if (!this.config.isProduction() && graffiti) {
       const user = await this.usersService.findByGraffiti(graffiti);
+
       if (user) {
         const uptime = await this.nodeUptimes.upsert(user);
+
         if (uptime && uptime.total_hours >= NODE_UPTIME_CREDIT_HOURS) {
           await this.graphileWorkerService.addJob(
             GraphileWorkerPattern.CREATE_NODE_UPTIME_EVENT,


### PR DESCRIPTION
## Summary

Users weren't credited on their first node-uptime telemetry because it
was created with 0 in the hours, so they would only be credited after 13
hours.

## Testing Plan
Fixed test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
