### PR TITLE
Use the transaction instance of prisma for deposits upsert

### DIFF
--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -62,7 +62,7 @@ export class DepositsUpsertService {
             amount: amount,
           };
 
-          const deposit = await this.prisma.deposit.upsert({
+          const deposit = await prisma.deposit.upsert({
             create: depositParams,
             update: depositParams,
             where: {
@@ -76,7 +76,7 @@ export class DepositsUpsertService {
           deposits.push(deposit);
 
           if (!deposit.main) {
-            const event = await this.prisma.event.findUnique({
+            const event = await prisma.event.findUnique({
               where: {
                 deposit_id: deposit.id,
               },


### PR DESCRIPTION
## Summary

Since these are inside a transaction block, they should be using the transaction's instance of prisma to ensure the db transaction is happening correctly

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
