### PR TITLE
take this upsert out of an unnecessary transaction

### DIFF
--- a/src/blocks-transactions-loader/blocks-transactions-loader.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.ts
@@ -37,6 +37,9 @@ export class BlocksTransactionsLoader {
       previousHashes.set(block.hash, block);
     }
 
+    //TODO IRO-1984
+    //This used to be in a huge DB transaction, but that was removed due to performance concerns
+    //If this causes any data consistency issues, find a more surgical way to keep things synced
     for (const block of blocks) {
       let timeSinceLastBlockMs = undefined;
       if (block.previous_block_hash !== undefined) {


### PR DESCRIPTION
## Summary
We had a transaction around a mass upsert that would be blocking some important tables and would also cause the syncer to fail if one of the transactions is invalid. Both of those seem bad, so taking it out.

(This change is mostly whitespace, be sure to view with the flag on)

Fixes IRO-1986

## Testing Plan
automated tests pass

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
