### PR TITLE
Move some aggregations and counts over to the read replica

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -297,7 +297,7 @@ export class EventsService {
     { id }: User,
     type: EventType,
   ): Promise<SerializedEventMetrics> {
-    const aggregate = await this.prisma.event.aggregate({
+    const aggregate = await this.prisma.readClient.event.aggregate({
       _sum: {
         points: true,
       },
@@ -333,7 +333,7 @@ export class EventsService {
     eventMetrics: Record<EventType, SerializedEventMetrics>;
     points: number;
   }> {
-    const pointsAggregate = await this.prisma.event.aggregate({
+    const pointsAggregate = await this.prisma.readClient.event.aggregate({
       _sum: {
         points: true,
       },
@@ -407,7 +407,7 @@ export class EventsService {
         lt: end,
       },
     };
-    const aggregate = await this.prisma.event.aggregate({
+    const aggregate = await this.prisma.readClient.event.aggregate({
       _sum: {
         points: true,
       },
@@ -663,7 +663,7 @@ export class EventsService {
   ): Promise<SerializedEventMetrics> {
     const rank = await this.getLifetimeEventsRankForUser(user, events);
 
-    const count = await this.prisma.event.count({
+    const count = await this.prisma.readClient.event.count({
       where: {
         type: {
           in: events,

--- a/src/node-uptimes/node-uptimes.service.ts
+++ b/src/node-uptimes/node-uptimes.service.ts
@@ -71,7 +71,7 @@ export class NodeUptimesService {
   }
 
   async get(user: User): Promise<NodeUptime | null> {
-    return this.getWithClient(user, this.prisma);
+    return this.getWithClient(user, this.prisma.readClient);
   }
 
   async getWithClient(

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -10,7 +10,7 @@ export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
-  private readonly readClient: PrismaClient;
+  readonly readClient: PrismaClient;
 
   constructor(readonly config: ApiConfigService) {
     super({

--- a/src/user-points/user-points.service.ts
+++ b/src/user-points/user-points.service.ts
@@ -12,7 +12,7 @@ export class UserPointsService {
   constructor(private readonly prisma: PrismaService) {}
 
   async findOrThrow(userId: number): Promise<UserPoints> {
-    const record = await this.prisma.userPoints.findUnique({
+    const record = await this.prisma.readClient.userPoints.findUnique({
       where: {
         user_id: userId,
       },


### PR DESCRIPTION
## Summary

I'm not totally sure that this will be helpful, but this change moves the aggregation and counts used when calling /user/metrics over to the read replica. Those queries 
were often timing out on the primary, so it might reduce the load.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
