### PR TITLE
Add RSS metric to telemetry whitelist

### DIFF
--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -36,6 +36,7 @@ const TELEMETRY_WHITELIST = new Map<string, true | Array<string>>([
       'heap_total',
       'heap_used',
       'peers_count',
+      'rss',
       'session_id',
       'node_id',
       'mempool_size',


### PR DESCRIPTION
## Summary
Adds RSS metric to telemetry whitelist

## Testing Plan
Run tests, and watch influx dashboard.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
