### PR TITLE
Don't queue mined block events unless its enabled

### DIFF
--- a/src/blocks-transactions-loader/blocks-transactions-loader.module.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.module.ts
@@ -5,6 +5,7 @@ import { Module } from '@nestjs/common';
 import { BlocksModule } from '../blocks/blocks.module';
 import { BlocksDailyModule } from '../blocks-daily/blocks-daily.module';
 import { BlocksTransactionsModule } from '../blocks-transactions/blocks-transactions.module';
+import { EventsModule } from '../events/events.module';
 import { GraphileWorkerModule } from '../graphile-worker/graphile-worker.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { TransactionsModule } from '../transactions/transactions.module';
@@ -19,6 +20,7 @@ import { BlocksTransactionsLoader } from './blocks-transactions-loader';
     GraphileWorkerModule,
     PrismaModule,
     TransactionsModule,
+    EventsModule,
   ],
   providers: [BlocksTransactionsLoader],
 })

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -593,15 +593,10 @@ export class EventsService {
   }
 
   async upsertBlockMined(block: Block, user: User): Promise<Event | null> {
-    // https://ironfish.network/blog/2022/03/07/incentivized-testnet-roadmap
-    const endOfPhaseOneSequence = 150000;
-    const allowBlockMinedPoints = this.config.get<boolean>(
-      'ALLOW_BLOCK_MINED_POINTS',
-    );
-
-    if (!allowBlockMinedPoints || block.sequence > endOfPhaseOneSequence) {
+    if (!this.blockMinedEnabled(block.sequence)) {
       return null;
     }
+
     return this.create({
       blockId: block.id,
       occurredAt: block.timestamp,
@@ -744,5 +739,17 @@ export class EventsService {
       },
       client,
     );
+  }
+
+  /**
+   * https://ironfish.network/blog/2022/03/07/incentivized-testnet-roadmap
+   */
+  blockMinedEnabled(sequence: number): boolean {
+    const endOfPhaseOneSequence = 150000;
+    const allowBlockMinedPoints = this.config.get<boolean>(
+      'ALLOW_BLOCK_MINED_POINTS',
+    );
+
+    return allowBlockMinedPoints && sequence <= endOfPhaseOneSequence;
   }
 }


### PR DESCRIPTION
## Summary
Try to not queue `DELETE_BLOCK_MINED_EVENT` and `UPSERT_BLOCK_MINED_EVENT` if these events are disabled at the current block height.

## Testing Plan
None

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
