### PR TITLE
fixes the payload for REFRESH_DEPOSIT graphile worker jobs

### DIFF
--- a/src/events/deposits.upsert.service.spec.ts
+++ b/src/events/deposits.upsert.service.spec.ts
@@ -308,8 +308,8 @@ describe('DepositsUpsertService', () => {
     it('enqueues refreshDeposit jobs', async () => {
       const operation = depositOperation(
         [transaction1],
-        BlockOperation.DISCONNECTED,
-        'block1Hash',
+        BlockOperation.CONNECTED,
+        uuid(),
       );
 
       await depositsUpsertService.upsert(operation);
@@ -320,7 +320,23 @@ describe('DepositsUpsertService', () => {
 
       await depositsUpsertService.refreshDeposits();
 
-      expect(addJob).toHaveBeenCalledWith('REFRESH_DEPOSIT', expect.anything());
+      expect(addJob).toHaveBeenCalledWith(
+        'REFRESH_DEPOSIT',
+        expect.objectContaining({
+          id: expect.any(Number),
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+          transaction_hash: expect.any(String),
+          block_hash: expect.any(String),
+          graffiti: expect.any(String),
+          block_sequence: expect.any(Number),
+          network_version: expect.any(Number),
+          main: expect.any(Boolean),
+          amount: expect.any(Number),
+          block_main: null,
+          block_timestamp: null,
+        }),
+      );
     });
   });
 

--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -214,9 +214,7 @@ export class DepositsUpsertService {
     for (const deposit of mismatchedDeposits) {
       await this.graphileWorkerService.addJob(
         GraphileWorkerPattern.REFRESH_DEPOSIT,
-        {
-          mismatchedDeposit: deposit,
-        },
+        deposit,
       );
     }
   }


### PR DESCRIPTION
## Summary

- uses deposit object as payload instead of nesting within another object
- amends unit tests to set expectations on the fiels of the payload object

## Testing Plan

- synced blocks and deposits to local API
- created mismatched deposits in local DB
- ran /deposits/refresh locally, observed successful jobs

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
