### PR TITLE
Remove per-transaction upserts and replace with bulk createMany

### DIFF
--- a/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
@@ -44,7 +44,7 @@ describe('BlocksTransactionsLoader', () => {
     jest.clearAllMocks();
   });
 
-  describe('bulkUpsert', () => {
+  describe('createMany', () => {
     it('stores a Block, Transaction, and BlockTransaction record', async () => {
       const blockHash1 = uuid();
       const blockHash2 = uuid();
@@ -58,7 +58,7 @@ describe('BlocksTransactionsLoader', () => {
         notes: [{ commitment: uuid() }],
         spends: [{ nullifier: uuid() }],
       };
-      const blocks = await blocksTransactionsLoader.bulkUpsert({
+      const blocks = await blocksTransactionsLoader.createMany({
         blocks: [
           {
             hash: blockHash1,
@@ -139,7 +139,7 @@ describe('BlocksTransactionsLoader', () => {
           graffiti,
           country_code: faker.address.countryCode('alpha-3'),
         });
-        const blocks = await blocksTransactionsLoader.bulkUpsert({
+        const blocks = await blocksTransactionsLoader.createMany({
           blocks: [
             {
               hash: uuid(),
@@ -172,7 +172,7 @@ describe('BlocksTransactionsLoader', () => {
           graffiti,
           country_code: faker.address.countryCode('alpha-3'),
         });
-        const blocks = await blocksTransactionsLoader.bulkUpsert({
+        const blocks = await blocksTransactionsLoader.createMany({
           blocks: [
             {
               hash: uuid(),
@@ -200,7 +200,7 @@ describe('BlocksTransactionsLoader', () => {
       });
 
       it('queues a job to sync a daily snapshot', async () => {
-        await blocksTransactionsLoader.bulkUpsert({
+        await blocksTransactionsLoader.createMany({
           blocks: [
             {
               hash: uuid(),

--- a/src/blocks/blocks.controller.ts
+++ b/src/blocks/blocks.controller.ts
@@ -54,7 +54,7 @@ export class BlocksController {
   @ApiExcludeEndpoint()
   @Post()
   @UseGuards(ApiKeyGuard)
-  async bulkUpsert(
+  async createMany(
     @Body(
       new ValidationPipe({
         errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
@@ -63,7 +63,7 @@ export class BlocksController {
     )
     upsertBlocksDto: UpsertBlocksDto,
   ): Promise<List<SerializedBlock>> {
-    const blocks = await this.blocksTransactionsLoader.bulkUpsert(
+    const blocks = await this.blocksTransactionsLoader.createMany(
       upsertBlocksDto,
     );
     return {

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -58,7 +58,7 @@ export class TransactionsController {
   @ApiExcludeEndpoint()
   @Post()
   @UseGuards(ApiKeyGuard)
-  async bulkUpsert(
+  async bulkCreate(
     @Body(
       new ValidationPipe({
         errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
@@ -67,7 +67,7 @@ export class TransactionsController {
     )
     upsertTransactionsDto: UpsertTransactionsDto,
   ): Promise<List<SerializedTransaction>> {
-    const transactions = await this.transactionsService.bulkUpsert(
+    const transactions = await this.transactionsService.createMany(
       upsertTransactionsDto.transactions,
     );
     return {

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -51,14 +51,14 @@ describe('TransactionsService', () => {
     return { block };
   };
 
-  describe('bulkUpsert', () => {
+  describe('createMany', () => {
     describe('when a hash does not exist for the network version', () => {
       it('stores a transaction record', async () => {
         const notes = [{ commitment: uuid() }];
         const spends = [{ nullifier: uuid() }];
         const hash = faker.random.alpha({ count: 10, upcase: true });
         expect(hash).toEqual(hash.toUpperCase());
-        const transactions = await transactionsService.bulkUpsertWithClient(
+        const transactions = await transactionsService.createManyWithClient(
           prisma,
           [
             {
@@ -85,7 +85,7 @@ describe('TransactionsService', () => {
       it('updates the transaction record', async () => {
         const notes = [{ commitment: uuid() }];
         const spends = [{ nullifier: uuid() }];
-        const transactions = await transactionsService.bulkUpsertWithClient(
+        const transactions = await transactionsService.createManyWithClient(
           prisma,
           [
             {
@@ -102,7 +102,7 @@ describe('TransactionsService', () => {
         const newNotes = [{ commitment: uuid() }];
         const newSpends = [{ nullifier: uuid() }];
         const transaction = transactions[0];
-        const newTransactions = await transactionsService.bulkUpsertWithClient(
+        const newTransactions = await transactionsService.createManyWithClient(
           prisma,
           [
             {
@@ -137,7 +137,7 @@ describe('TransactionsService', () => {
             count: 10,
             upcase: true,
           });
-          const transactions = await transactionsService.bulkUpsertWithClient(
+          const transactions = await transactionsService.createManyWithClient(
             prisma,
             [
               {
@@ -184,7 +184,7 @@ describe('TransactionsService', () => {
         it('returns null', async () => {
           const notes = [{ commitment: uuid() }];
           const spends = [{ nullifier: uuid() }];
-          await transactionsService.bulkUpsertWithClient(prisma, [
+          await transactionsService.createManyWithClient(prisma, [
             {
               hash: uuid(),
               fee: faker.datatype.number(),
@@ -209,7 +209,7 @@ describe('TransactionsService', () => {
           const notes = [{ commitment: uuid() }];
           const spends = [{ nullifier: uuid() }];
           const testTransactionHash = uuid();
-          const transactions = await transactionsService.bulkUpsertWithClient(
+          const transactions = await transactionsService.createManyWithClient(
             prisma,
             [
               {
@@ -233,7 +233,7 @@ describe('TransactionsService', () => {
         it('returns null', async () => {
           const notes = [{ commitment: uuid() }];
           const spends = [{ nullifier: uuid() }];
-          await transactionsService.bulkUpsertWithClient(prisma, [
+          await transactionsService.createManyWithClient(prisma, [
             {
               hash: uuid(),
               fee: faker.datatype.number(),
@@ -257,7 +257,7 @@ describe('TransactionsService', () => {
         const testTransactionHash = uuid();
         const notes = [{ commitment: uuid() }];
         const spends = [{ nullifier: uuid() }];
-        const transactions = await transactionsService.bulkUpsertWithClient(
+        const transactions = await transactionsService.createManyWithClient(
           prisma,
           [
             {
@@ -302,7 +302,7 @@ describe('TransactionsService', () => {
         const testTransactionHash = uuid();
         const notes = [{ commitment: uuid() }];
         const spends = [{ nullifier: uuid() }];
-        await transactionsService.bulkUpsertWithClient(prisma, [
+        await transactionsService.createManyWithClient(prisma, [
           {
             hash: testTransactionHash,
             fee: faker.datatype.number(),


### PR DESCRIPTION
## Summary

Transactions are already unique on hash + network version, and transactions should never change once they've been created, so we can use the bulk createMany operation to create Transactions and BlockTransactions.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
