### PR TITLE
feat(api): Drop `events.deleted_at`

### DIFF
--- a/prisma/migrations/20221101163714_drop_deleted_at_from_events/migration.sql
+++ b/prisma/migrations/20221101163714_drop_deleted_at_from_events/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `deleted_at` on the `events` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "events" DROP COLUMN "deleted_at";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,6 @@ model Event {
   occurred_at DateTime  @db.Timestamp(6)
   points      Int
   user_id     Int
-  deleted_at  DateTime? @db.Timestamp(6)
   deposit_id  Int?      @unique(map: "uq_events_on_deposit_id")
   block_id    Int?      @unique(map: "uq_events_on_block_id")
   deposit     Deposit?  @relation(fields: [deposit_id], references: [id])

--- a/src/events/deposits.upsert.service.spec.ts
+++ b/src/events/deposits.upsert.service.spec.ts
@@ -195,10 +195,8 @@ describe('DepositsUpsertService', () => {
           },
         });
 
-        //notes([0.1, 3], user2.graffiti)
         expect(user2Events[0].points).toBe(31);
-        expect(user2Events[1].points).toBe(0);
-        expect(user2Events[1].deposit_id).toEqual(user2Deposits[1].id);
+        expect(user2Events[0].deposit_id).toEqual(user2Deposits[0].id);
         expect(user2Deposits[1].amount).toEqual(1 * ORE_TO_IRON);
 
         expect(user1Deposits).toHaveLength(2);

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -676,8 +676,7 @@ describe('EventsService', () => {
         });
         assert(event);
         const eventToDelete = await eventsService.findOrThrow(event.id);
-        const deletedEvent = await eventsService.delete(eventToDelete);
-        expect(deletedEvent.deleted_at).toBeTruthy();
+        await eventsService.delete(eventToDelete);
 
         const newPoints = 500;
         const event2 = await eventsService.create({
@@ -688,7 +687,6 @@ describe('EventsService', () => {
         });
 
         expect(event2?.points).toStrictEqual(newPoints);
-        expect(event2?.deleted_at).toBeFalsy();
       });
     });
 
@@ -809,13 +807,10 @@ describe('EventsService', () => {
     describe('when the event exists', () => {
       it('deletes the record', async () => {
         const { block, event } = await setupBlockMinedWithEvent();
-        const record = await eventsService.deleteBlockMined(block);
-        expect(record).toMatchObject({
-          ...event,
-          deleted_at: expect.any(Date),
-          updated_at: expect.any(Date),
-          points: 0,
-        });
+        await eventsService.deleteBlockMined(block);
+        await expect(eventsService.findOrThrow(event.id)).rejects.toThrow(
+          NotFoundException,
+        );
       });
 
       it('subtracts points from the user total points', async () => {
@@ -850,16 +845,12 @@ describe('EventsService', () => {
   });
 
   describe('delete', () => {
-    it('sets `deleted_at` for the record', async () => {
-      const { event } = await setupBlockMinedWithEvent();
-      const record = await eventsService.delete(event);
-
-      expect(record).toMatchObject({
-        ...event,
-        deleted_at: expect.any(Date),
-        updated_at: expect.any(Date),
-        points: 0,
-      });
+    it('deletes the record', async () => {
+      const { block, event } = await setupBlockMinedWithEvent();
+      await eventsService.deleteBlockMined(block);
+      await expect(eventsService.findOrThrow(event.id)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('subtracts points from the user total points', async () => {
@@ -933,7 +924,6 @@ describe('EventsService', () => {
         type: EventType.NODE_UPTIME,
         points: POINTS_PER_CATEGORY[EventType.NODE_UPTIME],
         user_id: user.id,
-        deleted_at: null,
       });
     });
   });

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -67,7 +67,6 @@ export class EventsService {
     const skip = cursorId ? 1 : 0;
     const where: Prisma.EventWhereInput = {
       user_id: options.userId,
-      deleted_at: null,
     };
 
     if (cursorId) {
@@ -249,7 +248,6 @@ export class EventsService {
       where: {
         type,
         user_id: id,
-        deleted_at: null,
       },
     });
     return {
@@ -307,7 +305,6 @@ export class EventsService {
       where: {
         type,
         user_id: id,
-        deleted_at: null,
       },
     });
     return {
@@ -320,7 +317,6 @@ export class EventsService {
     return this.prisma.event.findFirst({
       where: {
         url,
-        deleted_at: null,
       },
     });
   }
@@ -343,7 +339,6 @@ export class EventsService {
           lt: end,
         },
         user_id: user.id,
-        deleted_at: null,
       },
     });
     return {
@@ -417,7 +412,6 @@ export class EventsService {
       where: {
         type,
         user_id: id,
-        deleted_at: null,
         ...dateFilter,
       },
     });
@@ -507,11 +501,10 @@ export class EventsService {
       const pointDifference = adjustedPoints - existingEvent.points;
 
       // Only update event points if necessary
-      if (pointDifference !== 0 || existingEvent.deleted_at) {
+      if (pointDifference !== 0) {
         existingEvent = await client.event.update({
           data: {
             points: adjustedPoints,
-            deleted_at: null,
           },
           where: {
             id: existingEvent.id,
@@ -571,7 +564,6 @@ export class EventsService {
       where: {
         type,
         user_id: userId,
-        deleted_at: null,
       },
     });
     const latestOccurredAt = occurredAtAggregate._max.occurred_at;
@@ -583,7 +575,6 @@ export class EventsService {
       where: {
         type,
         user_id: userId,
-        deleted_at: null,
       },
     });
     const points = pointsAggregate._sum.points ?? 0;
@@ -594,7 +585,6 @@ export class EventsService {
       },
       where: {
         user_id: userId,
-        deleted_at: null,
       },
     });
     const totalPoints = totalPointsAggregate._sum.points ?? 0;
@@ -642,11 +632,7 @@ export class EventsService {
     event: Event,
     prisma: BasePrismaClient,
   ): Promise<Event> {
-    const updated = await prisma.event.update({
-      data: {
-        deleted_at: new Date().toISOString(),
-        points: 0,
-      },
+    const record = await prisma.event.delete({
       where: {
         id: event.id,
       },
@@ -654,7 +640,7 @@ export class EventsService {
 
     await this.addUpdateLatestPointsJob(event.user_id, event.type);
 
-    return updated;
+    return record;
   }
 
   async getLifetimeEventsMetricsForUser(
@@ -669,7 +655,6 @@ export class EventsService {
           in: events,
         },
         user_id: user.id,
-        deleted_at: null,
       },
     });
 


### PR DESCRIPTION
## Summary

We're not using `deleted_at` and soft deletes are a scam, so we can drop this column. I'll delete all the unused records from production before deploying.

## Testing Plan

Existing unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
