### PR TITLE
Aggregate SEND_TRANSACTION events on UserPoints

### DIFF
--- a/prisma/migrations/20220426235432_add_send_transaction_to_user_points/migration.sql
+++ b/prisma/migrations/20220426235432_add_send_transaction_to_user_points/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "user_points" ADD COLUMN     "send_transaction_last_occurred_at" TIMESTAMP(6),
+ADD COLUMN     "send_transaction_points" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE INDEX "index_user_points_on_node_uptime" ON "user_points"("node_uptime_points");
+
+-- CreateIndex
+CREATE INDEX "index_user_points_on_send_transaction" ON "user_points"("send_transaction_points");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,6 +188,8 @@ model UserPoints {
   social_media_promotion_last_occurred_at        DateTime? @db.Timestamp(6)
   node_uptime_points                             Int       @default(0)
   node_uptime_last_occurred_at                   DateTime? @db.Timestamp(6)
+  send_transaction_points                        Int       @default(0)
+  send_transaction_last_occurred_at              DateTime? @db.Timestamp(6)
   user                                           User      @relation(fields: [user_id], references: [id])
 
   @@index([user_id], map: "index_user_points_on_user_id")
@@ -196,5 +198,7 @@ model UserPoints {
   @@index([community_contribution_points], map: "index_user_points_on_community_contribution")
   @@index([pull_request_merged_points], map: "index_user_points_on_pull_request_merged")
   @@index([social_media_promotion_points], map: "index_user_points_on_social_media_promotion")
+  @@index([node_uptime_points], map: "index_user_points_on_node_uptime")
+  @@index([send_transaction_points], map: "index_user_points_on_send_transaction")
   @@map("user_points")
 }

--- a/src/user-points/user-points.service.ts
+++ b/src/user-points/user-points.service.ts
@@ -28,6 +28,8 @@ export class UserPointsService {
       const communityContribution = points[EventType.COMMUNITY_CONTRIBUTION];
       const pullRequestMerged = points[EventType.PULL_REQUEST_MERGED];
       const socialMediaPromotion = points[EventType.SOCIAL_MEDIA_PROMOTION];
+      const nodeUptime = points[EventType.NODE_UPTIME];
+      const transactionSent = points[EventType.SEND_TRANSACTION];
 
       if (blockMined) {
         options.block_mined_last_occurred_at = blockMined.latestOccurredAt;
@@ -51,6 +53,15 @@ export class UserPointsService {
         options.social_media_promotion_last_occurred_at =
           socialMediaPromotion.latestOccurredAt;
         options.social_media_promotion_points = socialMediaPromotion.points;
+      }
+      if (nodeUptime) {
+        options.node_uptime_last_occurred_at = nodeUptime.latestOccurredAt;
+        options.node_uptime_points = nodeUptime.points;
+      }
+      if (transactionSent) {
+        options.send_transaction_last_occurred_at =
+          transactionSent.latestOccurredAt;
+        options.send_transaction_points = transactionSent.points;
       }
     }
 


### PR DESCRIPTION
## Summary
The UserPoints object will be used to cache aggregated events data for faster retrieval from the API. For example, total points for a user and total points for a user in a given category. This PR adds support for aggregating the new `SEND_TRANSACTION` event for Phase 2

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
