### PR TITLE
Reduce send_transaction points down to 1 points

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -36,5 +36,5 @@ export const POINTS_PER_CATEGORY: Record<EventType, number> = {
   [EventType.PULL_REQUEST_MERGED]: 500,
   [EventType.SOCIAL_MEDIA_PROMOTION]: 100,
   [EventType.NODE_UPTIME]: 10,
-  [EventType.SEND_TRANSACTION]: 10,
+  [EventType.SEND_TRANSACTION]: 1,
 };

--- a/src/events/deposits.controller.spec.ts
+++ b/src/events/deposits.controller.spec.ts
@@ -233,7 +233,7 @@ describe('DepositsController', () => {
         },
       });
 
-      expect(user2Events[0].points).toBe(10);
+      expect(user2Events[0].points).toBe(1);
       expect(user2Events[1].points).toBe(0);
       expect(user2Events[1].deposit_id).toEqual(user2Deposits[1].id);
       expect(user2Deposits[1].amount).toEqual(1 * ORE_TO_IRON);


### PR DESCRIPTION
## Summary

Based on a conversation in slack to adjust the point economy.

## Testing Plan
Run  tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
