### PR TITLE
Fix performance of Events list

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -64,13 +64,7 @@ export class EventsService {
       occurred_at: Prisma.SortOrder.desc,
     };
     const skip = cursorId ? 1 : 0;
-    const where: {
-      user_id?: number;
-      deleted_at: null;
-      id?: {
-        [key: string]: number;
-      };
-    } = {
+    const where: Prisma.EventWhereInput = {
       user_id: options.userId,
       deleted_at: null,
     };

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -300,6 +300,9 @@ export class EventsService {
       _sum: {
         points: true,
       },
+      _count: {
+        points: true,
+      },
       where: {
         type,
         user_id: id,
@@ -307,13 +310,7 @@ export class EventsService {
       },
     });
     return {
-      count: await this.prisma.event.count({
-        where: {
-          type,
-          user_id: id,
-          deleted_at: null,
-        },
-      }),
+      count: aggregate._count.points || 0,
       points: aggregate._sum.points || 0,
     };
   }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -136,7 +136,7 @@ export class EventsService {
     }
 
     const [nextRecords = [], previousRecords = []] = await Promise.all([
-      await this.prisma.event.findMany({
+      this.prisma.event.findMany({
         where: {
           ...where,
           id: {
@@ -146,7 +146,7 @@ export class EventsService {
         orderBy,
         take: 1,
       }),
-      await this.prisma.event.findMany({
+      this.prisma.event.findMany({
         where: {
           ...where,
           id: {

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -410,6 +410,9 @@ export class EventsService {
       _sum: {
         points: true,
       },
+      _count: {
+        points: true,
+      },
       where: {
         type,
         user_id: id,
@@ -418,14 +421,7 @@ export class EventsService {
       },
     });
     return {
-      count: await this.prisma.event.count({
-        where: {
-          type,
-          user_id: id,
-          deleted_at: null,
-          ...dateFilter,
-        },
-      }),
+      count: aggregate._count.points || 0,
       points: aggregate._sum.points || 0,
     };
   }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -57,20 +57,26 @@ export class EventsService {
     hasPrevious: boolean;
   }> {
     const cursorId = options.before ?? options.after;
-    const cursor = cursorId ? { id: cursorId } : undefined;
     const direction = options.before !== undefined ? -1 : 1;
     const limit =
       direction * Math.min(MAX_LIMIT, options.limit || DEFAULT_LIMIT);
     const orderBy = {
       occurred_at: Prisma.SortOrder.desc,
     };
-    const skip = cursor ? 1 : 0;
+    const skip = cursorId ? 1 : 0;
+    const fn = options.before ? 'gte' : 'lte';
     const where = {
       user_id: options.userId,
       deleted_at: null,
+      ...(cursorId
+        ? {
+            id: {
+              [fn]: cursorId,
+            },
+          }
+        : {}),
     };
     const records = await this.prisma.event.findMany({
-      cursor,
       orderBy,
       skip,
       take: limit,
@@ -128,20 +134,29 @@ export class EventsService {
         hasPrevious: false,
       };
     }
-    const nextRecords = await this.prisma.event.findMany({
-      where,
-      orderBy,
-      cursor: { id: data[length - 1].id },
-      skip: 1,
-      take: 1,
-    });
-    const previousRecords = await this.prisma.event.findMany({
-      where,
-      orderBy,
-      cursor: { id: data[0].id },
-      skip: 1,
-      take: -1,
-    });
+
+    const [nextRecords = [], previousRecords = []] = await Promise.all([
+      await this.prisma.event.findMany({
+        where: {
+          ...where,
+          id: {
+            lt: data[length - 1].id,
+          },
+        },
+        orderBy,
+        take: 1,
+      }),
+      await this.prisma.event.findMany({
+        where: {
+          ...where,
+          id: {
+            gt: data[0].id,
+          },
+        },
+        orderBy,
+        take: 1,
+      }),
+    ]);
     return {
       hasNext: nextRecords.length > 0,
       hasPrevious: previousRecords.length > 0,


### PR DESCRIPTION
## Summary

I am fixing an issue with API performance on the Users page as described in https://github.com/iron-fish/website-testnet/issues/271 for users with a large number of events.

Cursor paginating (in Prisma implementation) is becoming very heavy for many entries since it fetches all available rows from DB and limits the result on the client side.
Proposed changes query DB almost in the same way cursor pagination is intended to work, including `limit` in the SQL query.

See performance for `/events` route:

Before changes - ~6sec:
<img width="1079" alt="Screen Shot 2022-07-23 at 19 59 34" src="https://user-images.githubusercontent.com/1768919/180615378-2d95165c-eabb-4ce9-8bdf-a1ddf04109ea.png">

After - ~440ms:
<img width="977" alt="Screen Shot 2022-07-23 at 20 00 14" src="https://user-images.githubusercontent.com/1768919/180615389-a09345c3-ad8c-4c88-bca3-9de6c7a3d95d.png">


UPD:
`/metrics` route also was performing poorly on a big amount of events:
Before:
![Screen Shot 2022-07-26 at 12 55 30](https://user-images.githubusercontent.com/1768919/180982026-95558f90-749b-4c52-a042-d91bc271400b.png)

After:
![Screen Shot 2022-07-26 at 13 06 55](https://user-images.githubusercontent.com/1768919/180982062-b4be1059-6c94-4a24-b4c9-29a84effb20f.png)


## Testing Plan

Tests are passing without changes

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
