### PR TITLE
feat(api): Use point update queues per user id

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -555,7 +555,7 @@ export class EventsService {
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
       { userId, type },
       {
-        queueName: 'update_latest_points',
+        queueName: `update_latest_points_for_${userId}`,
       },
     );
 
@@ -664,11 +664,12 @@ export class EventsService {
       },
     });
 
+    const userId = event.user_id;
     await this.graphileWorkerService.addJob(
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
-      { userId: event.user_id, type: event.type },
+      { userId, type: event.type },
       {
-        queueName: 'update_latest_points',
+        queueName: `update_latest_points_for_${userId}`,
       },
     );
 


### PR DESCRIPTION
## Summary

We don't need to use a single queue for updating points. This can be per User.

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
