### PR TITLE
Whitelist forks_count metric in telemetry

### DIFF
--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -75,6 +75,7 @@ const TELEMETRY_WHITELIST = new Map<string, true | Array<string>>([
   ],
   ['transaction_propagation', true],
   ['block_assembled', true],
+  ['forks_count', true],
 ]);
 
 @Controller('telemetry')


### PR DESCRIPTION
## Summary

Whitelist `forks_count` metric in telemetry.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
