### PR TITLE
feat(api): Add concurrency configuration for Graphile

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,7 @@ DATABASE_CONNECTION_POOL_URL=postgres://postgres:password@localhost:5432/ironfis
 DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_development
 DATADOG_URL=127.0.0.1
 DEPOSIT_ADDRESS=5cfbcbf6e6f84e2bab6c17309f39908d7cdb8ae5ad4ab600bbb9101403a1edc2d03f71754764e8c66afc08
+GRAPHILE_CONCURRENCY=10
 INCENTIVIZED_TESTNET_URL=http://localhost:3001
 INFLUXDB_API_TOKEN=test
 INFLUXDB_BUCKET=test

--- a/.env.test
+++ b/.env.test
@@ -7,6 +7,7 @@ DATABASE_CONNECTION_POOL_URL=postgres://postgres:password@localhost:5432/ironfis
 DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_test
 DATADOG_URL=127.0.0.1
 DEPOSIT_ADDRESS=5cfbcbf6e6f84e2bab6c17309f39908d7cdb8ae5ad4ab600bbb9101403a1edc2d03f71754764e8c66afc08
+GRAPHILE_CONCURRENCY=10
 INCENTIVIZED_TESTNET_URL=http://localhost:3001
 INFLUXDB_API_TOKEN=test
 INFLUXDB_BUCKET=test

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -73,6 +73,7 @@ export const REST_MODULES = [
         DATADOG_URL: joi.string().required(),
         DISABLE_FAUCET: joi.boolean().default(false),
         DISABLE_LOGIN: joi.boolean().default(false),
+        GRAPHILE_CONCURRENCY: joi.number().required(),
         INCENTIVIZED_TESTNET_URL: joi.string().required(),
         INFLUXDB_API_TOKEN: joi.string().required(),
         INFLUXDB_BUCKET: joi.string().required(),

--- a/src/graphile-worker/graphile-worker.microservice.ts
+++ b/src/graphile-worker/graphile-worker.microservice.ts
@@ -26,6 +26,7 @@ export class GraphileWorkerMicroservice
 
   async listen(): Promise<void> {
     this.runner = await run({
+      concurrency: this.config.get<number>('GRAPHILE_CONCURRENCY'),
       noHandleSignals: false,
       pgPool: new Pool(this.getPostgresPoolConfig()),
       taskList: this.getTaskHandlers(),

--- a/src/test/test-app.ts
+++ b/src/test/test-app.ts
@@ -27,6 +27,7 @@ export async function bootstrapTestApp(): Promise<INestApplication> {
           DATADOG_URL: joi.string().required(),
           DISABLE_FAUCET: joi.boolean().default(false),
           DISABLE_LOGIN: joi.boolean().default(false),
+          GRAPHILE_CONCURRENCY: joi.number().required(),
           INCENTIVIZED_TESTNET_URL: joi.string().required(),
           INFLUXDB_API_TOKEN: joi.string().required(),
           INFLUXDB_BUCKET: joi.string().required(),


### PR DESCRIPTION
## Summary

Allow environment variable configuration for Graphile Worker concurrency.

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
