### PR TITLE
test(api): Add minimum to mocked size in blocks controller

### DIFF
--- a/src/blocks/blocks.controller.spec.ts
+++ b/src/blocks/blocks.controller.spec.ts
@@ -96,7 +96,7 @@ describe('BlocksController', () => {
             transactions_count: 0,
             graffiti: uuid(),
             previous_block_hash: uuid(),
-            size: faker.datatype.number(),
+            size: faker.datatype.number({ min: 1 }),
             transactions: [
               {
                 hash: uuid(),


### PR DESCRIPTION
## Summary

This test sometimes updates snapshots and throws a different validation error since the API validates for a positive size.

## Testing Plan

Ran unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
