### PR TITLE
only considers deposits without blocks mismatched if marked as main

### DIFF
--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -156,7 +156,7 @@ export class DepositsUpsertService {
       LEFT JOIN
         blocks
       ON blocks.hash = deposits.block_hash
-      WHERE blocks.hash IS NULL OR blocks.main <> deposits.main
+      WHERE (blocks.hash IS NULL AND deposits.main) OR blocks.main <> deposits.main
       `,
     );
     if (!is.array(result) || result.length !== 1 || !is.object(result[0])) {
@@ -189,7 +189,7 @@ export class DepositsUpsertService {
         blocks
       ON blocks.hash = deposits.block_hash
       WHERE
-        blocks.hash IS NULL OR
+        (blocks.hash IS NULL AND deposits.main) OR
         blocks.main <> deposits.main AND
         (
           blocks.hash IS NULL OR


### PR DESCRIPTION
## Summary

refreshDeposit will set deposits.main to false for any deposit without a block
in blocks. however, the queries that identify mismatched deposits will still
surface those deposit records as mismatches even after that update. these
changes treat deposits without blocks as mismatches only if they are marked as
being on the main chain.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
