### PR TITLE
Add SEND_TRANSACTION to user metrics API

### DIFF
--- a/src/users/interfaces/serialized-user-metrics.ts
+++ b/src/users/interfaces/serialized-user-metrics.ts
@@ -15,6 +15,7 @@ export interface SerializedUserMetrics {
     pull_requests_merged: SerializedEventMetrics;
     social_media_contributions: SerializedEventMetrics;
     node_uptime: SerializedEventMetrics;
+    send_transaction: SerializedEventMetrics;
   };
   pools?: {
     main: SerializedEventMetrics;

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -342,6 +342,10 @@ describe('UsersController', () => {
               count: 0,
               points: 0,
             },
+            send_transaction: {
+              count: 0,
+              points: 0,
+            },
           },
         });
       });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -186,6 +186,7 @@ export class UsersController {
         social_media_contributions:
           eventMetrics[EventType.SOCIAL_MEDIA_PROMOTION],
         node_uptime: eventMetrics[EventType.NODE_UPTIME],
+        send_transaction: eventMetrics[EventType.SEND_TRANSACTION],
       },
     };
   }


### PR DESCRIPTION
## Summary
Exposing this now

## Testing Plan

Run tests and hit the API manually

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
