### PR TITLE
add bulk upload transactions endpoint

### DIFF
--- a/src/blocks-transactions-loader/blocks-transactions-loader.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.ts
@@ -81,10 +81,11 @@ export class BlocksTransactionsLoader {
             upsertBlockMinedPayloads.push(upsertBlockMinedOptions);
           }
 
-          const transactions = await this.transactionsService.bulkUpsert(
-            prisma,
-            block.transactions,
-          );
+          const transactions =
+            await this.transactionsService.bulkUpsertWithClient(
+              prisma,
+              block.transactions,
+            );
 
           for (const transaction of transactions) {
             await this.blocksTransactionsService.upsert(

--- a/src/transactions/transactions.controller.spec.ts
+++ b/src/transactions/transactions.controller.spec.ts
@@ -387,4 +387,49 @@ describe('TransactionsController', () => {
       });
     });
   });
+
+  describe('POST /transactions', () => {
+    it('uploads bulk transactions', async () => {
+      const transaction1 = {
+        hash: uuid(),
+        fee: faker.datatype.number(),
+        size: faker.datatype.number(),
+        notes: [{ commitment: uuid() }],
+        spends: [{ nullifier: uuid() }],
+      };
+
+      const transaction2 = {
+        hash: uuid(),
+        fee: faker.datatype.number(),
+        size: faker.datatype.number(),
+        notes: [{ commitment: uuid() }],
+        spends: [{ nullifier: uuid() }],
+      };
+
+      const API_KEY = 'test';
+      await request(app.getHttpServer())
+        .post('/transactions')
+        .set('Authorization', `Bearer ${API_KEY}`)
+        .send({ transactions: [transaction1, transaction2] })
+        .expect(HttpStatus.CREATED);
+
+      const { body: body1 } = await request(app.getHttpServer())
+        .get('/transactions/find')
+        .query({ hash: transaction1.hash })
+        .expect(HttpStatus.OK);
+
+      expect(body1.notes).toStrictEqual(transaction1.notes);
+      expect(body1.spends).toStrictEqual(transaction1.spends);
+      expect(body1.hash).toStrictEqual(transaction1.hash);
+
+      const { body: body2 } = await request(app.getHttpServer())
+        .get('/transactions/find')
+        .query({ hash: transaction2.hash })
+        .expect(HttpStatus.OK);
+
+      expect(body2.notes).toStrictEqual(transaction2.notes);
+      expect(body2.spends).toStrictEqual(transaction2.spends);
+      expect(body2.hash).toStrictEqual(transaction2.hash);
+    });
+  });
 });

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -58,15 +58,18 @@ describe('TransactionsService', () => {
         const spends = [{ nullifier: uuid() }];
         const hash = faker.random.alpha({ count: 10, upcase: true });
         expect(hash).toEqual(hash.toUpperCase());
-        const transactions = await transactionsService.bulkUpsert(prisma, [
-          {
-            hash,
-            fee: faker.datatype.number(),
-            size: faker.datatype.number(),
-            notes,
-            spends,
-          },
-        ]);
+        const transactions = await transactionsService.bulkUpsertWithClient(
+          prisma,
+          [
+            {
+              hash,
+              fee: faker.datatype.number(),
+              size: faker.datatype.number(),
+              notes,
+              spends,
+            },
+          ],
+        );
         expect(transactions[0]).toMatchObject({
           id: expect.any(Number),
           hash: standardizeHash(hash),
@@ -82,29 +85,35 @@ describe('TransactionsService', () => {
       it('updates the transaction record', async () => {
         const notes = [{ commitment: uuid() }];
         const spends = [{ nullifier: uuid() }];
-        const transactions = await transactionsService.bulkUpsert(prisma, [
-          {
-            hash: uuid(),
-            fee: faker.datatype.number(),
-            size: faker.datatype.number(),
-            notes,
-            spends,
-          },
-        ]);
+        const transactions = await transactionsService.bulkUpsertWithClient(
+          prisma,
+          [
+            {
+              hash: uuid(),
+              fee: faker.datatype.number(),
+              size: faker.datatype.number(),
+              notes,
+              spends,
+            },
+          ],
+        );
         const newFee = faker.datatype.number();
         const newSize = faker.datatype.number();
         const newNotes = [{ commitment: uuid() }];
         const newSpends = [{ nullifier: uuid() }];
         const transaction = transactions[0];
-        const newTransactions = await transactionsService.bulkUpsert(prisma, [
-          {
-            hash: transaction.hash,
-            fee: newFee,
-            size: newSize,
-            notes: newNotes,
-            spends: newSpends,
-          },
-        ]);
+        const newTransactions = await transactionsService.bulkUpsertWithClient(
+          prisma,
+          [
+            {
+              hash: transaction.hash,
+              fee: newFee,
+              size: newSize,
+              notes: newNotes,
+              spends: newSpends,
+            },
+          ],
+        );
         expect(newTransactions[0]).toMatchObject({
           id: transaction.id,
           hash: transaction.hash,
@@ -128,15 +137,18 @@ describe('TransactionsService', () => {
             count: 10,
             upcase: true,
           });
-          const transactions = await transactionsService.bulkUpsert(prisma, [
-            {
-              hash: testTransactionHash,
-              fee: faker.datatype.number(),
-              size: faker.datatype.number(),
-              notes,
-              spends,
-            },
-          ]);
+          const transactions = await transactionsService.bulkUpsertWithClient(
+            prisma,
+            [
+              {
+                hash: testTransactionHash,
+                fee: faker.datatype.number(),
+                size: faker.datatype.number(),
+                notes,
+                spends,
+              },
+            ],
+          );
           const testTransaction = transactions[0];
 
           await blocksTransactionsService.upsert(
@@ -171,7 +183,7 @@ describe('TransactionsService', () => {
         it('returns null', async () => {
           const notes = [{ commitment: uuid() }];
           const spends = [{ nullifier: uuid() }];
-          await transactionsService.bulkUpsert(prisma, [
+          await transactionsService.bulkUpsertWithClient(prisma, [
             {
               hash: uuid(),
               fee: faker.datatype.number(),
@@ -196,15 +208,18 @@ describe('TransactionsService', () => {
           const notes = [{ commitment: uuid() }];
           const spends = [{ nullifier: uuid() }];
           const testTransactionHash = uuid();
-          const transactions = await transactionsService.bulkUpsert(prisma, [
-            {
-              hash: testTransactionHash,
-              fee: faker.datatype.number(),
-              size: faker.datatype.number(),
-              notes,
-              spends,
-            },
-          ]);
+          const transactions = await transactionsService.bulkUpsertWithClient(
+            prisma,
+            [
+              {
+                hash: testTransactionHash,
+                fee: faker.datatype.number(),
+                size: faker.datatype.number(),
+                notes,
+                spends,
+              },
+            ],
+          );
           const testTransaction = transactions[0];
           const transaction = await transactionsService.find({
             hash: testTransactionHash,
@@ -217,7 +232,7 @@ describe('TransactionsService', () => {
         it('returns null', async () => {
           const notes = [{ commitment: uuid() }];
           const spends = [{ nullifier: uuid() }];
-          await transactionsService.bulkUpsert(prisma, [
+          await transactionsService.bulkUpsertWithClient(prisma, [
             {
               hash: uuid(),
               fee: faker.datatype.number(),
@@ -241,22 +256,25 @@ describe('TransactionsService', () => {
         const testTransactionHash = uuid();
         const notes = [{ commitment: uuid() }];
         const spends = [{ nullifier: uuid() }];
-        const transactions = await transactionsService.bulkUpsert(prisma, [
-          {
-            hash: testTransactionHash,
-            fee: faker.datatype.number(),
-            size: faker.datatype.number(),
-            notes,
-            spends,
-          },
-          {
-            hash: uuid(),
-            fee: faker.datatype.number(),
-            size: faker.datatype.number(),
-            notes,
-            spends,
-          },
-        ]);
+        const transactions = await transactionsService.bulkUpsertWithClient(
+          prisma,
+          [
+            {
+              hash: testTransactionHash,
+              fee: faker.datatype.number(),
+              size: faker.datatype.number(),
+              notes,
+              spends,
+            },
+            {
+              hash: uuid(),
+              fee: faker.datatype.number(),
+              size: faker.datatype.number(),
+              notes,
+              spends,
+            },
+          ],
+        );
 
         for (const transaction of transactions) {
           await blocksTransactionsService.upsert(prisma, block, transaction);
@@ -282,7 +300,7 @@ describe('TransactionsService', () => {
         const testTransactionHash = uuid();
         const notes = [{ commitment: uuid() }];
         const spends = [{ nullifier: uuid() }];
-        await transactionsService.bulkUpsert(prisma, [
+        await transactionsService.bulkUpsertWithClient(prisma, [
           {
             hash: testTransactionHash,
             fee: faker.datatype.number(),

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -24,7 +24,7 @@ export class TransactionsService {
     private readonly prisma: PrismaService,
   ) {}
 
-  async bulkUpsert(
+  async bulkUpsertWithClient(
     prisma: BasePrismaClient,
     transactions: UpsertTransactionOptions[],
   ): Promise<Transaction[]> {
@@ -33,6 +33,14 @@ export class TransactionsService {
       records.push(await this.upsert(prisma, transaction));
     }
     return records;
+  }
+
+  async bulkUpsert(
+    transactions: UpsertTransactionOptions[],
+  ): Promise<Transaction[]> {
+    return this.prisma.$transaction(async (prisma) => {
+      return this.bulkUpsertWithClient(prisma, transactions);
+    });
   }
 
   private async upsert(


### PR DESCRIPTION
## Summary
There are many reasons why we may want to see transactions that are not associated with a block in the block explorer. The use case driving this change is that when the pool tries to make a payout we want to be able to show the transaction before it's added to a block. Being able to view them in the block explorer would give more insight on when they get sent out and if they expire. We also could use them to create a mempool explorer in the future

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
