### PR TITLE
feat(api): Push transaction in deposit upserts per amount

### DIFF
--- a/src/deposit-heads/deposit-heads.module.ts
+++ b/src/deposit-heads/deposit-heads.module.ts
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
 import { DepositHeadsService } from './deposit-heads.service';
 
 @Module({
   exports: [DepositHeadsService],
+  imports: [PrismaModule],
   providers: [DepositHeadsService],
 })
 export class DepositHeadsModule {}

--- a/src/deposit-heads/deposit-heads.service.spec.ts
+++ b/src/deposit-heads/deposit-heads.service.spec.ts
@@ -3,19 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
 import { v4 as uuid } from 'uuid';
-import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { DepositHeadsService } from './deposit-heads.service';
 
 describe('DepositHeadsService', () => {
   let app: INestApplication;
   let depositHeadsService: DepositHeadsService;
-  let prisma: PrismaService;
 
   beforeAll(async () => {
     app = await bootstrapTestApp();
     depositHeadsService = app.get(DepositHeadsService);
-    prisma = app.get(PrismaService);
     await app.init();
   });
 
@@ -26,7 +23,7 @@ describe('DepositHeadsService', () => {
   describe('upsert', () => {
     it('upserts a DepositHead record', async () => {
       const hash = uuid();
-      const record = await depositHeadsService.upsert(hash, prisma);
+      const record = await depositHeadsService.upsert(hash);
       expect(record).toMatchObject({
         id: 1,
         block_hash: hash,

--- a/src/deposit-heads/deposit-heads.service.ts
+++ b/src/deposit-heads/deposit-heads.service.ts
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable } from '@nestjs/common';
-import { BasePrismaClient } from '../prisma/types/base-prisma-client';
+import { PrismaService } from '../prisma/prisma.service';
 import { DepositHead } from '.prisma/client';
 
 @Injectable()
 export class DepositHeadsService {
-  async upsert(
-    blockHash: string,
-    client: BasePrismaClient,
-  ): Promise<DepositHead> {
-    return client.depositHead.upsert({
+  constructor(private readonly prisma: PrismaService) {}
+
+  async upsert(blockHash: string): Promise<DepositHead> {
+    return this.prisma.depositHead.upsert({
       create: {
         id: 1,
         block_hash: blockHash,


### PR DESCRIPTION
## Summary

We can push the transaction per amount in the deposit here. This is one of the slowest running jobs, so it should help speed it up and make it easier to move parts into other worker jobs later if necessary.

## Testing Plan

Covered by existing tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
