### PR TITLE
fix(api): Add `NODE_UPTIME` and `SEND_TRANSACTION` aggregates in refresh

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -284,10 +284,16 @@ describe('EventsService', () => {
         userId: user.id,
         points: 300,
       });
+      const eventE = await eventsService.create({
+        type: EventType.NODE_UPTIME,
+        userId: user.id,
+        points: 300,
+      });
       assert.ok(eventA);
       assert.ok(eventB);
       assert.ok(eventC);
       assert.ok(eventD);
+      assert.ok(eventE);
 
       const options = await eventsService.getUpsertPointsOptions(user);
       expect(options).toMatchObject({
@@ -305,6 +311,10 @@ describe('EventsService', () => {
           COMMUNITY_CONTRIBUTION: {
             points: 0,
             latestOccurredAt: null,
+          },
+          NODE_UPTIME: {
+            points: eventE.points,
+            latestOccurredAt: eventE.occurred_at,
           },
           PULL_REQUEST_MERGED: {
             points: eventA.points + eventB.points,

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -298,7 +298,11 @@ describe('EventsService', () => {
       const options = await eventsService.getUpsertPointsOptions(user);
       expect(options).toMatchObject({
         totalPoints:
-          eventA.points + eventB.points + eventC.points + eventD.points,
+          eventA.points +
+          eventB.points +
+          eventC.points +
+          eventD.points +
+          eventE.points,
         points: {
           BLOCK_MINED: {
             points: 0,

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -199,7 +199,9 @@ export class EventsService {
       bugCaughtAggregate.points +
       communityContributionAggregate.points +
       pullRequestAggregate.points +
-      socialMediaAggregate.points;
+      socialMediaAggregate.points +
+      nodeUptimeAggregate.points +
+      sendTransactionAggregate.points;
 
     return {
       userId: user.id,


### PR DESCRIPTION
## Summary

Total point aggregates on `user_points` are not taking into account `NODE_UPTIME` and `SEND_TRANSACTION`.

## Testing Plan

Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
