### PR TITLE
fix(api): Properly return main pool ranks

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -137,27 +137,26 @@ export class UsersController {
     let eventMetrics: Record<EventType, SerializedEventMetrics>;
     let points: number;
     let pools: Record<MetricsPool, SerializedEventMetrics> | undefined;
-    let node_uptime: SerializedUserMetrics['node_uptime'];
+    let nodeUptime: SerializedUserMetrics['node_uptime'];
 
     if (query.granularity === MetricsGranularity.LIFETIME) {
       eventMetrics = await this.eventsService.getLifetimeEventMetricsForUser(
         user,
       );
 
-      const [main, code] = await Promise.all([
-        this.eventsService.getLifetimeEventsMetricsForUser(user, [
+      pools = {
+        main: await this.eventsService.getLifetimeEventsMetricsForUser(user, [
           EventType.BUG_CAUGHT,
           EventType.NODE_UPTIME,
+          EventType.SEND_TRANSACTION,
         ]),
-        this.eventsService.getLifetimeEventsMetricsForUser(user, [
+        code: await this.eventsService.getLifetimeEventsMetricsForUser(user, [
           EventType.PULL_REQUEST_MERGED,
         ]),
-      ]);
-
-      pools = { main, code };
+      };
 
       const uptime = await this.nodeUptimeService.get(user);
-      node_uptime = {
+      nodeUptime = {
         total_hours: uptime?.total_hours ?? 0,
         last_checked_in: uptime?.last_checked_in?.toISOString() ?? null,
       };
@@ -184,7 +183,7 @@ export class UsersController {
       granularity: query.granularity,
       points,
       pools,
-      node_uptime,
+      node_uptime: nodeUptime,
       metrics: {
         blocks_mined: eventMetrics[EventType.BLOCK_MINED],
         bugs_caught: eventMetrics[EventType.BUG_CAUGHT],


### PR DESCRIPTION
## Summary

The API is not returning the correct rank for Pool 1 ranks. This code change:
* Adds the `SEND_TRANSACTION` event type
* Fixes some minor formatting for consistency
* Queries explicit columns from `user_ranks`

## Testing Plan

Manual tests and existing unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
