### PR TITLE
fix(api): Ensure `occurredAt` is a `Date` instance at runtime

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -447,7 +447,7 @@ export class EventsService {
     }: CreateEventOptions,
     client: BasePrismaClient,
   ): Promise<EventWithMetadata | null> {
-    occurredAt = occurredAt || new Date();
+    occurredAt = occurredAt ? new Date(occurredAt) : new Date();
 
     const beforeLaunch = occurredAt < PHASE_1_START;
     const afterPhaseOne = occurredAt > PHASE_1_END;


### PR DESCRIPTION
## Summary

See title

https://linear.app/ironfish/issue/IRO-1959/ensure-occurredat-is-always-a-date-instance

## Testing Plan

Manually ran node and verified uptime events against local API

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
