### PR TITLE
Limit nodes that get credit for uptime by the latest version with a 1 week grace period

### DIFF
--- a/src/telemetry/telemetry.rest.module.ts
+++ b/src/telemetry/telemetry.rest.module.ts
@@ -6,10 +6,17 @@ import { ApiConfigModule } from '../api-config/api-config.module';
 import { InfluxDbModule } from '../influxdb/influxdb.module';
 import { NodeUptimesModule } from '../node-uptimes/node-uptimes.module';
 import { UsersModule } from '../users/users.module';
+import { VersionsModule } from '../versions/versions.module';
 import { TelemetryController } from './telemetry.controller';
 
 @Module({
   controllers: [TelemetryController],
-  imports: [ApiConfigModule, InfluxDbModule, NodeUptimesModule, UsersModule],
+  imports: [
+    ApiConfigModule,
+    InfluxDbModule,
+    NodeUptimesModule,
+    UsersModule,
+    VersionsModule,
+  ],
 })
 export class TelemetryRestModule {}

--- a/src/versions/versions.service.ts
+++ b/src/versions/versions.service.ts
@@ -27,4 +27,17 @@ export class VersionsService {
       },
     });
   }
+
+  async getLatestAtDate(date: Date): Promise<Version | null> {
+    return this.prisma.version.findFirst({
+      orderBy: {
+        version: 'desc',
+      },
+      where: {
+        created_at: {
+          lte: date,
+        },
+      },
+    });
+  }
 }


### PR DESCRIPTION
## Summary

This will help incentivize users to run the latest version by only giving credit for node uptime for nodes running the latest version (with a 1 week grace period).

Note that we should probably announce we're making this change before we merge/deploy this, so that users have time to upgrade their nodes appropriately.

Potential alternatives:
- Bigger rolling window on the grace period (2 weeks). This seems fairly reasonable, if we feel 1 week is too aggressive
- Set the version in a config variable. This feels fine, with the added caveat that we have to remember to update it and announce when we do
- Other? Open to suggestions

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
