### PR TITLE
Update user points on event deletion

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -949,6 +949,7 @@ describe('EventsService', () => {
     it('sets `deleted_at` for the record', async () => {
       const { event } = await setupBlockMinedWithEvent();
       const record = await eventsService.delete(event);
+
       expect(record).toMatchObject({
         ...event,
         deleted_at: expect.any(Date),
@@ -961,6 +962,14 @@ describe('EventsService', () => {
       const { event, user } = await setupBlockMinedWithEvent();
       await eventsService.delete(event);
       const updatedUser = await usersService.findOrThrow(event.user_id);
+      expect(updatedUser.total_points).toBe(user.total_points - event.points);
+    });
+
+    it('subtracts points from user_points total points', async () => {
+      const { event, user } = await setupBlockMinedWithEvent();
+      await eventsService.delete(event);
+
+      const updatedUser = await userPointsService.findOrThrow(event.user_id);
       expect(updatedUser.total_points).toBe(user.total_points - event.points);
     });
   });

--- a/src/user-points/user-points.service.spec.ts
+++ b/src/user-points/user-points.service.spec.ts
@@ -26,6 +26,23 @@ describe('UserPointsService', () => {
     await app.close();
   });
 
+  it('should find UserPoints', async () => {
+    await expect(userPointsService.findOrThrow(0)).rejects.toThrow('Not Found');
+
+    const user = await usersService.create({
+      email: faker.internet.email(),
+      graffiti: uuid(),
+      country_code: faker.address.countryCode('alpha-3'),
+    });
+
+    await userPointsService.upsert({
+      userId: user.id,
+    });
+
+    const points = await userPointsService.findOrThrow(user.id);
+    expect(points.user_id).toBe(user.id);
+  });
+
   describe('upsert', () => {
     it('updates user points and timestamps with the payload', async () => {
       const user = await usersService.create({
@@ -33,6 +50,7 @@ describe('UserPointsService', () => {
         graffiti: uuid(),
         country_code: faker.address.countryCode('alpha-3'),
       });
+
       const points = {
         [EventType.BLOCK_MINED]: {
           points: 100,


### PR DESCRIPTION
## Summary

When events are deleted, the UserPoints aggregate model is not
deleted. This causes the aggregate table to now be updated when an event
is deleted.

## Testing Plan
I wrote a test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
