### PR TITLE
Move event scheduling into uptime service

### DIFF
--- a/src/node-uptimes/node-uptimes.jobs.controller.ts
+++ b/src/node-uptimes/node-uptimes.jobs.controller.ts
@@ -27,6 +27,7 @@ export class NodeUptimesJobsController {
     userId,
   }: CreateNodeUptimeEventOptions): Promise<GraphileWorkerHandlerResponse> {
     const user = await this.usersService.find(userId);
+
     if (!user) {
       this.loggerService.error(`No user found for '${userId}'`, '');
       return { requeue: false };
@@ -52,6 +53,7 @@ export class NodeUptimesJobsController {
         throw new Error(`Error updating node uptime table`);
       }
     });
+
     return { requeue: false };
   }
 }

--- a/src/node-uptimes/node-uptimes.module.ts
+++ b/src/node-uptimes/node-uptimes.module.ts
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
+import { GraphileWorkerModule } from '../graphile-worker/graphile-worker.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { NodeUptimesService } from './node-uptimes.service';
 
 @Module({
   exports: [NodeUptimesService],
-  imports: [PrismaModule],
+  imports: [PrismaModule, GraphileWorkerModule],
   providers: [NodeUptimesService],
 })
 export class NodeUptimesModule {}

--- a/src/node-uptimes/node-uptimes.service.spec.ts
+++ b/src/node-uptimes/node-uptimes.service.spec.ts
@@ -40,14 +40,14 @@ describe('NodeUptimesService', () => {
       const now = new Date();
       const user = await createUser();
 
-      const uptime = await nodeUptimesService.upsert(user);
+      const { uptime } = await nodeUptimesService.addUptime(user);
 
       expect(uptime).toMatchObject({
         user_id: user.id,
         last_checked_in: expect.any(Date),
         total_hours: 0,
       });
-      assert(uptime);
+
       expect(uptime.last_checked_in.getTime()).toBeGreaterThanOrEqual(
         now.getTime(),
       );
@@ -66,14 +66,14 @@ describe('NodeUptimesService', () => {
         },
       });
 
-      const uptime = await nodeUptimesService.upsert(user);
+      const { uptime } = await nodeUptimesService.addUptime(user);
 
       expect(uptime).toMatchObject({
         user_id: user.id,
         last_checked_in: expect.any(Date),
         total_hours: 1,
       });
-      assert(uptime);
+
       expect(uptime.last_checked_in.getTime()).toBeGreaterThanOrEqual(
         now.getTime(),
       );
@@ -82,6 +82,7 @@ describe('NodeUptimesService', () => {
     it('does not update node uptime if enough time has not passed', async () => {
       const now = new Date();
       const user = await createUser();
+
       await prisma.nodeUptime.create({
         data: {
           user_id: user.id,
@@ -90,12 +91,11 @@ describe('NodeUptimesService', () => {
         },
       });
 
-      const uptime = await nodeUptimesService.upsert(user);
-      const dbUptime = await nodeUptimesService.get(user);
+      const { uptime, added } = await nodeUptimesService.addUptime(user);
 
-      expect(uptime).toBeNull();
+      expect(added).toBe(false);
 
-      expect(dbUptime).toMatchObject({
+      expect(uptime).toMatchObject({
         user_id: user.id,
         last_checked_in: now,
         total_hours: 0,

--- a/src/telemetry/telemetry.controller.spec.ts
+++ b/src/telemetry/telemetry.controller.spec.ts
@@ -178,7 +178,7 @@ describe('TelemetryController', () => {
 
       it('updates the node uptime', async () => {
         const nodeUptimeUpsert = jest
-          .spyOn(nodeUptimesService, 'upsert')
+          .spyOn(nodeUptimesService, 'addUptime')
           .mockImplementationOnce(jest.fn());
 
         const graffiti = uuid();
@@ -189,6 +189,7 @@ describe('TelemetryController', () => {
             country_code: faker.address.countryCode(),
           },
         });
+
         await request(app.getHttpServer())
           .post('/telemetry')
           .send({ points: [], graffiti })
@@ -206,14 +207,14 @@ describe('TelemetryController', () => {
         const oldCheckin = new Date();
         oldCheckin.setHours(oldCheckin.getHours() - 2);
 
-        const graffiti = uuid();
         const user = await prisma.user.create({
           data: {
             email: faker.internet.email(),
-            graffiti,
+            graffiti: uuid(),
             country_code: faker.address.countryCode(),
           },
         });
+
         await prisma.nodeUptime.create({
           data: {
             user_id: user.id,
@@ -224,7 +225,7 @@ describe('TelemetryController', () => {
 
         await request(app.getHttpServer())
           .post('/telemetry')
-          .send({ points: [], graffiti })
+          .send({ points: [], graffiti: user.graffiti })
           .expect(HttpStatus.CREATED);
 
         expect(workerAddJob).toHaveBeenCalledTimes(1);

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -13,8 +13,6 @@ import { ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Request } from 'express';
 import { gte, valid } from 'semver';
 import { ApiConfigService } from '../api-config/api-config.service';
-import { NODE_UPTIME_CREDIT_HOURS } from '../common/constants';
-import { GraphileWorkerPattern } from '../graphile-worker/enums/graphile-worker-pattern';
 import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
 import { InfluxDbService } from '../influxdb/influxdb.service';
 import { NodeUptimesService } from '../node-uptimes/node-uptimes.service';
@@ -68,14 +66,9 @@ export class TelemetryController {
 
     if (!this.config.isProduction() && graffiti) {
       const user = await this.usersService.findByGraffiti(graffiti);
+
       if (user) {
-        const uptime = await this.nodeUptimes.upsert(user);
-        if (uptime && uptime.total_hours >= NODE_UPTIME_CREDIT_HOURS) {
-          await this.graphileWorkerService.addJob(
-            GraphileWorkerPattern.CREATE_NODE_UPTIME_EVENT,
-            { userId: user.id },
-          );
-        }
+        await this.nodeUptimes.addUptime(user);
       }
     }
   }


### PR DESCRIPTION
## Summary

I did this because I'm starting to see an issue with our code base in
that it's not clear who owns what responsibility, and I see a lot of
code fragmentation. I'm not sure what to do about it, though I just feel
like a "NodeUptime" service should be in charge of also creating or
scheduling the creation of the event it's related to.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
