### PR TITLE
feat(api): Add read client for ranking queries

### DIFF
--- a/src/api-config/api-config.service.ts
+++ b/src/api-config/api-config.service.ts
@@ -31,4 +31,18 @@ export class ApiConfigService {
   isProduction(): boolean {
     return this.get<string>('NODE_ENV') === 'production';
   }
+
+  get dbPoolUrl(): string {
+    return `${this.get<string>('DATABASE_CONNECTION_POOL_URL')}?pgbouncer=true`;
+  }
+
+  get readDbPoolUrl(): string {
+    const readDbPoolUrl = this.config.get<string>(
+      'DATABASE_READ_CONNECTION_POOL_URL',
+    );
+    if (!readDbPoolUrl) {
+      return this.dbPoolUrl;
+    }
+    return `${readDbPoolUrl}?pgbouncer=true`;
+  }
 }

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, PrismaPromise } from '@prisma/client';
 import { ApiConfigService } from '../api-config/api-config.service';
 
 @Injectable()
@@ -10,23 +10,38 @@ export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
+  private readonly readClient: PrismaClient;
+
   constructor(readonly config: ApiConfigService) {
     super({
       datasources: {
         db: {
-          url: `${config.get<string>(
-            'DATABASE_CONNECTION_POOL_URL',
-          )}?pgbouncer=true`,
+          url: config.dbPoolUrl,
         },
       },
     });
+    this.readClient = new PrismaClient({
+      datasources: { db: { url: config.readDbPoolUrl } },
+    });
+  }
+
+  $queryRawUnsafe<T = unknown>(
+    query: string,
+    ...values: unknown[]
+  ): PrismaPromise<T> {
+    if (this.config.isProduction()) {
+      return this.readClient.$queryRawUnsafe<T>(query, ...values);
+    }
+    return super.$queryRawUnsafe<T>(query, ...values);
   }
 
   async onModuleInit(): Promise<void> {
     await this.$connect();
+    await this.readClient.$connect();
   }
 
   async onModuleDestroy(): Promise<void> {
     await this.$disconnect();
+    await this.readClient.$disconnect();
   }
 }


### PR DESCRIPTION
## Summary

There is a read replica now set up on production. This code change uses a new client to perform aggregations and rankings to reduce CPU load on the main machine.

## Testing Plan

Manually ran against read replica URL.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
