### PR TITLE
outlines queries to fix data from out of order deposits

### DIFF
--- a/backfill_mismatched_deposits.sql
+++ b/backfill_mismatched_deposits.sql
@@ -1,0 +1,64 @@
+-- soft-delete events for overcounted deposits
+UPDATE events SET deleted_at = current_timestamp
+WHERE
+  deposit_id IN (
+  SELECT 
+    deposits.id
+  FROM
+    deposits
+  LEFT JOIN 
+    blocks
+  ON
+    deposits.block_hash = blocks.hash
+  WHERE
+    deposits.main = true AND (blocks.main IS NULL OR blocks.main = false)
+);
+
+-- upsert events for undercounted mismatched deposits
+INSERT INTO events (type, occurred_at, points, user_id, deposit_id)
+SELECT
+  'SEND_TRANSACTION' AS type,
+  missing_events.block_timestamp AS occurred_at,
+  1 AS points,
+  users.id AS user_id,
+  missing_events.deposit_id AS deposit_id
+FROM
+  users
+JOIN
+  (
+    SELECT
+      deposits.id AS deposit_id,
+      deposits.graffiti AS deposit_graffiti
+      blocks.timestamp AS block_timestamp
+    FROM
+      deposits
+    JOIN
+      blocks
+    ON
+      deposits.block_hash = blocks.hash
+    WHERE
+      deposits.main = false AND blocks.main = true AND deposits.amount >= 10000000
+  ) missing_events
+ON
+  users.graffiti = missing_events.deposit_graffiti;
+
+-- set deposits.main to match blocks.main
+UPDATE deposits SET main = blocks.main
+FROM blocks
+WHERE deposits.block_hash = blocks.hash AND deposits.main <> blocks.main;
+
+-- set main to false for deposits without blocks
+UPDATE deposits SET main = false
+WHERE
+  deposits.id IN (
+  SELECT
+    deposits.id
+  FROM
+    deposits
+  LEFT JOIN
+    blocks
+  ON
+    deposits.block_hash = blocks.hash
+  WHERE
+    blocks.hash IS NULL
+);


### PR DESCRIPTION
## Summary

backfill_mismatched_deposits.sql includes four queries to do the following:

1. soft-delete events from deposits that don't correspond to a block on the main
chain. ('overcounted' deposits)
2. upsert events from deposits on the main chain but currently marked otherwise
('undercounted' deposits)
3. set deposits.main to match blocks.main for any deposits where it doesn't
4. set deposits.main to false for any deposit marked main that doesn't have a
block in blocks

NOTE: this PR isn't necessarily intended to be merged into the repo, but useful for sharing and reviewing the queries before we run them.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
