### PR TITLE
test(api): Add missing check for `SEND_TRANSACTION` in `getUpsertOptions`

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -289,11 +289,17 @@ describe('EventsService', () => {
         userId: user.id,
         points: 300,
       });
+      const eventF = await eventsService.create({
+        type: EventType.SEND_TRANSACTION,
+        userId: user.id,
+        points: 300,
+      });
       assert.ok(eventA);
       assert.ok(eventB);
       assert.ok(eventC);
       assert.ok(eventD);
       assert.ok(eventE);
+      assert.ok(eventF);
 
       const options = await eventsService.getUpsertPointsOptions(user);
       expect(options).toMatchObject({
@@ -323,6 +329,10 @@ describe('EventsService', () => {
           PULL_REQUEST_MERGED: {
             points: eventA.points + eventB.points,
             latestOccurredAt: eventB.occurred_at,
+          },
+          SEND_TRANSACTION: {
+            points: eventE.points,
+            latestOccurredAt: eventE.occurred_at,
           },
           SOCIAL_MEDIA_PROMOTION: {
             points: eventD.points,


### PR DESCRIPTION
## Summary

@deekerno pointed out there was a missing test case.

## Testing Plan

This is a test PR

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
