### PR TITLE
remove api key from deposits head

### DIFF
--- a/src/events/deposits.controller.ts
+++ b/src/events/deposits.controller.ts
@@ -27,7 +27,6 @@ export class DepositsController {
 
   @ApiOperation({ summary: 'Gets the head of the chain' })
   @ApiExcludeEndpoint()
-  @UseGuards(ApiKeyGuard)
   @Get('head')
   async head(): Promise<{ block_hash: string }> {
     const depositHead = await this.deposits.head();


### PR DESCRIPTION
## Summary
The `deposits/head` endpoint does not need to be protected by an API Key

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
