### PR TITLE
allow empty deposit blocks

### DIFF
--- a/src/events/dto/upsert-deposit.dto.ts
+++ b/src/events/dto/upsert-deposit.dto.ts
@@ -57,7 +57,6 @@ export class UpsertDepositsOperationDto {
   readonly block!: UpsertDepositBlockDto;
 
   @IsArray()
-  @ArrayMinSize(1)
   @ValidateNested({ each: true })
   @Type(() => DepositTransactionDto)
   readonly transactions!: DepositTransactionDto[];


### PR DESCRIPTION
## Summary
Allow empty blocks to be uploaded for deposits. We need to track empty blocks so the syncer knows where to start syncing from

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
