### PR TITLE
feat(api): Pull `total_points` from `user_points`

### DIFF
--- a/src/events/events.controller.spec.ts
+++ b/src/events/events.controller.spec.ts
@@ -8,6 +8,7 @@ import { v4 as uuid } from 'uuid';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
+import { UsersService } from '../users/users.service';
 import { EventType } from '.prisma/client';
 
 const API_KEY = 'test';
@@ -16,11 +17,13 @@ describe('EventsController', () => {
   let app: INestApplication;
   let config: ApiConfigService;
   let prisma: PrismaService;
+  let usersService: UsersService;
 
   beforeAll(async () => {
     app = await bootstrapTestApp();
     config = app.get(ApiConfigService);
     prisma = app.get(PrismaService);
+    usersService = app.get(UsersService);
     await app.init();
   });
 
@@ -48,12 +51,10 @@ describe('EventsController', () => {
 
     describe('with a user filter', () => {
       it('returns events only for that user', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         const firstEvent = await prisma.event.create({
           data: {
@@ -142,12 +143,10 @@ describe('EventsController', () => {
 
     describe('with a valid payload', () => {
       it('creates an event record', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         const occurredAt = new Date().toISOString();
         const type = EventType.BUG_CAUGHT;
@@ -173,12 +172,10 @@ describe('EventsController', () => {
       });
 
       it('creates an event with url parameter', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         const occurredAt = new Date().toISOString();
         const type = EventType.PULL_REQUEST_MERGED;
@@ -236,12 +233,10 @@ describe('EventsController', () => {
 
     describe('with a valid event id', () => {
       it('returns a 204', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         const event = await prisma.event.create({
           data: {

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -518,19 +518,8 @@ export class EventsService {
     if (existingEvent) {
       const pointDifference = adjustedPoints - existingEvent.points;
 
-      // Only update total user points and event points if necessary
+      // Only update event points if necessary
       if (pointDifference !== 0) {
-        await client.user.update({
-          data: {
-            total_points: {
-              increment: adjustedPoints - existingEvent.points,
-            },
-          },
-          where: {
-            id: userId,
-          },
-        });
-
         existingEvent = await client.event.update({
           data: {
             points: adjustedPoints,
@@ -541,17 +530,6 @@ export class EventsService {
         });
       }
     } else {
-      await client.user.update({
-        data: {
-          total_points: {
-            increment: adjustedPoints,
-          },
-        },
-        where: {
-          id: userId,
-        },
-      });
-
       existingEvent = await client.event.create({
         data: {
           type,
@@ -661,17 +639,6 @@ export class EventsService {
     event: Event,
     prisma: BasePrismaClient,
   ): Promise<Event> {
-    await prisma.user.update({
-      where: {
-        id: event.user_id,
-      },
-      data: {
-        total_points: {
-          decrement: event.points,
-        },
-      },
-    });
-
     const updated = await prisma.event.update({
       data: {
         deleted_at: new Date().toISOString(),

--- a/src/node-uptimes/node-uptimes.jobs.controller.spec.ts
+++ b/src/node-uptimes/node-uptimes.jobs.controller.spec.ts
@@ -9,6 +9,7 @@ import { v4 as uuid } from 'uuid';
 import { EventsService } from '../events/events.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
+import { UsersService } from '../users/users.service';
 import { NodeUptimesJobsController } from './node-uptimes.jobs.controller';
 import { NodeUptimesService } from './node-uptimes.service';
 
@@ -18,6 +19,7 @@ describe('NodeUptimesJobsController', () => {
   let nodeUptimesJobsController: NodeUptimesJobsController;
   let nodeUptimesService: NodeUptimesService;
   let prisma: PrismaService;
+  let usersService: UsersService;
 
   beforeAll(async () => {
     app = await bootstrapTestApp();
@@ -25,6 +27,7 @@ describe('NodeUptimesJobsController', () => {
     nodeUptimesJobsController = app.get(NodeUptimesJobsController);
     nodeUptimesService = app.get(NodeUptimesService);
     prisma = app.get(PrismaService);
+    usersService = app.get(UsersService);
     await app.init();
   });
 
@@ -33,12 +36,10 @@ describe('NodeUptimesJobsController', () => {
   });
 
   const setupUser = async () => {
-    return prisma.user.create({
-      data: {
-        email: faker.internet.email(),
-        graffiti: uuid(),
-        country_code: faker.address.countryCode(),
-      },
+    return usersService.create({
+      email: faker.internet.email(),
+      graffiti: uuid(),
+      country_code: faker.address.countryCode(),
     });
   };
 

--- a/src/node-uptimes/node-uptimes.service.spec.ts
+++ b/src/node-uptimes/node-uptimes.service.spec.ts
@@ -7,17 +7,20 @@ import faker from 'faker';
 import { v4 as uuid } from 'uuid';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
+import { UsersService } from '../users/users.service';
 import { NodeUptimesService } from './node-uptimes.service';
 
 describe('NodeUptimesService', () => {
   let app: INestApplication;
   let nodeUptimesService: NodeUptimesService;
   let prisma: PrismaService;
+  let usersService: UsersService;
 
   beforeAll(async () => {
     app = await bootstrapTestApp();
     nodeUptimesService = app.get(NodeUptimesService);
     prisma = app.get(PrismaService);
+    usersService = app.get(UsersService);
     await app.init();
   });
 
@@ -26,12 +29,10 @@ describe('NodeUptimesService', () => {
   });
 
   const createUser = async () => {
-    return prisma.user.create({
-      data: {
-        email: faker.internet.email(),
-        graffiti: uuid(),
-        country_code: faker.address.countryCode(),
-      },
+    return usersService.create({
+      email: faker.internet.email(),
+      graffiti: uuid(),
+      country_code: faker.address.countryCode(),
     });
   };
 

--- a/src/telemetry/telemetry.controller.spec.ts
+++ b/src/telemetry/telemetry.controller.spec.ts
@@ -11,6 +11,7 @@ import { InfluxDbService } from '../influxdb/influxdb.service';
 import { NodeUptimesService } from '../node-uptimes/node-uptimes.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
+import { UsersService } from '../users/users.service';
 
 describe('TelemetryController', () => {
   let app: INestApplication;
@@ -18,6 +19,7 @@ describe('TelemetryController', () => {
   let influxDbService: InfluxDbService;
   let nodeUptimesService: NodeUptimesService;
   let prisma: PrismaService;
+  let usersService: UsersService;
 
   beforeAll(async () => {
     app = await bootstrapTestApp();
@@ -25,6 +27,7 @@ describe('TelemetryController', () => {
     influxDbService = app.get(InfluxDbService);
     nodeUptimesService = app.get(NodeUptimesService);
     prisma = app.get(PrismaService);
+    usersService = app.get(UsersService);
     await app.init();
   });
 
@@ -182,12 +185,10 @@ describe('TelemetryController', () => {
           .mockImplementationOnce(jest.fn());
 
         const graffiti = uuid();
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti,
-            country_code: faker.address.countryCode(),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti,
+          country_code: faker.address.countryCode(),
         });
 
         await request(app.getHttpServer())
@@ -207,12 +208,10 @@ describe('TelemetryController', () => {
         const oldCheckin = new Date();
         oldCheckin.setHours(oldCheckin.getHours() - 2);
 
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode(),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode(),
         });
 
         await prisma.nodeUptime.create({

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -10,7 +10,6 @@ import { MetricsGranularity } from '../common/enums/metrics-granularity';
 import { standardizeEmail } from '../common/utils/email';
 import { EventsService } from '../events/events.service';
 import { MagicLinkService } from '../magic-link/magic-link.service';
-import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { UsersService } from './users.service';
 
@@ -19,14 +18,12 @@ const API_KEY = 'test';
 describe('UsersController', () => {
   let app: INestApplication;
   let magicLinkService: MagicLinkService;
-  let prisma: PrismaService;
   let usersService: UsersService;
   let eventsService: EventsService;
 
   beforeAll(async () => {
     app = await bootstrapTestApp();
     magicLinkService = app.get(MagicLinkService);
-    prisma = app.get(PrismaService);
     usersService = app.get(UsersService);
     eventsService = app.get(EventsService);
 
@@ -40,12 +37,10 @@ describe('UsersController', () => {
   describe('GET /users/:id', () => {
     describe('with a valid id', () => {
       it('returns the user', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode(),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode(),
         });
         const { body } = await request(app.getHttpServer())
           .get(`/users/${user.id}`)
@@ -75,12 +70,10 @@ describe('UsersController', () => {
       describe('with a valid graffiti', () => {
         it('returns the user', async () => {
           const graffiti = uuid();
-          const user = await prisma.user.create({
-            data: {
-              email: faker.internet.email(),
-              graffiti,
-              country_code: faker.address.countryCode(),
-            },
+          const user = await usersService.create({
+            email: faker.internet.email(),
+            graffiti,
+            country_code: faker.address.countryCode(),
           });
           const { body } = await request(app.getHttpServer())
             .get(`/users/find`)
@@ -102,12 +95,10 @@ describe('UsersController', () => {
       describe('with a valid graffiti', () => {
         it('returns the user', async () => {
           const graffiti = uuid();
-          const user = await prisma.user.create({
-            data: {
-              email: faker.internet.email(),
-              graffiti,
-              country_code: faker.address.countryCode(),
-            },
+          const user = await usersService.create({
+            email: faker.internet.email(),
+            graffiti,
+            country_code: faker.address.countryCode(),
           });
           const { body } = await request(app.getHttpServer())
             .get(`/users/find`)
@@ -235,12 +226,10 @@ describe('UsersController', () => {
 
     describe('with a TOTAL request and no time range', () => {
       it('returns a 422', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
 
         const { body } = await request(app.getHttpServer())
@@ -271,12 +260,10 @@ describe('UsersController', () => {
 
     describe('with a valid lifetime request', () => {
       it('returns the lifetime metrics for the user', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
 
         await eventsService.create({
@@ -353,12 +340,10 @@ describe('UsersController', () => {
 
     describe('with a valid total request', () => {
       it('returns the total metrics for the user in the given range', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
 
         const start = new Date(Date.now() - 1).toISOString();
@@ -532,12 +517,10 @@ describe('UsersController', () => {
 
     describe('with a duplicate email', () => {
       it('returns a 422', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         await request(app.getHttpServer())
           .post(`/users`)

--- a/src/users/users.rest.module.ts
+++ b/src/users/users.rest.module.ts
@@ -5,6 +5,7 @@ import { Module } from '@nestjs/common';
 import { ApiConfigModule } from '../api-config/api-config.module';
 import { EventsModule } from '../events/events.module';
 import { NodeUptimesModule } from '../node-uptimes/node-uptimes.module';
+import { UserPointsModule } from '../user-points/user-points.module';
 import { MeController } from './me.controller';
 import { UsersController } from './users.controller';
 import { UsersModule } from './users.module';
@@ -15,6 +16,7 @@ import { UsersUpdaterModule } from './users-updater.module';
   imports: [
     ApiConfigModule,
     EventsModule,
+    UserPointsModule,
     UsersModule,
     UsersUpdaterModule,
     NodeUptimesModule,

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -11,6 +11,7 @@ import faker from 'faker';
 import { ulid } from 'ulid';
 import { v4 as uuid } from 'uuid';
 import { standardizeEmail } from '../common/utils/email';
+import { EventsService } from '../events/events.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { UserPointsService } from '../user-points/user-points.service';
@@ -19,15 +20,17 @@ import { EventType } from '.prisma/client';
 
 describe('UsersService', () => {
   let app: INestApplication;
+  let eventsService: EventsService;
   let usersService: UsersService;
   let prisma: PrismaService;
   let userPointsService: UserPointsService;
 
   beforeAll(async () => {
     app = await bootstrapTestApp();
-    usersService = app.get(UsersService);
+    eventsService = app.get(EventsService);
     prisma = app.get(PrismaService);
     userPointsService = app.get(UserPointsService);
+    usersService = app.get(UsersService);
     await app.init();
   });
 
@@ -38,12 +41,10 @@ describe('UsersService', () => {
   describe('find', () => {
     describe('with a valid id', () => {
       it('returns the record', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         const record = await usersService.find(user.id);
         expect(record).not.toBeNull();
@@ -61,12 +62,10 @@ describe('UsersService', () => {
   describe('findOrThrow', () => {
     describe('with a valid id', () => {
       it('returns the record', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         const record = await usersService.findOrThrow(user.id);
         expect(record).not.toBeNull();
@@ -86,12 +85,10 @@ describe('UsersService', () => {
   describe('findByGraffiti', () => {
     describe('with a valid graffiti', () => {
       it('returns the record', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         const record = await usersService.findByGraffiti(user.graffiti);
         expect(record).not.toBeNull();
@@ -109,12 +106,10 @@ describe('UsersService', () => {
   describe('findByGraffitiOrThrow', () => {
     describe('with a valid graffiti', () => {
       it('returns the record', async () => {
-        const user = await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
         const record = await usersService.findByGraffitiOrThrow(user.graffiti);
         expect(record).not.toBeNull();
@@ -143,12 +138,10 @@ describe('UsersService', () => {
     describe('with a valid email', () => {
       it('returns the confirmed record', async () => {
         const email = faker.internet.email();
-        const user = await prisma.user.create({
-          data: {
-            email,
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email,
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
 
         const record = await usersService.findByEmailOrThrow(email);
@@ -167,12 +160,10 @@ describe('UsersService', () => {
     describe('with a valid email', () => {
       it('returns the confirmed record', async () => {
         const email = faker.internet.email();
-        const user = await prisma.user.create({
-          data: {
-            email,
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        const user = await usersService.create({
+          email,
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
 
         const record = await usersService.findByEmail(email);
@@ -219,32 +210,26 @@ describe('UsersService', () => {
       const graffiti = uuid();
       const now = new Date();
 
-      const userA = await prisma.user.create({
-        data: {
-          email: faker.internet.email(),
-          graffiti: graffiti + '-a',
-          country_code: faker.address.countryCode('alpha-3'),
-          total_points: 2,
-        },
+      const userA = await usersService.create({
+        email: faker.internet.email(),
+        graffiti: graffiti + '-a',
+        country_code: faker.address.countryCode('alpha-3'),
       });
+      await userPointsService.upsert({ userId: userA.id, totalPoints: 2 });
 
-      const userB = await prisma.user.create({
-        data: {
-          email: faker.internet.email(),
-          graffiti: graffiti + '-b',
-          country_code: faker.address.countryCode('alpha-3'),
-          total_points: 2,
-        },
+      const userB = await usersService.create({
+        email: faker.internet.email(),
+        graffiti: graffiti + '-b',
+        country_code: faker.address.countryCode('alpha-3'),
       });
+      await userPointsService.upsert({ userId: userB.id, totalPoints: 2 });
 
-      const userC = await prisma.user.create({
-        data: {
-          email: faker.internet.email(),
-          graffiti: graffiti + '-c',
-          country_code: faker.address.countryCode('alpha-3'),
-          total_points: 1,
-        },
+      const userC = await usersService.create({
+        email: faker.internet.email(),
+        graffiti: graffiti + '-c',
+        country_code: faker.address.countryCode('alpha-3'),
       });
+      await userPointsService.upsert({ userId: userC.id, totalPoints: 1 });
 
       await prisma.event.create({
         data: {
@@ -319,12 +304,10 @@ describe('UsersService', () => {
     describe('with a duplicate graffiti', () => {
       it('throws an exception', async () => {
         const graffiti = uuid();
-        await prisma.user.create({
-          data: {
-            email: faker.internet.email(),
-            graffiti,
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        await usersService.create({
+          email: faker.internet.email(),
+          graffiti,
+          country_code: faker.address.countryCode('alpha-3'),
         });
 
         await expect(
@@ -340,12 +323,10 @@ describe('UsersService', () => {
     describe('with a duplicate email', () => {
       it('throws an exception', async () => {
         const email = faker.internet.email();
-        await prisma.user.create({
-          data: {
-            email: standardizeEmail(email),
-            graffiti: uuid(),
-            country_code: faker.address.countryCode('alpha-3'),
-          },
+        await usersService.create({
+          email: standardizeEmail(email),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
         });
 
         await expect(
@@ -411,68 +392,59 @@ describe('UsersService', () => {
 
   describe('getRank', () => {
     it('returns the correct rank', async () => {
-      const aggregate = await prisma.user.aggregate({
+      const firstUser = await usersService.create({
+        email: faker.internet.email(),
+        graffiti: uuid(),
+        country_code: faker.address.countryCode('alpha-3'),
+      });
+      const secondUser = await usersService.create({
+        email: faker.internet.email(),
+        graffiti: uuid(),
+        country_code: faker.address.countryCode('alpha-3'),
+      });
+      const thirdUser = await usersService.create({
+        email: faker.internet.email(),
+        graffiti: uuid(),
+        country_code: faker.address.countryCode('alpha-3'),
+      });
+
+      const now = new Date();
+      await eventsService.create({
+        type: EventType.BUG_CAUGHT,
+        userId: firstUser.id,
+        occurredAt: now,
+        points: 1,
+      });
+      await eventsService.create({
+        type: EventType.BUG_CAUGHT,
+        userId: secondUser.id,
+        occurredAt: new Date(now.valueOf() - 1000),
+        points: 1,
+      });
+      await eventsService.create({
+        type: EventType.BUG_CAUGHT,
+        userId: secondUser.id,
+        occurredAt: new Date(now.valueOf() + 1000),
+        points: 0,
+      });
+
+      const aggregate = await prisma.userPoints.aggregate({
         _max: {
           total_points: true,
         },
       });
-
       const currentMaxPoints = aggregate._max.total_points || 0;
-
-      const firstUser = await prisma.user.create({
-        data: {
-          email: faker.internet.email(),
-          graffiti: uuid(),
-          country_code: faker.address.countryCode('alpha-3'),
-          total_points: currentMaxPoints + 2,
-        },
+      await userPointsService.upsert({
+        userId: firstUser.id,
+        totalPoints: currentMaxPoints + 2,
       });
-
-      const secondUser = await prisma.user.create({
-        data: {
-          email: faker.internet.email(),
-          graffiti: uuid(),
-          country_code: faker.address.countryCode('alpha-3'),
-          total_points: currentMaxPoints + 2,
-        },
+      await userPointsService.upsert({
+        userId: secondUser.id,
+        totalPoints: currentMaxPoints + 2,
       });
-
-      const thirdUser = await prisma.user.create({
-        data: {
-          email: faker.internet.email(),
-          graffiti: uuid(),
-          country_code: faker.address.countryCode('alpha-3'),
-          total_points: currentMaxPoints + 1,
-        },
-      });
-
-      const now = new Date();
-
-      await prisma.event.create({
-        data: {
-          type: EventType.BUG_CAUGHT,
-          user_id: firstUser.id,
-          occurred_at: now,
-          points: 1,
-        },
-      });
-
-      await prisma.event.create({
-        data: {
-          type: EventType.BUG_CAUGHT,
-          user_id: secondUser.id,
-          occurred_at: new Date(now.valueOf() - 1000),
-          points: 1,
-        },
-      });
-
-      await prisma.event.create({
-        data: {
-          type: EventType.BUG_CAUGHT,
-          user_id: secondUser.id,
-          occurred_at: new Date(now.valueOf() + 1000),
-          points: 0,
-        },
+      await userPointsService.upsert({
+        userId: thirdUser.id,
+        totalPoints: currentMaxPoints + 1,
       });
 
       // Because secondUser caught a bug first, we consider secondUser to be

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -70,6 +70,7 @@ export class UsersService {
   }
 
   async findByEmail(email: string): Promise<User | null> {
+    email = standardizeEmail(email);
     return this.prisma.user.findFirst({
       where: {
         email,
@@ -407,15 +408,19 @@ export class UsersService {
       FROM
         (
           SELECT
-            id,
+            users.id,
             RANK () OVER (
               ORDER BY
-                total_points DESC,
+                user_points.total_points DESC,
                 COALESCE(latest_event_occurred_at, NOW()) ASC,
-                created_at ASC
+                users.created_at ASC
             ) AS rank
           FROM
             users
+          JOIN
+            user_points
+          ON
+            user_points.user_id = users.id
           LEFT JOIN
             (
               SELECT

--- a/src/users/utils/user-translator.ts
+++ b/src/users/utils/user-translator.ts
@@ -3,27 +3,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { SerializedUser } from '../interfaces/serialized-user';
 import { SerializedUserWithRank } from '../interfaces/serialized-user-with-rank';
-import { User } from '.prisma/client';
+import { User, UserPoints } from '.prisma/client';
 
-export function serializedUserFromRecord(user: User): SerializedUser {
+export function serializedUserFromRecord(
+  user: User,
+  userPoints: UserPoints,
+): SerializedUser {
   return {
     id: user.id,
     country_code: user.country_code,
     graffiti: user.graffiti,
-    total_points: user.total_points,
+    total_points: userPoints.total_points,
     created_at: user.created_at.toISOString(),
   };
 }
 
 export function serializedUserFromRecordWithRank(
   user: User,
+  userPoints: UserPoints,
   rank: number,
 ): SerializedUserWithRank {
   return {
     id: user.id,
     country_code: user.country_code,
     graffiti: user.graffiti,
-    total_points: user.total_points,
+    total_points: userPoints.total_points,
     created_at: user.created_at.toISOString(),
     rank,
   };


### PR DESCRIPTION
## Summary

We can remove `users.total_points` since we have materialized values in `user_points`. Before removing that column, we should migrate existing reads to use the new table.

## Testing Plan

Updated unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
