### PR TITLE
Trigger CI on pull reuqest actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: API CI
 
-on: [push]
+on: [push, pull_request]
 
 env:
   API_URL: http://localhost:8003


### PR DESCRIPTION
## Summary
To handle PRs that are submitted via a forked repo we should trigger CI to re-run on the `pull_request` event

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
