### PR TITLE
adds a queue name to the upsert deposit job

### DIFF
--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -40,6 +40,7 @@ export class DepositsUpsertService {
           operation,
           {
             jobKey: `upsert_deposit:${operation.block.hash}:${operation.type}`,
+            queueName: 'upsert_deposit',
           },
         );
       }


### PR DESCRIPTION
## Summary

adding graphile-worker jobs to a named queue will run them in series. uses a
queue name of 'upsert_deposit' to match the job identifier.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
