### PR TITLE
feat: points graphile job update, metrics api query counts cache

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -341,55 +341,6 @@ describe('EventsService', () => {
     });
   });
 
-  describe('getLifetimeEventMetricsForUser', () => {
-    it('sums up all the events for the users', async () => {
-      const eventCounts: Record<EventType, number> = {
-        BLOCK_MINED: 4,
-        BUG_CAUGHT: 1,
-        COMMUNITY_CONTRIBUTION: 0,
-        PULL_REQUEST_MERGED: 2,
-        SOCIAL_MEDIA_PROMOTION: 0,
-        NODE_UPTIME: 1,
-        SEND_TRANSACTION: 1,
-      };
-      const user = await usersService.create({
-        email: faker.internet.email(),
-        graffiti: uuid(),
-        country_code: faker.address.countryCode('alpha-3'),
-      });
-
-      for (const [eventType, count] of Object.entries(eventCounts)) {
-        for (let i = 0; i < count; i++) {
-          await prisma.event.create({
-            data: {
-              user_id: user.id,
-              type: EventType[eventType as keyof typeof EventType],
-              occurred_at: new Date(),
-              points: 0,
-            },
-          });
-        }
-      }
-
-      const lifetimeMetrics =
-        await eventsService.getLifetimeEventMetricsForUser(user);
-      const lifetimeCounts = {
-        [EventType.BLOCK_MINED]: lifetimeMetrics[EventType.BLOCK_MINED].count,
-        [EventType.BUG_CAUGHT]: lifetimeMetrics[EventType.BUG_CAUGHT].count,
-        [EventType.COMMUNITY_CONTRIBUTION]:
-          lifetimeMetrics[EventType.COMMUNITY_CONTRIBUTION].count,
-        [EventType.PULL_REQUEST_MERGED]:
-          lifetimeMetrics[EventType.PULL_REQUEST_MERGED].count,
-        [EventType.SOCIAL_MEDIA_PROMOTION]:
-          lifetimeMetrics[EventType.SOCIAL_MEDIA_PROMOTION].count,
-        [EventType.NODE_UPTIME]: lifetimeMetrics[EventType.NODE_UPTIME].count,
-        [EventType.SEND_TRANSACTION]:
-          lifetimeMetrics[EventType.SEND_TRANSACTION].count,
-      };
-      expect(lifetimeCounts).toEqual(eventCounts);
-    });
-  });
-
   describe('getTotalEventMetricsForUser', () => {
     it('returns sums of event counts within the provided time range', async () => {
       const now = new Date();

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -689,6 +689,7 @@ describe('EventsService', () => {
       expect(upsertPoints.mock.calls[0][0].points).toEqual({
         [type]: {
           points,
+          count: 1,
           latestOccurredAt: event.occurred_at,
         },
       });

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -341,6 +341,55 @@ describe('EventsService', () => {
     });
   });
 
+  describe('getLifetimeEventMetricsForUser', () => {
+    it('sums up all the events for the users', async () => {
+      const eventCounts: Record<EventType, number> = {
+        BLOCK_MINED: 4,
+        BUG_CAUGHT: 1,
+        COMMUNITY_CONTRIBUTION: 0,
+        PULL_REQUEST_MERGED: 2,
+        SOCIAL_MEDIA_PROMOTION: 0,
+        NODE_UPTIME: 1,
+        SEND_TRANSACTION: 1,
+      };
+      const user = await usersService.create({
+        email: faker.internet.email(),
+        graffiti: uuid(),
+        country_code: faker.address.countryCode('alpha-3'),
+      });
+
+      for (const [eventType, count] of Object.entries(eventCounts)) {
+        for (let i = 0; i < count; i++) {
+          await prisma.event.create({
+            data: {
+              user_id: user.id,
+              type: EventType[eventType as keyof typeof EventType],
+              occurred_at: new Date(),
+              points: 0,
+            },
+          });
+        }
+      }
+
+      const lifetimeMetrics =
+        await eventsService.getLifetimeEventMetricsForUser(user);
+      const lifetimeCounts = {
+        [EventType.BLOCK_MINED]: lifetimeMetrics[EventType.BLOCK_MINED].count,
+        [EventType.BUG_CAUGHT]: lifetimeMetrics[EventType.BUG_CAUGHT].count,
+        [EventType.COMMUNITY_CONTRIBUTION]:
+          lifetimeMetrics[EventType.COMMUNITY_CONTRIBUTION].count,
+        [EventType.PULL_REQUEST_MERGED]:
+          lifetimeMetrics[EventType.PULL_REQUEST_MERGED].count,
+        [EventType.SOCIAL_MEDIA_PROMOTION]:
+          lifetimeMetrics[EventType.SOCIAL_MEDIA_PROMOTION].count,
+        [EventType.NODE_UPTIME]: lifetimeMetrics[EventType.NODE_UPTIME].count,
+        [EventType.SEND_TRANSACTION]:
+          lifetimeMetrics[EventType.SEND_TRANSACTION].count,
+      };
+      expect(lifetimeCounts).toEqual(eventCounts);
+    });
+  });
+
   describe('getTotalEventMetricsForUser', () => {
     it('returns sums of event counts within the provided time range', async () => {
       const now = new Date();

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -658,19 +658,10 @@ export class EventsService {
   ): Promise<SerializedEventMetrics> {
     const rank = await this.getLifetimeEventsRankForUser(user, events);
 
-    const count = await this.prisma.readClient.event.count({
-      where: {
-        type: {
-          in: events,
-        },
-        user_id: user.id,
-      },
-    });
-
     return {
       rank: rank.rank,
       points: rank.points,
-      count: count,
+      count: rank.count,
     };
   }
 
@@ -684,7 +675,6 @@ export class EventsService {
     const queryCounts = events
       .map((e) => e.toLowerCase() + '_count')
       .join(' + ');
-
     const queryLastOccurredAt = events
       .map((e) => e.toLowerCase() + '_last_occurred_at')
       .join(', ');

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -261,6 +261,63 @@ export class EventsService {
     };
   }
 
+  async getLifetimeEventMetricsForUser(
+    user: User,
+  ): Promise<Record<EventType, SerializedEventMetrics>> {
+    return {
+      BLOCK_MINED: await this.getLifetimeEventTypeMetricsForUser(
+        user,
+        EventType.BLOCK_MINED,
+      ),
+      BUG_CAUGHT: await this.getLifetimeEventTypeMetricsForUser(
+        user,
+        EventType.BUG_CAUGHT,
+      ),
+      COMMUNITY_CONTRIBUTION: await this.getLifetimeEventTypeMetricsForUser(
+        user,
+        EventType.COMMUNITY_CONTRIBUTION,
+      ),
+      PULL_REQUEST_MERGED: await this.getLifetimeEventTypeMetricsForUser(
+        user,
+        EventType.PULL_REQUEST_MERGED,
+      ),
+      SOCIAL_MEDIA_PROMOTION: await this.getLifetimeEventTypeMetricsForUser(
+        user,
+        EventType.SOCIAL_MEDIA_PROMOTION,
+      ),
+      NODE_UPTIME: await this.getLifetimeEventTypeMetricsForUser(
+        user,
+        EventType.NODE_UPTIME,
+      ),
+      SEND_TRANSACTION: await this.getLifetimeEventTypeMetricsForUser(
+        user,
+        EventType.SEND_TRANSACTION,
+      ),
+    };
+  }
+
+  private async getLifetimeEventTypeMetricsForUser(
+    { id }: User,
+    type: EventType,
+  ): Promise<SerializedEventMetrics> {
+    const aggregate = await this.prisma.readClient.event.aggregate({
+      _sum: {
+        points: true,
+      },
+      _count: {
+        points: true,
+      },
+      where: {
+        type,
+        user_id: id,
+      },
+    });
+    return {
+      count: aggregate._count.points || 0,
+      points: aggregate._sum.points || 0,
+    };
+  }
+
   private async getEventByUrl(url: string): Promise<Event | null> {
     return this.prisma.event.findFirst({
       where: {

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -520,12 +520,16 @@ export class EventsService {
       _sum: {
         points: true,
       },
+      _count: {
+        points: true,
+      },
       where: {
         type,
         user_id: userId,
       },
     });
     const points = pointsAggregate._sum.points ?? 0;
+    const count = pointsAggregate._count.points ?? 0;
 
     const totalPointsAggregate = await this.prisma.readClient.event.aggregate({
       _sum: {
@@ -539,7 +543,7 @@ export class EventsService {
 
     await this.userPointsService.upsert({
       userId,
-      points: { [type]: { points, latestOccurredAt } },
+      points: { [type]: { points, count, latestOccurredAt } },
       totalPoints,
     });
   }

--- a/src/user-points/interfaces/upsert-user-points-options.ts
+++ b/src/user-points/interfaces/upsert-user-points-options.ts
@@ -6,7 +6,11 @@ import { EventType } from '.prisma/client';
 export interface UpsertUserPointsOptions {
   userId: number;
   points?: Partial<
-    Record<EventType, { points: number; latestOccurredAt: Date | null }>
+    Record<
+      EventType,
+      { points: number; count: number; latestOccurredAt: Date | null }
+    >
   >;
   totalPoints?: number;
+  totalCount?: number;
 }

--- a/src/user-points/user-points.jobs.controller.spec.ts
+++ b/src/user-points/user-points.jobs.controller.spec.ts
@@ -121,30 +121,37 @@ describe('UserPointsJobsController', () => {
         points: {
           BLOCK_MINED: {
             points: 50,
+            count: 1,
             latestOccurredAt: new Date(),
           },
           BUG_CAUGHT: {
             points: 50,
+            count: 1,
             latestOccurredAt: new Date(),
           },
           COMMUNITY_CONTRIBUTION: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
           PULL_REQUEST_MERGED: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
           SOCIAL_MEDIA_PROMOTION: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
           NODE_UPTIME: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
           SEND_TRANSACTION: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
         },
@@ -172,30 +179,37 @@ describe('UserPointsJobsController', () => {
         points: {
           BLOCK_MINED: {
             points: 50,
+            count: 1,
             latestOccurredAt: new Date(),
           },
           BUG_CAUGHT: {
             points: 50,
+            count: 1,
             latestOccurredAt: new Date(),
           },
           COMMUNITY_CONTRIBUTION: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
           PULL_REQUEST_MERGED: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
           SOCIAL_MEDIA_PROMOTION: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
           NODE_UPTIME: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
           SEND_TRANSACTION: {
             points: 0,
+            count: 0,
             latestOccurredAt: new Date(),
           },
         },

--- a/src/user-points/user-points.service.spec.ts
+++ b/src/user-points/user-points.service.spec.ts
@@ -54,18 +54,22 @@ describe('UserPointsService', () => {
       const points = {
         [EventType.BLOCK_MINED]: {
           points: 100,
+          count: 5,
           latestOccurredAt: new Date(),
         },
         [EventType.PULL_REQUEST_MERGED]: {
           points: 110,
+          count: 5,
           latestOccurredAt: new Date(),
         },
         [EventType.NODE_UPTIME]: {
           points: 150,
+          count: 5,
           latestOccurredAt: new Date(),
         },
         [EventType.SEND_TRANSACTION]: {
           points: 120,
+          count: 5,
           latestOccurredAt: new Date(),
         },
       };

--- a/src/user-points/user-points.service.ts
+++ b/src/user-points/user-points.service.ts
@@ -48,34 +48,41 @@ export class UserPointsService {
       if (blockMined) {
         options.block_mined_last_occurred_at = blockMined.latestOccurredAt;
         options.block_mined_points = blockMined.points;
+        options.block_mined_count = blockMined.count;
       }
       if (bugCaught) {
         options.bug_caught_last_occurred_at = bugCaught.latestOccurredAt;
         options.bug_caught_points = bugCaught.points;
+        options.bug_caught_count = bugCaught.count;
       }
       if (communityContribution) {
         options.community_contribution_last_occurred_at =
           communityContribution.latestOccurredAt;
         options.community_contribution_points = communityContribution.points;
+        options.community_contribution_count = communityContribution.count;
       }
       if (pullRequestMerged) {
         options.pull_request_merged_last_occurred_at =
           pullRequestMerged.latestOccurredAt;
         options.pull_request_merged_points = pullRequestMerged.points;
+        options.pull_request_merged_count = pullRequestMerged.count;
       }
       if (socialMediaPromotion) {
         options.social_media_promotion_last_occurred_at =
           socialMediaPromotion.latestOccurredAt;
         options.social_media_promotion_points = socialMediaPromotion.points;
+        options.social_media_promotion_count = socialMediaPromotion.count;
       }
       if (nodeUptime) {
         options.node_uptime_last_occurred_at = nodeUptime.latestOccurredAt;
         options.node_uptime_points = nodeUptime.points;
+        options.node_uptime_count = nodeUptime.count;
       }
       if (transactionSent) {
         options.send_transaction_last_occurred_at =
           transactionSent.latestOccurredAt;
         options.send_transaction_points = transactionSent.points;
+        options.send_transaction_count = transactionSent.count;
       }
     }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -130,29 +130,82 @@ export class UsersController {
     let nodeUptime: SerializedUserMetrics['node_uptime'];
 
     if (query.granularity === MetricsGranularity.LIFETIME) {
-      eventMetrics = await this.eventsService.getLifetimeEventMetricsForUser(
-        user,
-      );
+      const bugCaughtRankPromise =
+        this.eventsService.getLifetimeEventsRankForUser(user, [
+          EventType.BUG_CAUGHT,
+        ]);
 
-      pools = {
-        main: await this.eventsService.getLifetimeEventsMetricsForUser(user, [
+      const pullRequestRankPromise =
+        this.eventsService.getLifetimeEventsRankForUser(user, [
+          EventType.PULL_REQUEST_MERGED,
+        ]);
+
+      const nodeUptimeRankPromise =
+        this.eventsService.getLifetimeEventsRankForUser(user, [
+          EventType.NODE_UPTIME,
+        ]);
+
+      const sendTransactionRankPromise =
+        this.eventsService.getLifetimeEventsRankForUser(user, [
+          EventType.SEND_TRANSACTION,
+        ]);
+
+      const mainRankPromise =
+        await this.eventsService.getLifetimeEventsRankForUser(user, [
           EventType.BUG_CAUGHT,
           EventType.NODE_UPTIME,
           EventType.SEND_TRANSACTION,
-        ]),
-        code: await this.eventsService.getLifetimeEventsMetricsForUser(user, [
+        ]);
+
+      const codeRanksPromise =
+        await this.eventsService.getLifetimeEventsRankForUser(user, [
           EventType.PULL_REQUEST_MERGED,
-        ]),
+        ]);
+
+      const [
+        bugCaughtRank,
+        pullRequestRank,
+        nodeUptimeRank,
+        sendTransactionRank,
+        codeRank,
+        mainRank,
+      ] = await Promise.all([
+        bugCaughtRankPromise,
+        pullRequestRankPromise,
+        nodeUptimeRankPromise,
+        sendTransactionRankPromise,
+        codeRanksPromise,
+        mainRankPromise,
+      ]);
+
+      const empty = { count: 0, points: 0, rank: 0 };
+
+      eventMetrics = {
+        BUG_CAUGHT: bugCaughtRank,
+        PULL_REQUEST_MERGED: pullRequestRank,
+        NODE_UPTIME: nodeUptimeRank,
+        SEND_TRANSACTION: sendTransactionRank,
+        BLOCK_MINED: empty,
+        COMMUNITY_CONTRIBUTION: empty,
+        SOCIAL_MEDIA_PROMOTION: empty,
       };
+
+      pools = {
+        main: mainRank,
+        code: codeRank,
+      };
+
+      points =
+        bugCaughtRank.points +
+        pullRequestRank.points +
+        nodeUptimeRank.points +
+        sendTransactionRank.points;
 
       const uptime = await this.nodeUptimeService.get(user);
       nodeUptime = {
         total_hours: uptime?.total_hours ?? 0,
         last_checked_in: uptime?.last_checked_in?.toISOString() ?? null,
       };
-
-      const userPoints = await this.userPointsService.findOrThrow(user.id);
-      points = userPoints.total_points;
     } else {
       if (query.start === undefined || query.end === undefined) {
         throw new UnprocessableEntityException(


### PR DESCRIPTION
## Summary
Updates graphile job to update `count` as well as `points`

Also makes `metrics` endpoint query use the value stored in DB rather than redoing aggregation.

## Testing Plan
unittest
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
