### PR TITLE
Improve performance on update_latest_points graphile job

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -556,7 +556,6 @@ export class EventsService {
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
       { userId, type },
       {
-        queueName: 'update_latest_points',
         jobKey,
       },
     );

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable, NotFoundException } from '@nestjs/common';
 import is from '@sindresorhus/is';
+import { Job } from 'graphile-worker';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { BlocksService } from '../blocks/blocks.service';
 import { serializedBlockFromRecord } from '../blocks/utils/block-translator';
@@ -24,7 +25,6 @@ import { EventWithMetadata } from './interfaces/event-with-metadata';
 import { ListEventsOptions } from './interfaces/list-events-options';
 import { SerializedEventMetrics } from './interfaces/serialized-event-metrics';
 import { Block, Event, EventType, Prisma, User } from '.prisma/client';
-import { Job } from 'graphile-worker';
 
 // 2021 December 1 8 PM UTC
 const PHASE_1_START = new Date(Date.UTC(2021, 11, 1, 20, 0, 0));

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -569,7 +569,7 @@ export class EventsService {
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
       { userId, type },
       {
-        jobKey,
+        jobKey: `ulp:${userId}:${type}`,
       },
     );
   }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -551,11 +551,13 @@ export class EventsService {
       });
     }
 
+    const jobKey = 'ulp:' + userId.toString() + ':' + type.toString();
     await this.graphileWorkerService.addJob(
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
       { userId, type },
       {
         queueName: 'update_latest_points',
+        jobKey,
       },
     );
 
@@ -664,11 +666,13 @@ export class EventsService {
       },
     });
 
+    const jobKey =
+      'ulp:' + event.user_id.toString() + ':' + event.type.toString();
     await this.graphileWorkerService.addJob(
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
       { userId: event.user_id, type: event.type },
       {
-        queueName: 'update_latest_points',
+        jobKey,
       },
     );
 

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -564,7 +564,6 @@ export class EventsService {
     userId: number,
     type: EventType,
   ): Promise<Job> {
-    const jobKey = 'ulp:' + userId.toString() + ':' + type.toString();
     return this.graphileWorkerService.addJob(
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
       { userId, type },

--- a/src/graphile-worker/graphile-worker.service.ts
+++ b/src/graphile-worker/graphile-worker.service.ts
@@ -18,13 +18,13 @@ export class GraphileWorkerService {
   async addJob<T = unknown>(
     pattern: GraphileWorkerPattern,
     payload?: T,
-    { queueName, runAt }: GraphileWorkerJobOptions = {},
+    { queueName, runAt, jobKey }: GraphileWorkerJobOptions = {},
   ): Promise<Job> {
     if (!this.workerUtils) {
       await this.initWorkerUtils();
     }
     return this.workerUtils.addJob(pattern.toString(), payload, {
-      jobKey: `job_${uuid()}`,
+      jobKey: jobKey || `job_${uuid()}`,
       queueName,
       runAt,
     });

--- a/src/graphile-worker/interfaces/graphile-worker-job-options.ts
+++ b/src/graphile-worker/interfaces/graphile-worker-job-options.ts
@@ -4,4 +4,5 @@
 export interface GraphileWorkerJobOptions {
   queueName?: string;
   runAt?: Date;
+  jobKey?: string;
 }


### PR DESCRIPTION
## Summary
We have a large number of update_latest_points graphile jobs queued in prod. Many of them are duplicates which we can improve by not adding duplicate jobs into the queue using a [jobKey](https://github.com/graphile/worker#replacing-updating-and-removing-jobs). Also this removes the `queueName` parameter. `queueName` is used when jobs need to be [executed synchronously in a queue](https://github.com/graphile/worker#parsedcronitems). For these jobs we do not require that so maybe removing this will help speed them up as well.

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
