### PR TITLE
feat(api): Move node uptimes job out of transaction

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -1213,6 +1213,7 @@ describe('EventsService', () => {
       const user = await setupUser();
       const record = await eventsService.createNodeUptimeEventWithClient(
         user,
+        new Date(),
         prisma,
       );
       expect(record).toMatchObject({

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -869,11 +869,12 @@ export class EventsService {
 
   async createNodeUptimeEventWithClient(
     user: User,
+    occurredAt: Date,
     client: BasePrismaClient,
   ): Promise<Event | null> {
     return this.createWithClient(
       {
-        occurredAt: new Date(),
+        occurredAt,
         type: EventType.NODE_UPTIME,
         userId: user.id,
         points: POINTS_PER_CATEGORY[EventType.NODE_UPTIME],

--- a/src/node-uptimes/interfaces/create-node-uptime-event-options.ts
+++ b/src/node-uptimes/interfaces/create-node-uptime-event-options.ts
@@ -2,5 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export interface CreateNodeUptimeEventOptions {
+  occurredAt: Date;
   userId: number;
 }

--- a/src/node-uptimes/node-uptimes-loader.module.ts
+++ b/src/node-uptimes/node-uptimes-loader.module.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Module } from '@nestjs/common';
+import { EventsModule } from '../events/events.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { NodeUptimesModule } from './node-uptimes.module';
+import { NodeUptimesLoader } from './node-uptimes-loader';
+
+@Module({
+  exports: [NodeUptimesLoader],
+  imports: [EventsModule, NodeUptimesModule, PrismaModule],
+  providers: [NodeUptimesLoader],
+})
+export class NodeUptimesLoaderModule {}

--- a/src/node-uptimes/node-uptimes-loader.spec.ts
+++ b/src/node-uptimes/node-uptimes-loader.spec.ts
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { INestApplication } from '@nestjs/common';
+import faker from 'faker';
+import { v4 as uuid } from 'uuid';
+import { NODE_UPTIME_CREDIT_HOURS } from '../common/constants';
+import { EventsService } from '../events/events.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { bootstrapTestApp } from '../test/test-app';
+import { UsersService } from '../users/users.service';
+import { NodeUptimesService } from './node-uptimes.service';
+import { NodeUptimesLoader } from './node-uptimes-loader';
+
+describe('NodeUptimesLoader', () => {
+  let app: INestApplication;
+  let eventsService: EventsService;
+  let nodeUptimesLoader: NodeUptimesLoader;
+  let nodeUptimesService: NodeUptimesService;
+  let prisma: PrismaService;
+  let usersService: UsersService;
+
+  beforeAll(async () => {
+    app = await bootstrapTestApp();
+    eventsService = app.get(EventsService);
+    nodeUptimesLoader = app.get(NodeUptimesLoader);
+    nodeUptimesService = app.get(NodeUptimesService);
+    prisma = app.get(PrismaService);
+    usersService = app.get(UsersService);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const setupUser = async () => {
+    return usersService.create({
+      email: faker.internet.email(),
+      graffiti: uuid(),
+      country_code: faker.address.countryCode(),
+    });
+  };
+
+  describe('createEvent', () => {
+    describe('with no uptime', () => {
+      it('does nothing', async () => {
+        const createNodeUptimeEventWithClient = jest.spyOn(
+          eventsService,
+          'createNodeUptimeEventWithClient',
+        );
+        const decrementCountedHoursWithClient = jest.spyOn(
+          nodeUptimesService,
+          'decrementCountedHoursWithClient',
+        );
+        const user = await setupUser();
+
+        await nodeUptimesLoader.createEvent(user, new Date());
+        expect(createNodeUptimeEventWithClient).not.toHaveBeenCalled();
+        expect(decrementCountedHoursWithClient).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the uptime does not have enough hours', () => {
+      it('does nothing', async () => {
+        const createNodeUptimeEventWithClient = jest.spyOn(
+          eventsService,
+          'createNodeUptimeEventWithClient',
+        );
+        const decrementCountedHoursWithClient = jest.spyOn(
+          nodeUptimesService,
+          'decrementCountedHoursWithClient',
+        );
+        const user = await setupUser();
+        await prisma.nodeUptime.create({
+          data: {
+            user_id: user.id,
+            total_hours: NODE_UPTIME_CREDIT_HOURS - 1,
+          },
+        });
+
+        await nodeUptimesLoader.createEvent(user, new Date());
+        expect(createNodeUptimeEventWithClient).not.toHaveBeenCalled();
+        expect(decrementCountedHoursWithClient).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the uptime has enough hours', () => {
+      it('creates event and decrements hours', async () => {
+        const createNodeUptimeEventWithClient = jest.spyOn(
+          eventsService,
+          'createNodeUptimeEventWithClient',
+        );
+        const decrementCountedHoursWithClient = jest
+          .spyOn(nodeUptimesService, 'decrementCountedHoursWithClient')
+          .mockImplementationOnce(jest.fn());
+        const user = await setupUser();
+        const uptime = await prisma.nodeUptime.create({
+          data: {
+            user_id: user.id,
+            total_hours: NODE_UPTIME_CREDIT_HOURS,
+          },
+        });
+        const occurredAt = new Date();
+
+        await nodeUptimesLoader.createEvent(user, occurredAt);
+        expect(createNodeUptimeEventWithClient).toHaveBeenCalledTimes(1);
+        expect(createNodeUptimeEventWithClient).toHaveBeenCalledWith(
+          user,
+          occurredAt,
+          expect.anything(),
+        );
+        expect(decrementCountedHoursWithClient).toHaveBeenCalledTimes(1);
+        expect(decrementCountedHoursWithClient).toHaveBeenLastCalledWith(
+          uptime,
+          expect.anything(),
+        );
+      });
+    });
+  });
+});

--- a/src/node-uptimes/node-uptimes-loader.ts
+++ b/src/node-uptimes/node-uptimes-loader.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Injectable } from '@nestjs/common';
+import { NODE_UPTIME_CREDIT_HOURS } from '../common/constants';
+import { EventsService } from '../events/events.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { NodeUptimesService } from './node-uptimes.service';
+import { User } from '.prisma/client';
+
+@Injectable()
+export class NodeUptimesLoader {
+  constructor(
+    private readonly eventsService: EventsService,
+    private readonly nodeUptimesService: NodeUptimesService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async createEvent(user: User, occurredAt: Date): Promise<void> {
+    const uptime = await this.nodeUptimesService.get(user);
+    if (!uptime || uptime.total_hours < NODE_UPTIME_CREDIT_HOURS) {
+      return;
+    }
+
+    await this.prisma.$transaction(async (prisma) => {
+      const event = await this.eventsService.createNodeUptimeEventWithClient(
+        user,
+        occurredAt,
+        prisma,
+      );
+      if (!event) {
+        throw new Error(`Error creating node uptime event`);
+      }
+
+      await this.nodeUptimesService.decrementCountedHoursWithClient(
+        uptime,
+        prisma,
+      );
+    });
+  }
+}

--- a/src/node-uptimes/node-uptimes.jobs.controller.ts
+++ b/src/node-uptimes/node-uptimes.jobs.controller.ts
@@ -3,57 +3,33 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Controller } from '@nestjs/common';
 import { MessagePattern } from '@nestjs/microservices';
-import { EventsService } from '../events/events.service';
 import { GraphileWorkerPattern } from '../graphile-worker/enums/graphile-worker-pattern';
 import { GraphileWorkerHandlerResponse } from '../graphile-worker/interfaces/graphile-worker-handler-response';
 import { LoggerService } from '../logger/logger.service';
-import { PrismaService } from '../prisma/prisma.service';
 import { UsersService } from '../users/users.service';
 import { CreateNodeUptimeEventOptions } from './interfaces/create-node-uptime-event-options';
-import { NodeUptimesService } from './node-uptimes.service';
+import { NodeUptimesLoader } from './node-uptimes-loader';
 
 @Controller()
 export class NodeUptimesJobsController {
   constructor(
-    private readonly eventsService: EventsService,
     private readonly loggerService: LoggerService,
-    private readonly nodeUptimesService: NodeUptimesService,
-    private readonly prisma: PrismaService,
+    private readonly nodeUptimesLoader: NodeUptimesLoader,
     private readonly usersService: UsersService,
   ) {}
 
   @MessagePattern(GraphileWorkerPattern.CREATE_NODE_UPTIME_EVENT)
   async createNodeUptimeEvent({
     userId,
+    occurredAt,
   }: CreateNodeUptimeEventOptions): Promise<GraphileWorkerHandlerResponse> {
     const user = await this.usersService.find(userId);
-
     if (!user) {
       this.loggerService.error(`No user found for '${userId}'`, '');
       return { requeue: false };
     }
 
-    await this.prisma.$transaction(async (prisma) => {
-      const event = await this.eventsService.createNodeUptimeEventWithClient(
-        user,
-        prisma,
-      );
-
-      if (!event) {
-        throw new Error(`Error creating node uptime event`);
-      }
-
-      const nodeUptime =
-        await this.nodeUptimesService.decrementCountedHoursWithClient(
-          user,
-          prisma,
-        );
-
-      if (!nodeUptime) {
-        throw new Error(`Error updating node uptime table`);
-      }
-    });
-
+    await this.nodeUptimesLoader.createEvent(user, occurredAt);
     return { requeue: false };
   }
 }

--- a/src/node-uptimes/node-uptimes.jobs.module.ts
+++ b/src/node-uptimes/node-uptimes.jobs.module.ts
@@ -2,21 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
-import { EventsModule } from '../events/events.module';
 import { LoggerModule } from '../logger/logger.module';
-import { PrismaModule } from '../prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
 import { NodeUptimesJobsController } from './node-uptimes.jobs.controller';
-import { NodeUptimesModule } from './node-uptimes.module';
+import { NodeUptimesLoaderModule } from './node-uptimes-loader.module';
 
 @Module({
   controllers: [NodeUptimesJobsController],
-  imports: [
-    EventsModule,
-    LoggerModule,
-    NodeUptimesModule,
-    PrismaModule,
-    UsersModule,
-  ],
+  imports: [LoggerModule, NodeUptimesLoaderModule, UsersModule],
 })
 export class NodeUptimesJobsModule {}

--- a/src/node-uptimes/node-uptimes.service.spec.ts
+++ b/src/node-uptimes/node-uptimes.service.spec.ts
@@ -41,7 +41,7 @@ describe('NodeUptimesService', () => {
       const now = new Date();
       const user = await createUser();
 
-      const { uptime } = await nodeUptimesService.addUptime(user);
+      const uptime = await nodeUptimesService.addUptime(user);
 
       expect(uptime).toMatchObject({
         user_id: user.id,
@@ -67,7 +67,7 @@ describe('NodeUptimesService', () => {
         },
       });
 
-      const { uptime } = await nodeUptimesService.addUptime(user);
+      const uptime = await nodeUptimesService.addUptime(user);
 
       expect(uptime).toMatchObject({
         user_id: user.id,
@@ -84,7 +84,7 @@ describe('NodeUptimesService', () => {
       const now = new Date();
       const user = await createUser();
 
-      await prisma.nodeUptime.create({
+      const existingUptime = await prisma.nodeUptime.create({
         data: {
           user_id: user.id,
           last_checked_in: now,
@@ -92,15 +92,8 @@ describe('NodeUptimesService', () => {
         },
       });
 
-      const { uptime, added } = await nodeUptimesService.addUptime(user);
-
-      expect(added).toBe(false);
-
-      expect(uptime).toMatchObject({
-        user_id: user.id,
-        last_checked_in: now,
-        total_hours: 0,
-      });
+      const uptime = await nodeUptimesService.addUptime(user);
+      expect(uptime).toEqual(existingUptime);
     });
   });
 
@@ -131,8 +124,7 @@ describe('NodeUptimesService', () => {
   describe('decrementCountedHoursWithClient', () => {
     it('decrements total hours count', async () => {
       const user = await createUser();
-
-      await prisma.nodeUptime.create({
+      const uptime = await prisma.nodeUptime.create({
         data: {
           user_id: user.id,
           total_hours: 12,
@@ -140,7 +132,7 @@ describe('NodeUptimesService', () => {
       });
 
       const result = await nodeUptimesService.decrementCountedHoursWithClient(
-        user,
+        uptime,
         prisma,
       );
 

--- a/src/telemetry/telemetry.controller.spec.ts
+++ b/src/telemetry/telemetry.controller.spec.ts
@@ -238,7 +238,8 @@ describe('TelemetryController', () => {
           expect(workerAddJob).toHaveBeenCalledTimes(1);
           expect(workerAddJob).toHaveBeenCalledWith(
             GraphileWorkerPattern.CREATE_NODE_UPTIME_EVENT,
-            { userId: user.id },
+            { userId: user.id, occurredAt: expect.any(Date) },
+            expect.anything(),
           );
         });
       });


### PR DESCRIPTION
## Summary

* Enqueue `NODE_UPTIME` graphile job out of Prisma transaction
* Create `NodeUptimesLoader` to remove coupling between ORM and worker controller
* Add credit hour check to graphile job (was only in transaction from service before)
* Add `occurredAt` to payloads to account for worker delays
* Remove unused `added` return value

## Testing Plan

Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
