### PR TITLE
Ignore FORK operations when creating deposits and events

### DIFF
--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -27,10 +27,17 @@ export class DepositsUpsertService {
     const deposits = new Array<Deposit>();
 
     for (const operation of operations) {
-      const results = await this.upsert(operation);
+      // We only want to handle deposits that deal with the main chain
+      // (not forks). This will only be connected and disconnected events
+      const shouldUpsertDeposits =
+        operation.type === BlockOperation.CONNECTED ||
+        operation.type === BlockOperation.DISCONNECTED;
 
-      for (const result of results) {
-        deposits.push(result);
+      if (shouldUpsertDeposits) {
+        const results = await this.upsert(operation);
+        for (const result of results) {
+          deposits.push(result);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
When we are syncing deposits to the Iron Bank the API listens to events coming from the syncer. There are 3 types of events

- Connected => when a new block is added to the main chain

- Disconnected => when a block is removed from the main chain (in the process of switching to another heavier chain)

- Fork => when a new block is added to a fork that is not the heaviest chain

We should not care about Fork operations because any transaction made on a fork will not be counted as a deposit. If that fork eventually becomes the heaviest chain then there will be a Connected  event emitted for that block eventually and the transaction will be picked up there.

Descriptions of the event types are in code [here](https://github.com/iron-fish/ironfish/blob/staging/ironfish/src/blockchain/blockchain.ts#L98)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
