### PR TITLE
limits concurrency of UPDATE_LATEST_POINTS jobs

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -578,7 +578,10 @@ describe('EventsService', () => {
           userId: user.id,
           type: EventType.BLOCK_MINED,
         },
-        expect.anything(),
+        expect.objectContaining({
+          jobKey: expect.any(String),
+          queueName: expect.any(String),
+        }),
       );
 
       const userPoints = await userPointsService.findOrThrow(user.id);
@@ -717,7 +720,10 @@ describe('EventsService', () => {
           userId: user.id,
           type: EventType.PULL_REQUEST_MERGED,
         },
-        expect.anything(),
+        expect.objectContaining({
+          jobKey: expect.any(String),
+          queueName: expect.any(String),
+        }),
       );
 
       assert.ok(event);
@@ -823,7 +829,10 @@ describe('EventsService', () => {
             userId: user.id,
             type: EventType.BLOCK_MINED,
           },
-          expect.anything(),
+          expect.objectContaining({
+            jobKey: expect.any(String),
+            queueName: expect.any(String),
+          }),
         );
 
         const userPoints = await userPointsService.findOrThrow(user.id);
@@ -862,7 +871,10 @@ describe('EventsService', () => {
           userId: user.id,
           type: EventType.BLOCK_MINED,
         },
-        expect.anything(),
+        expect.objectContaining({
+          jobKey: expect.any(String),
+          queueName: expect.any(String),
+        }),
       );
 
       const userPoints = await userPointsService.findOrThrow(user.id);
@@ -886,7 +898,10 @@ describe('EventsService', () => {
           userId: user.id,
           type: EventType.BLOCK_MINED,
         },
-        expect.anything(),
+        expect.objectContaining({
+          jobKey: expect.any(String),
+          queueName: expect.any(String),
+        }),
       );
 
       const updatedUserPoints = await userPointsService.findOrThrow(user.id);

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -520,11 +520,14 @@ export class EventsService {
     userId: number,
     type: EventType,
   ): Promise<Job> {
+    const updateLatestPointsQueues = 4;
+    const queueNumber = Math.floor(Math.random() * updateLatestPointsQueues);
     return this.graphileWorkerService.addJob(
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
       { userId, type },
       {
         jobKey: `ulp:${userId}:${type}`,
+        queueName: `update_latest_points_${queueNumber}`,
       },
     );
   }


### PR DESCRIPTION
## Summary

concurrent jobs are contending with one another and with UPSERT_DEPOSIT jobs for
access to the `events` table. limiting concurrency may help to reduce the error
rate and to reduce the time each job spends waiting to acquire a transaction
lock.

- adds queues for UPDATE_LATEST_POINTS jobs
- each job randomly added to one of four queues

## Testing Plan

- updated unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
