### PR TITLE
sets deleted_at to null when upserting events

### DIFF
--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -226,8 +226,10 @@ export class DepositsUpsertService {
       ON deposits.id = events.deposit_id
       WHERE
         (blocks.hash IS NULL AND deposits.main) OR
-        blocks.main <> deposits.main OR
-        ((blocks.main OR deposits.main) AND events.deleted_at IS NOT NULL) AND
+        (
+          blocks.main <> deposits.main OR
+          ((blocks.main OR deposits.main) AND events.deleted_at IS NOT NULL)
+        ) AND
         (
           blocks.hash IS NULL OR
           blocks.sequence <= ${blocksHead.sequence - beforeSequence}

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -484,10 +484,11 @@ export class EventsService {
       const pointDifference = adjustedPoints - existingEvent.points;
 
       // Only update event points if necessary
-      if (pointDifference !== 0) {
+      if (pointDifference !== 0 || existingEvent.deleted_at) {
         existingEvent = await client.event.update({
           data: {
             points: adjustedPoints,
+            deleted_at: null,
           },
           where: {
             id: existingEvent.id,


### PR DESCRIPTION
## Summary

- changes behavior of `EventsService.createWithClient` to revive previously
  soft-deleted events. this un-soft-deletes events from blocks or transactions
  re-orged back onto the main chain.

- updates refreshDeposits to find cases where events.deleted_at is null but
  deposits.main is true

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
