### PR TITLE
Add ability to skip measurements in telemetry

### DIFF
--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -52,6 +52,10 @@ export class TelemetryController {
       }
       nodeVersion = version.value;
 
+      if (this.getSkippedMeasurements().includes(measurement)) {
+        continue;
+      }
+
       options.push({
         fields,
         measurement,
@@ -88,6 +92,11 @@ export class TelemetryController {
         await this.nodeUptimes.addUptime(user);
       }
     }
+  }
+
+  private getSkippedMeasurements(): string[] {
+    const measurements = this.config.get<string>('SKIP_MEASUREMENTS');
+    return measurements ? measurements.split(',') : [];
   }
 
   private isValidTelemetryVersion(version: string): boolean {

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -95,7 +95,10 @@ export class TelemetryController {
   }
 
   private getSkippedMeasurements(): string[] {
-    const measurements = this.config.get<string>('SKIP_MEASUREMENTS');
+    const measurements = this.config.getWithDefault<string>(
+      'SKIP_MEASUREMENTS',
+      '',
+    );
     return measurements ? measurements.split(',') : [];
   }
 


### PR DESCRIPTION
## Summary
We are running up against InfluxDB usage limits. There are some measurements we are not using currently but still want to keep in telemetry so we don't have to do another release if we remove them. This allows us to keep them in telemetry but not upload to influx

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
