### PR TITLE
Use read only slave for updating user points

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -564,7 +564,7 @@ export class EventsService {
   }
 
   async updateLatestPoints(userId: number, type: EventType): Promise<void> {
-    const occurredAtAggregate = await this.prisma.event.aggregate({
+    const occurredAtAggregate = await this.prisma.readClient.event.aggregate({
       _max: {
         occurred_at: true,
       },
@@ -576,7 +576,7 @@ export class EventsService {
     });
     const latestOccurredAt = occurredAtAggregate._max.occurred_at;
 
-    const pointsAggregate = await this.prisma.event.aggregate({
+    const pointsAggregate = await this.prisma.readClient.event.aggregate({
       _sum: {
         points: true,
       },
@@ -588,7 +588,7 @@ export class EventsService {
     });
     const points = pointsAggregate._sum.points ?? 0;
 
-    const totalPointsAggregate = await this.prisma.event.aggregate({
+    const totalPointsAggregate = await this.prisma.readClient.event.aggregate({
       _sum: {
         points: true,
       },


### PR DESCRIPTION
## Summary

This should take some CPU load off the master DB, with the caveat that we might be aggregating incorrect events if the writes haven't propagated yet. However, we can just recalculate everyones points at some interval to make sure we fix up any missing points.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
