### PR TITLE
POST /blocks now upserts incrementally

### DIFF
--- a/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
+import assert from 'assert';
 import faker from 'faker';
 import { v4 as uuid } from 'uuid';
 import { BlockOperation } from '../blocks/enums/block-operation';
 import { BlocksTransactionsService } from '../blocks-transactions/blocks-transactions.service';
 import { GraphileWorkerPattern } from '../graphile-worker/enums/graphile-worker-pattern';
 import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
+import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { UsersService } from '../users/users.service';
 import { BlocksTransactionsLoader } from './blocks-transactions-loader';
@@ -17,6 +19,7 @@ describe('BlocksTransactionsLoader', () => {
   let blocksTransactionsLoader: BlocksTransactionsLoader;
   let blocksTransactionsService: BlocksTransactionsService;
   let graphileWorkerService: GraphileWorkerService;
+  let prismaService: PrismaService;
   let usersService: UsersService;
 
   let addJob: jest.SpyInstance;
@@ -26,6 +29,7 @@ describe('BlocksTransactionsLoader', () => {
     blocksTransactionsLoader = app.get(BlocksTransactionsLoader);
     blocksTransactionsService = app.get(BlocksTransactionsService);
     graphileWorkerService = app.get(GraphileWorkerService);
+    prismaService = app.get(PrismaService);
     usersService = app.get(UsersService);
     await app.init();
   });
@@ -58,7 +62,7 @@ describe('BlocksTransactionsLoader', () => {
         notes: [{ commitment: uuid() }],
         spends: [{ nullifier: uuid() }],
       };
-      const blocks = await blocksTransactionsLoader.bulkUpsert({
+      await blocksTransactionsLoader.bulkUpsert({
         blocks: [
           {
             hash: blockHash1,
@@ -85,7 +89,13 @@ describe('BlocksTransactionsLoader', () => {
         ],
       });
 
-      expect(blocks[0]).toMatchObject({
+      const block1 = await prismaService.block.findFirst({
+        where: {
+          hash: blockHash1,
+        },
+      });
+      assert(block1);
+      expect(block1).toMatchObject({
         id: expect.any(Number),
         hash: blockHash1,
         sequence: expect.any(Number),
@@ -99,7 +109,13 @@ describe('BlocksTransactionsLoader', () => {
         time_since_last_block_ms: null,
       });
 
-      expect(blocks[1]).toMatchObject({
+      const block2 = await prismaService.block.findFirst({
+        where: {
+          hash: blockHash2,
+        },
+      });
+      assert(block2);
+      expect(block2).toMatchObject({
         id: expect.any(Number),
         hash: blockHash2,
         sequence: expect.any(Number),
@@ -113,7 +129,13 @@ describe('BlocksTransactionsLoader', () => {
         time_since_last_block_ms: timestamp2.getTime() - timestamp1.getTime(),
       });
 
-      expect(blocks[0].transactions[0]).toMatchObject({
+      const tx1 = await prismaService.transaction.findFirst({
+        where: {
+          hash: transaction.hash,
+        },
+      });
+      assert(tx1);
+      expect(tx1).toMatchObject({
         hash: transaction.hash,
         fee: transaction.fee,
         size: transaction.size,
@@ -122,27 +144,28 @@ describe('BlocksTransactionsLoader', () => {
       });
 
       const blockTransaction = await blocksTransactionsService.find(
-        blocks[0].id,
-        blocks[0].transactions[0].id,
+        block1.id,
+        tx1.id,
       );
       expect(blockTransaction).toMatchObject({
-        block_id: blocks[0].id,
-        transaction_id: blocks[0].transactions[0].id,
+        block_id: block1.id,
+        transaction_id: tx1.id,
       });
     });
 
     describe('when the blocks are associated with a registered user', () => {
       it('queues delete jobs for disconnected blocks', async () => {
+        const blockHash = uuid();
         const graffiti = uuid();
         const user = await usersService.create({
           email: faker.internet.email(),
           graffiti,
           country_code: faker.address.countryCode('alpha-3'),
         });
-        const blocks = await blocksTransactionsLoader.bulkUpsert({
+        await blocksTransactionsLoader.bulkUpsert({
           blocks: [
             {
-              hash: uuid(),
+              hash: blockHash,
               sequence: faker.datatype.number(),
               difficulty: faker.datatype.number(),
               timestamp: new Date(),
@@ -155,27 +178,34 @@ describe('BlocksTransactionsLoader', () => {
           ],
         });
 
+        const block = await prismaService.block.findFirst({
+          where: {
+            hash: blockHash,
+          },
+        });
+        assert(block);
         expect(addJob).toHaveBeenCalledTimes(2);
         expect(addJob).toHaveBeenCalledWith(
           GraphileWorkerPattern.DELETE_BLOCK_MINED_EVENT,
           {
-            block_id: blocks[0].id,
+            block_id: block.id,
           },
           expect.anything(),
         );
       });
 
       it('queues upsert jobs for disconnected blocks', async () => {
+        const blockHash = uuid();
         const graffiti = uuid();
         const user = await usersService.create({
           email: faker.internet.email(),
           graffiti,
           country_code: faker.address.countryCode('alpha-3'),
         });
-        const blocks = await blocksTransactionsLoader.bulkUpsert({
+        await blocksTransactionsLoader.bulkUpsert({
           blocks: [
             {
-              hash: uuid(),
+              hash: blockHash,
               sequence: faker.datatype.number(),
               difficulty: faker.datatype.number(),
               timestamp: new Date(),
@@ -188,11 +218,17 @@ describe('BlocksTransactionsLoader', () => {
           ],
         });
 
+        const block = await prismaService.block.findFirst({
+          where: {
+            hash: blockHash,
+          },
+        });
+        assert(block);
         expect(addJob).toHaveBeenCalledTimes(2);
         expect(addJob).toHaveBeenCalledWith(
           GraphileWorkerPattern.UPSERT_BLOCK_MINED_EVENT,
           {
-            block_id: blocks[0].id,
+            block_id: block.id,
             user_id: user.id,
           },
           expect.anything(),

--- a/src/blocks/blocks.controller.spec.ts
+++ b/src/blocks/blocks.controller.spec.ts
@@ -148,25 +148,11 @@ describe('BlocksController', () => {
             },
           ],
         };
-        const block = payload.blocks[0];
-        const { body } = await request(app.getHttpServer())
+        await request(app.getHttpServer())
           .post(`/blocks`)
           .set('Authorization', `Bearer ${API_KEY}`)
           .send(payload)
           .expect(HttpStatus.CREATED);
-
-        const { data } = body;
-        expect((data as unknown[]).length).toBeGreaterThan(0);
-        expect((data as unknown[])[0]).toMatchObject({
-          id: expect.any(Number),
-          hash: block.hash,
-          difficulty: block.difficulty,
-          sequence: block.sequence,
-          timestamp: block.timestamp.toISOString(),
-          transactions_count: 1,
-          previous_block_hash: block.previous_block_hash,
-          size: block.size,
-        });
       });
     });
   });

--- a/src/blocks/blocks.controller.ts
+++ b/src/blocks/blocks.controller.ts
@@ -62,16 +62,9 @@ export class BlocksController {
       }),
     )
     upsertBlocksDto: UpsertBlocksDto,
-  ): Promise<List<SerializedBlock>> {
-    const blocks = await this.blocksTransactionsLoader.bulkUpsert(
-      upsertBlocksDto,
-    );
-    return {
-      object: 'list',
-      data: blocks.map((block) =>
-        serializedBlockFromRecordWithTransactions(block),
-      ),
-    };
+  ): Promise<void> {
+    await this.blocksTransactionsLoader.bulkUpsert(upsertBlocksDto);
+    return;
   }
 
   @ApiOperation({ summary: 'Gets the head of the chain' })


### PR DESCRIPTION
## Summary

The actual change is just to move the DB transaction down into the block for-loop, so that it won't rollback the entire operation if it times out

The intended effect here is that even if the request times out, it will still progress on the ones that were successfully upserted, such that it will eventually process them all.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
