### PR TITLE
exposes mismatched deposits count in admin health check

### DIFF
--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -139,9 +139,9 @@ export class DepositsUpsertService {
       SELECT
         COUNT(*)
       FROM
-        blocks
-      RIGHT OUTER JOIN
         deposits
+      LEFT JOIN
+        blocks
       ON blocks.hash = deposits.block_hash
       WHERE blocks.hash IS NULL OR blocks.main <> deposits.main
       `,

--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable } from '@nestjs/common';
 import { Deposit, EventType } from '@prisma/client';
+import is from '@sindresorhus/is';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { BlockOperation } from '../blocks/enums/block-operation';
 import { SEND_TRANSACTION_LIMIT_ORE } from '../common/constants';
@@ -130,5 +131,24 @@ export class DepositsUpsertService {
     }
 
     return deposits;
+  }
+
+  async mismatchedDepositCount(): Promise<number> {
+    const result = await this.prisma.$queryRawUnsafe<{ count: number }[]>(
+      `
+      SELECT
+        COUNT(*) AS count
+      FROM
+        blocks
+      RIGHT OUTER JOIN
+        deposits
+      ON blocks.hash = deposits.block_hash
+      WHERE blocks.hash IS NULL OR blocks.main <> deposits.main
+      `,
+    );
+    if (!is.array(result) || result.length !== 1 || !is.object(result[0])) {
+      throw new Error('Unexpected database response');
+    }
+    return result[0].count;
   }
 }

--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -137,7 +137,7 @@ export class DepositsUpsertService {
     const result = await this.prisma.$queryRawUnsafe<{ count: number }[]>(
       `
       SELECT
-        COUNT(*) AS count
+        COUNT(*)
       FROM
         blocks
       RIGHT OUTER JOIN

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -36,6 +36,7 @@ describe('HealthController', () => {
 
       expect(body).toMatchObject({
         queued_jobs: expect.any(Number),
+        mismatched_deposits: expect.any(Number),
       });
     });
   });

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -4,12 +4,16 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiExcludeEndpoint, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ApiKeyGuard } from '../auth/guards/api-key.guard';
+import { DepositsUpsertService } from '../events/deposits.upsert.service';
 import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
 
 @ApiTags('Health')
 @Controller('health')
 export class HealthController {
-  constructor(private readonly graphileService: GraphileWorkerService) {}
+  constructor(
+    private readonly graphileService: GraphileWorkerService,
+    private readonly depositsUpsertService: DepositsUpsertService,
+  ) {}
 
   @ApiOperation({ summary: 'Gets the health of the Iron Fish API' })
   @Get()
@@ -22,9 +26,15 @@ export class HealthController {
   @Get('admin')
   async admin(): Promise<{
     queued_jobs: number;
+    mismatched_deposits: number;
   }> {
+    const [queuedJobs, mismatchedDeposits] = await Promise.all([
+      this.graphileService.queuedJobCount(),
+      this.depositsUpsertService.mismatchedDepositCount(),
+    ]);
     return {
-      queued_jobs: await this.graphileService.queuedJobCount(),
+      queued_jobs: queuedJobs,
+      mismatched_deposits: mismatchedDeposits,
     };
   }
 }

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -11,7 +11,7 @@ import { GraphileWorkerService } from '../graphile-worker/graphile-worker.servic
 @Controller('health')
 export class HealthController {
   constructor(
-    private readonly graphileService: GraphileWorkerService,
+    private readonly graphileWorkerService: GraphileWorkerService,
     private readonly depositsUpsertService: DepositsUpsertService,
   ) {}
 
@@ -29,7 +29,7 @@ export class HealthController {
     mismatched_deposits: number;
   }> {
     const [queuedJobs, mismatchedDeposits] = await Promise.all([
-      this.graphileService.queuedJobCount(),
+      this.graphileWorkerService.queuedJobCount(),
       this.depositsUpsertService.mismatchedDepositCount(),
     ]);
     return {

--- a/src/health/health.rest.module.ts
+++ b/src/health/health.rest.module.ts
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
+import { EventsModule } from '../events/events.module';
 import { GraphileWorkerModule } from '../graphile-worker/graphile-worker.module';
 import { HealthController } from './health.controller';
 
 @Module({
   controllers: [HealthController],
-  imports: [GraphileWorkerModule],
+  imports: [GraphileWorkerModule, EventsModule],
 })
 export class HealthRestModule {}


### PR DESCRIPTION
## Summary

- queries deposits and blocks tables to count deposits where either the block
  hash does not exist in blocks or there is a mismatch in 'main'
- adds DepositUpsertService to HealthController to expose mismatched deposits
  count

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
