### PR TITLE
Track deposits head

### DIFF
--- a/prisma/migrations/20220504205045_add_deposits_head_table/migration.sql
+++ b/prisma/migrations/20220504205045_add_deposits_head_table/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "deposit_head" (
+    "id" INTEGER NOT NULL,
+    "block_hash" VARCHAR NOT NULL,
+
+    CONSTRAINT "deposit_head_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -222,3 +222,10 @@ model Deposit {
   @@map("deposits")
   @@unique([transaction_hash, graffiti], name: "uq_deposits_on_transaction_hash_and_graffiti", map: "uq_deposits_on_transaction_hash_and_graffiti")
 }
+
+model DepositHead {
+    id                Int                @id
+    block_hash        String             @db.VarChar
+
+    @@map("deposit_head")
+}

--- a/src/events/deposits.controller.spec.ts
+++ b/src/events/deposits.controller.spec.ts
@@ -255,7 +255,7 @@ describe('DepositsController', () => {
   const transaction = (notes: UpsertDepositsNoteDto[], hash?: string) => {
     return {
       hash: hash || uuid(),
-      notes: notes,
+      notes,
     };
   };
 
@@ -267,14 +267,14 @@ describe('DepositsController', () => {
     sequence?: number,
   ): UpsertDepositsOperationDto => {
     return {
-      type: type,
+      type,
       block: {
         hash: hash || uuid(),
         timestamp: new Date(),
         sequence: sequence || 0,
         previousBlockHash: previousBlockHash || uuid(),
       },
-      transactions: transactions,
+      transactions,
     };
   };
 });

--- a/src/events/deposits.controller.ts
+++ b/src/events/deposits.controller.ts
@@ -29,19 +29,15 @@ export class DepositsController {
   @ApiExcludeEndpoint()
   @UseGuards(ApiKeyGuard)
   @Get('head')
-  async head(): Promise<SerializedDeposit> {
-    const deposit = await this.deposits.head();
+  async head(): Promise<{ block_hash: string }> {
+    const depositHead = await this.deposits.head();
 
-    if (!deposit) {
+    if (!depositHead) {
       throw new NotFoundException();
     }
 
     return {
-      id: deposit.id,
-      transaction_hash: deposit.transaction_hash,
-      block_sequence: deposit.block_sequence,
-      block_hash: deposit.block_hash,
-      object: 'deposit',
+      block_hash: depositHead.block_hash,
     };
   }
 

--- a/src/events/dto/upsert-deposit.dto.ts
+++ b/src/events/dto/upsert-deposit.dto.ts
@@ -37,6 +37,9 @@ export class UpsertDepositBlockDto {
   @IsString()
   readonly hash!: string;
 
+  @IsString()
+  readonly previousBlockHash!: string;
+
   @IsDate()
   @Type(() => Date)
   readonly timestamp!: Date;


### PR DESCRIPTION
## Summary
We need to track blocks that do not have deposits in them as well as deposits. This is so the transaction sync process can restart from a block that does not have deposits in it.

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
