### PR TITLE
Use occurred_at field as cursor

### DIFF
--- a/src/events/dto/events-query.dto.ts
+++ b/src/events/dto/events-query.dto.ts
@@ -3,14 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import {
-  IsInt,
-  IsISO8601,
-  IsNumber,
-  IsOptional,
-  Max,
-  Min,
-} from 'class-validator';
+import { IsDate, IsInt, IsNumber, IsOptional, Max, Min } from 'class-validator';
 
 export class EventsQueryDto {
   @ApiPropertyOptional({ description: 'Unique User identifier' })
@@ -24,20 +17,20 @@ export class EventsQueryDto {
     description:
       'An object identifier to use as a cursor pagination to fetch records after',
   })
-  @IsISO8601()
+  @IsDate()
   @IsOptional()
-  @Type(() => String)
-  readonly after?: string;
+  @Type(() => Date)
+  readonly after?: Date;
 
   @ApiPropertyOptional({
     description:
       'An object identifier to use as a cursor pagination to fetch records before',
   })
   @ApiPropertyOptional()
-  @IsISO8601()
+  @IsDate()
   @IsOptional()
-  @Type(() => String)
-  readonly before?: string;
+  @Type(() => Date)
+  readonly before?: Date;
 
   @ApiPropertyOptional({
     description: 'A limit on the number of objects to return between 1 and 100',

--- a/src/events/dto/events-query.dto.ts
+++ b/src/events/dto/events-query.dto.ts
@@ -3,14 +3,49 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, Max } from 'class-validator';
-import { PaginationArgsDto } from '../../common/dto/pagination-args.dto';
+import {
+  IsInt,
+  IsISO8601,
+  IsNumber,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
 
-export class EventsQueryDto extends PaginationArgsDto {
+export class EventsQueryDto {
   @ApiPropertyOptional({ description: 'Unique User identifier' })
   @IsInt()
   @IsOptional()
   @Max(Number.MAX_SAFE_INTEGER)
   @Type(() => Number)
   readonly user_id?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'An object identifier to use as a cursor pagination to fetch records after',
+  })
+  @IsISO8601()
+  @IsOptional()
+  @Type(() => String)
+  readonly after?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'An object identifier to use as a cursor pagination to fetch records before',
+  })
+  @ApiPropertyOptional()
+  @IsISO8601()
+  @IsOptional()
+  @Type(() => String)
+  readonly before?: string;
+
+  @ApiPropertyOptional({
+    description: 'A limit on the number of objects to return between 1 and 100',
+  })
+  @Max(100)
+  @Min(1)
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  readonly limit?: number;
 }

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -179,10 +179,8 @@ describe('EventsService', () => {
           });
 
           for (let i = 1; i < records.length; i++) {
-            expect(
-              records[i - 1].occurred_at.getUTCMilliseconds(),
-            ).toBeGreaterThanOrEqual(
-              records[i].occurred_at.getUTCMilliseconds(),
+            expect(records[i - 1].occurred_at.valueOf()).toBeGreaterThanOrEqual(
+              records[i].occurred_at.valueOf(),
             );
           }
 

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -211,13 +211,15 @@ describe('EventsService', () => {
         it('returns records before the cursor', async () => {
           const { events, user } = await setup();
           events.reverse();
-          const lastEventId = events[0].id;
+          const lastEventOccurredAt = events[0].occurred_at;
           const { data: records } = await eventsService.list({
             userId: user.id,
-            before: lastEventId,
+            before: lastEventOccurredAt,
           });
           for (const record of records) {
-            expect(record.id).toBeLessThan(lastEventId);
+            expect(record.occurred_at.valueOf()).toBeLessThan(
+              lastEventOccurredAt.valueOf(),
+            );
             expect(record.user_id).toBe(user.id);
           }
         });
@@ -226,13 +228,15 @@ describe('EventsService', () => {
       describe('with the after cursor', () => {
         it('returns records after the cursor', async () => {
           const { events, user } = await setup();
-          const firstEventId = events[0].id;
+          const firstEventOccurredAt = events[0].occurred_at;
           const { data: records } = await eventsService.list({
             userId: user.id,
-            after: firstEventId,
+            after: firstEventOccurredAt,
           });
           for (const record of records) {
-            expect(record.id).toBeGreaterThan(firstEventId);
+            expect(record.occurred_at.valueOf()).toBeGreaterThan(
+              firstEventOccurredAt.valueOf(),
+            );
             expect(record.user_id).toBe(user.id);
           }
         });

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -71,9 +71,9 @@ export class EventsService {
 
     if (cursorId) {
       if (options.before) {
-        where.id = { gte: cursorId };
+        where.occurred_at = { gte: cursorId };
       } else {
-        where.id = { lte: cursorId };
+        where.occurred_at = { lte: cursorId };
       }
     }
 
@@ -136,22 +136,22 @@ export class EventsService {
       };
     }
 
-    const nextRecords = await this.prisma.event.findMany({
+    const nextRecords = await this.prisma.event.count({
       where: {
         ...where,
-        id: {
-          lt: data[length - 1].id,
+        occurred_at: {
+          lt: data[length - 1].occurred_at,
         },
       },
       orderBy,
       take: 1,
     });
 
-    const previousRecords = await this.prisma.event.findMany({
+    const previousRecords = await this.prisma.event.count({
       where: {
         ...where,
-        id: {
-          gt: data[0].id,
+        occurred_at: {
+          gt: data[0].occurred_at,
         },
       },
       orderBy,
@@ -159,8 +159,8 @@ export class EventsService {
     });
 
     return {
-      hasNext: nextRecords.length > 0,
-      hasPrevious: previousRecords.length > 0,
+      hasNext: nextRecords > 0,
+      hasPrevious: previousRecords > 0,
     };
   }
 

--- a/src/events/interfaces/list-events-options.ts
+++ b/src/events/interfaces/list-events-options.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export interface ListEventsOptions {
-  after?: string;
-  before?: string;
+  after?: Date;
+  before?: Date;
   userId?: number;
   limit?: number;
 }

--- a/src/events/interfaces/list-events-options.ts
+++ b/src/events/interfaces/list-events-options.ts
@@ -1,8 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { PaginationOptions } from '../../common/interfaces/pagination-options';
 
-export interface ListEventsOptions extends PaginationOptions {
+export interface ListEventsOptions {
+  after?: string;
+  before?: string;
   userId?: number;
+  limit?: number;
 }


### PR DESCRIPTION
## Summary

Use `event`s `occurred_at` property as a cursor, since events are always ordered by `occurred_at`.
Previously used `id` as cursor didn't work well when an event was added with `occurred_at` in the past. Its `id` was greater than a more recent event. This led to fetching an incorrect list of events.

## Testing Plan

## Breaking Change

Needs the front-end part to be updated as well.  

- [ ] Yes
