### PR TITLE
Increase timeout for uploading blocks from the syncer

### DIFF
--- a/src/blocks-transactions-loader/blocks-transactions-loader.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.ts
@@ -113,7 +113,7 @@ export class BlocksTransactionsLoader {
         {
           // We increased this from the default of 5000 because the transactions were
           // timing out and failing to upsert blocks
-          timeout: 20000,
+          timeout: 30000,
         },
       );
     }


### PR DESCRIPTION
## Summary

Were dying at 20 seconds. We need more time.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
