### PR TITLE
throttles UPDATE_LATEST_POINTS for each job key

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -580,7 +580,9 @@ describe('EventsService', () => {
         },
         expect.objectContaining({
           jobKey: expect.any(String),
+          jobKeyMode: expect.any(String),
           queueName: expect.any(String),
+          runAt: expect.any(Date),
         }),
       );
 
@@ -722,7 +724,9 @@ describe('EventsService', () => {
         },
         expect.objectContaining({
           jobKey: expect.any(String),
+          jobKeyMode: expect.any(String),
           queueName: expect.any(String),
+          runAt: expect.any(Date),
         }),
       );
 
@@ -831,7 +835,9 @@ describe('EventsService', () => {
           },
           expect.objectContaining({
             jobKey: expect.any(String),
+            jobKeyMode: expect.any(String),
             queueName: expect.any(String),
+            runAt: expect.any(Date),
           }),
         );
 
@@ -873,7 +879,9 @@ describe('EventsService', () => {
         },
         expect.objectContaining({
           jobKey: expect.any(String),
+          jobKeyMode: expect.any(String),
           queueName: expect.any(String),
+          runAt: expect.any(Date),
         }),
       );
 
@@ -900,7 +908,9 @@ describe('EventsService', () => {
         },
         expect.objectContaining({
           jobKey: expect.any(String),
+          jobKeyMode: expect.any(String),
           queueName: expect.any(String),
+          runAt: expect.any(Date),
         }),
       );
 

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -521,13 +521,20 @@ export class EventsService {
     type: EventType,
   ): Promise<Job> {
     const updateLatestPointsQueues = 4;
+    const maxJobFrequencyMinutes = 10;
+
     const queueNumber = Math.floor(Math.random() * updateLatestPointsQueues);
+    const runAt = new Date();
+    runAt.setMinutes(runAt.getMinutes() + maxJobFrequencyMinutes);
+
     return this.graphileWorkerService.addJob(
       GraphileWorkerPattern.UPDATE_LATEST_POINTS,
       { userId, type },
       {
         jobKey: `ulp:${userId}:${type}`,
+        jobKeyMode: `preserve_run_at`,
         queueName: `update_latest_points_${queueNumber}`,
+        runAt: runAt,
       },
     );
   }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -534,7 +534,7 @@ export class EventsService {
         jobKey: `ulp:${userId}:${type}`,
         jobKeyMode: `preserve_run_at`,
         queueName: `update_latest_points_${queueNumber}`,
-        runAt: runAt,
+        runAt,
       },
     );
   }

--- a/src/graphile-worker/interfaces/graphile-worker-job-options.ts
+++ b/src/graphile-worker/interfaces/graphile-worker-job-options.ts
@@ -5,4 +5,5 @@ export interface GraphileWorkerJobOptions {
   queueName?: string;
   runAt?: Date;
   jobKey?: string;
+  jobKeyMode?: 'replace' | 'preserve_run_at' | 'unsafe_dedupe';
 }


### PR DESCRIPTION
## Summary

a large percentage of `UPDATE_LATEST_POINTS` jobs share the same jobKey. the
jobKey prevents duplicate jobs from being queued, but jobs for some users and
event types are queued so frequently that there is almost always one in the
queue.

- sets runAt to defer job execution by 10 minutes
- adds jobKeyMode argument to addJob
- uses jobKeyMode=preserve_run_at to throttle jobs with the same jobKey

## Testing Plan

- updated unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
