### PR TITLE
passes jobKeyMode argument through to workerUtils

### DIFF
--- a/src/graphile-worker/graphile-worker.service.ts
+++ b/src/graphile-worker/graphile-worker.service.ts
@@ -19,12 +19,13 @@ export class GraphileWorkerService {
   async addJob<T = unknown>(
     pattern: GraphileWorkerPattern,
     payload?: T,
-    { queueName, runAt, jobKey }: GraphileWorkerJobOptions = {},
+    { queueName, runAt, jobKey, jobKeyMode }: GraphileWorkerJobOptions = {},
   ): Promise<Job> {
     await this.initWorkerUtils();
 
     return this.workerUtils.addJob(pattern.toString(), payload, {
       jobKey: jobKey || `job_${uuid()}`,
+      jobKeyMode,
       queueName,
       runAt,
     });


### PR DESCRIPTION
## Summary

- without this change jobKeyMode is not set when a job is enqueued

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
