### PR TITLE
Add telemetry whitelisting

### DIFF
--- a/src/telemetry/dto/write-telemetry-points.dto.ts
+++ b/src/telemetry/dto/write-telemetry-points.dto.ts
@@ -30,7 +30,7 @@ class TagDto {
   readonly value!: string;
 }
 
-class WriteTelemetryPointDto {
+export class WriteTelemetryPointDto {
   @IsArray()
   @ArrayMaxSize(3000)
   @ValidateNested({ each: true })

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -26,7 +26,7 @@ import {
 /** How many blocks per sequence for block_propagation measurement to allow through telemetry */
 export const BLOCK_PROPAGATION_INTERVAL = 5;
 
-const TELEMETRY_WHITELIST = new Map<string, true | RegExp | Array<string>>([
+const TELEMETRY_WHITELIST = new Map<string, true | Array<string>>([
   ['block_mined', true],
   ['block_propagation', true],
   ['node_started', true],
@@ -142,13 +142,7 @@ export class TelemetryController {
       }
 
       const fields = point.fields.filter((field) => {
-        if (filters === true) {
-          return true;
-        } else if (filters instanceof RegExp) {
-          return filters.test(field.name);
-        } else {
-          return filters.includes(field.name);
-        }
+        return filters === true || filters.includes(field.name);
       });
 
       options.push({


### PR DESCRIPTION
## Summary

This whitelists all telemetry points. If you want telemetry in here,
you'll need to submit a code review after you submit it to the node
to let it through into our influx instance.

Likewise, we now only let every 5th block_propagation block sequence
point through.

## Testing Plan
Run new tests, and watch our influx dashboard.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
