### PR TITLE
Fix graphile WorkerUtils race condition

### DIFF
--- a/src/graphile-worker/graphile-worker.service.ts
+++ b/src/graphile-worker/graphile-worker.service.ts
@@ -12,6 +12,7 @@ import { GraphileWorkerJobOptions } from './interfaces/graphile-worker-job-optio
 @Injectable()
 export class GraphileWorkerService {
   private workerUtils!: WorkerUtils;
+  private workerUtilsPromise: Promise<WorkerUtils> | null = null;
 
   constructor(private readonly config: ApiConfigService) {}
 
@@ -20,9 +21,8 @@ export class GraphileWorkerService {
     payload?: T,
     { queueName, runAt, jobKey }: GraphileWorkerJobOptions = {},
   ): Promise<Job> {
-    if (!this.workerUtils) {
-      await this.initWorkerUtils();
-    }
+    await this.initWorkerUtils();
+
     return this.workerUtils.addJob(pattern.toString(), payload, {
       jobKey: jobKey || `job_${uuid()}`,
       queueName,
@@ -31,9 +31,7 @@ export class GraphileWorkerService {
   }
 
   async queuedJobCount(): Promise<number> {
-    if (!this.workerUtils) {
-      await this.initWorkerUtils();
-    }
+    await this.initWorkerUtils();
 
     return this.workerUtils.withPgClient(async (pgClient) => {
       const result = await pgClient.query<{ count: string }>(
@@ -45,9 +43,19 @@ export class GraphileWorkerService {
   }
 
   private async initWorkerUtils(): Promise<void> {
-    this.workerUtils = await makeWorkerUtils({
+    if (this.workerUtils) {
+      return;
+    }
+
+    if (this.workerUtilsPromise) {
+      await this.workerUtilsPromise;
+    }
+
+    this.workerUtilsPromise = makeWorkerUtils({
       pgPool: new Pool(this.getPostgresPoolConfig()),
     });
+
+    this.workerUtils = await this.workerUtilsPromise;
   }
 
   private getPostgresPoolConfig(): PoolConfig {

--- a/src/graphile-worker/graphile-worker.service.ts
+++ b/src/graphile-worker/graphile-worker.service.ts
@@ -49,6 +49,7 @@ export class GraphileWorkerService {
 
     if (this.workerUtilsPromise) {
       await this.workerUtilsPromise;
+      return;
     }
 
     this.workerUtilsPromise = makeWorkerUtils({


### PR DESCRIPTION
## Summary

There is a race condition here if initWorkerUtils() is called multiple
times in parallel.

## Testing Plan

Run tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
