### PR TITLE
Use read client for events endpoint

### DIFF
--- a/src/blocks-transactions/blocks-transactions.service.ts
+++ b/src/blocks-transactions/blocks-transactions.service.ts
@@ -85,17 +85,18 @@ export class BlocksTransactionsService {
   }
 
   async findTransactionsByBlock(block: Block): Promise<Transaction[]> {
-    const blocksTransactions = await this.prisma.blockTransaction.findMany({
-      where: {
-        block_id: block.id,
-      },
-      include: {
-        transaction: true,
-      },
-      orderBy: {
-        index: SortOrder.ASC,
-      },
-    });
+    const blocksTransactions =
+      await this.prisma.readClient.blockTransaction.findMany({
+        where: {
+          block_id: block.id,
+        },
+        include: {
+          transaction: true,
+        },
+        orderBy: {
+          index: SortOrder.ASC,
+        },
+      });
     return blocksTransactions.map(
       (blockTransaction) => blockTransaction.transaction,
     );

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -444,7 +444,7 @@ export class BlocksService {
     const networkVersion = this.config.get<number>('NETWORK_VERSION');
 
     if (typeof options === 'number') {
-      return this.prisma.block.findUnique({
+      return this.prisma.readClient.block.findUnique({
         where: {
           id: options,
         },
@@ -453,7 +453,7 @@ export class BlocksService {
 
     const { withTransactions } = options;
     if (options.hash !== undefined) {
-      const block = await this.prisma.block.findFirst({
+      const block = await this.prisma.readClient.block.findFirst({
         where: {
           hash: standardizeHash(options.hash),
           network_version: networkVersion,
@@ -468,7 +468,7 @@ export class BlocksService {
 
       return block;
     } else if (options.sequence !== undefined) {
-      const block = await this.prisma.block.findFirst({
+      const block = await this.prisma.readClient.block.findFirst({
         where: {
           sequence: options.sequence,
           main: true,

--- a/src/events/deposits.service.ts
+++ b/src/events/deposits.service.ts
@@ -10,7 +10,7 @@ export class DepositsService {
   constructor(private readonly prisma: PrismaService) {}
 
   async find(id: number): Promise<Deposit | null> {
-    return this.prisma.deposit.findUnique({
+    return this.prisma.readClient.deposit.findUnique({
       where: {
         id,
       },

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -78,7 +78,7 @@ export class EventsService {
       }
     }
 
-    const records = await this.prisma.event.findMany({
+    const records = await this.prisma.readClient.event.findMany({
       orderBy,
       skip,
       take: limit,
@@ -137,7 +137,7 @@ export class EventsService {
       };
     }
 
-    const nextRecords = await this.prisma.event.findMany({
+    const nextRecords = await this.prisma.readClient.event.findMany({
       where: {
         ...where,
         id: {
@@ -148,7 +148,7 @@ export class EventsService {
       take: 1,
     });
 
-    const previousRecords = await this.prisma.event.findMany({
+    const previousRecords = await this.prisma.readClient.event.findMany({
       where: {
         ...where,
         id: {


### PR DESCRIPTION
## Summary

Using the read client for the metrics endpoint has generally improved the response time of the user profile page on the testnet site, but the events endpoint is still timing out from time to time. Let's try moving that query over as well.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
