### PR TITLE
Preserve transaction index and sort by them

### DIFF
--- a/src/blocks-transactions-loader/blocks-transactions-loader.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.ts
@@ -87,13 +87,17 @@ export class BlocksTransactionsLoader {
               block.transactions,
             );
 
-          for (const transaction of transactions) {
+          for (let i = 0; i < transactions.length; ++i) {
+            const transaction = transactions[i];
+
             await this.blocksTransactionsService.upsert(
               prisma,
               createdBlock,
               transaction,
+              i,
             );
           }
+
           records.push({ ...createdBlock, transactions });
         },
         {

--- a/src/blocks-transactions/blocks-transactions.service.spec.ts
+++ b/src/blocks-transactions/blocks-transactions.service.spec.ts
@@ -133,7 +133,7 @@ describe('BlocksTransactionsService', () => {
               spends,
             },
           });
-          await blocksTransactionsService.upsert(prisma, block, transaction, 0);
+          await blocksTransactionsService.upsert(prisma, block, transaction, i);
         }
 
         const blocksTransactions = await blocksTransactionsService.list({

--- a/src/blocks-transactions/blocks-transactions.service.spec.ts
+++ b/src/blocks-transactions/blocks-transactions.service.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
+import assert from 'assert';
 import faker from 'faker';
 import { v4 as uuid } from 'uuid';
 import { PrismaService } from '../prisma/prisma.service';
@@ -66,7 +67,7 @@ describe('BlocksTransactionsService', () => {
             spends: [{ nullifier: uuid() }],
           },
         });
-        await blocksTransactionsService.upsert(prisma, block, transaction);
+        await blocksTransactionsService.upsert(prisma, block, transaction, 0);
 
         const record = await blocksTransactionsService.find(
           block.id,
@@ -103,6 +104,7 @@ describe('BlocksTransactionsService', () => {
           prisma,
           block,
           transaction,
+          0,
         );
 
         expect(blockTransaction).toMatchObject({
@@ -131,7 +133,7 @@ describe('BlocksTransactionsService', () => {
               spends,
             },
           });
-          await blocksTransactionsService.upsert(prisma, block, transaction);
+          await blocksTransactionsService.upsert(prisma, block, transaction, 0);
         }
 
         const blocksTransactions = await blocksTransactionsService.list({
@@ -160,7 +162,7 @@ describe('BlocksTransactionsService', () => {
 
         for (let i = 0; i < 10; i++) {
           const { block } = await seedBlock();
-          await blocksTransactionsService.upsert(prisma, block, transaction);
+          await blocksTransactionsService.upsert(prisma, block, transaction, i);
         }
 
         const blocksTransactions = await blocksTransactionsService.list({
@@ -189,7 +191,7 @@ describe('BlocksTransactionsService', () => {
 
       for (let i = 0; i < 10; i++) {
         const { block } = await seedBlock();
-        await blocksTransactionsService.upsert(prisma, block, transaction);
+        await blocksTransactionsService.upsert(prisma, block, transaction, i);
       }
 
       const blocks = await blocksTransactionsService.findBlocksByTransaction(
@@ -217,15 +219,30 @@ describe('BlocksTransactionsService', () => {
             spends: [{ nullifier: uuid() }],
           },
         });
-        await blocksTransactionsService.upsert(prisma, block, transaction);
+
+        const blockTransaction = await blocksTransactionsService.upsert(
+          prisma,
+          block,
+          transaction,
+          i,
+        );
+
+        expect(blockTransaction.index).toEqual(i);
       }
 
       const transactions =
         await blocksTransactionsService.findTransactionsByBlock(block);
-      for (const transaction of transactions) {
-        expect(
-          await blocksTransactionsService.find(block.id, transaction.id),
-        ).not.toBeNull();
+
+      for (let i = 0; i < transactions.length; ++i) {
+        const transaction = transactions[i];
+
+        const blockTransaction = await blocksTransactionsService.find(
+          block.id,
+          transaction.id,
+        );
+
+        assert.ok(blockTransaction);
+        expect(blockTransaction.index).toBe(i);
       }
     });
   });

--- a/src/blocks-transactions/blocks-transactions.service.ts
+++ b/src/blocks-transactions/blocks-transactions.service.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { Block, BlockTransaction, Transaction } from '@prisma/client';
+import { SortOrder } from '../common/enums/sort-order';
 import { PrismaService } from '../prisma/prisma.service';
 import { BasePrismaClient } from '../prisma/types/base-prisma-client';
 import { ListBlockTransactionOptions } from './interfaces/list-block-transactions-options';
@@ -29,15 +30,18 @@ export class BlocksTransactionsService {
     prisma: BasePrismaClient,
     block: Block,
     transaction: Transaction,
+    index: number,
   ): Promise<BlockTransaction> {
     return prisma.blockTransaction.upsert({
       create: {
         block_id: block.id,
         transaction_id: transaction.id,
+        index,
       },
       update: {
         block_id: block.id,
         transaction_id: transaction.id,
+        index,
       },
       where: {
         block_id_transaction_id: {
@@ -87,6 +91,9 @@ export class BlocksTransactionsService {
       },
       include: {
         transaction: true,
+      },
+      orderBy: {
+        index: SortOrder.ASC,
       },
     });
     return blocksTransactions.map(

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -155,6 +155,7 @@ describe('TransactionsService', () => {
             prisma,
             block,
             testTransaction,
+            0,
           );
 
           let receivedTransaction = await transactionsService.find({
@@ -276,8 +277,9 @@ describe('TransactionsService', () => {
           ],
         );
 
-        for (const transaction of transactions) {
-          await blocksTransactionsService.upsert(prisma, block, transaction);
+        for (let i = 0; i < transactions.length; ++i) {
+          const transaction = transactions[i];
+          await blocksTransactionsService.upsert(prisma, block, transaction, i);
         }
 
         const receivedTransactions = await transactionsService.list({


### PR DESCRIPTION
## Summary

Transactions should be returned in index order to be correct. This now
stores the index, and results them in index order.

## Testing Plan
Added tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
