### PR TITLE
Don't count block mining points for Phase 1

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -618,18 +618,20 @@ export class EventsService {
   }
 
   async upsertBlockMined(block: Block, user: User): Promise<Event | null> {
-    // https://ironfish.network/blog/2022/03/07/incentivized-testnet-roadmap
-    const endOfPhaseOneSequence = 150000;
-    if (block.sequence > endOfPhaseOneSequence) {
-      return null;
+    // We used this code for counting points for mining blocks for Phase 1
+    // but we are not counting mining points for Phase 2
+    const COUNT_POINTS_FOR_BLOCK_MINING = false;
+
+    if (COUNT_POINTS_FOR_BLOCK_MINING) {
+      return this.create({
+        blockId: block.id,
+        occurredAt: block.timestamp,
+        type: EventType.BLOCK_MINED,
+        userId: user.id,
+        points: POINTS_PER_CATEGORY[EventType.BLOCK_MINED],
+      });
     }
-    return this.create({
-      blockId: block.id,
-      occurredAt: block.timestamp,
-      type: EventType.BLOCK_MINED,
-      userId: user.id,
-      points: POINTS_PER_CATEGORY[EventType.BLOCK_MINED],
-    });
+    return null;
   }
 
   async deleteBlockMined(block: Block): Promise<Event | null> {


### PR DESCRIPTION
## Summary
We don't want to add events in the API for blocks mined in Phase 2. Those points were only for Phase 1

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
