### PR TITLE
fix: Limit CREATE_NODE_UPTIME_EVENT to 1 per user

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -770,10 +770,6 @@ export class EventsService {
     uptime: NodeUptime,
     client: BasePrismaClient,
   ): Promise<number> {
-    // calculate how many events to create
-    // create event payloads
-    // call create many on events
-
     const count = Math.floor(uptime.total_hours / NODE_UPTIME_CREDIT_HOURS);
 
     const payloads = [];

--- a/src/node-uptimes/node-uptimes-loader.spec.ts
+++ b/src/node-uptimes/node-uptimes-loader.spec.ts
@@ -87,32 +87,38 @@ describe('NodeUptimesLoader', () => {
 
     describe('when the uptime has enough hours', () => {
       it('creates event and decrements hours', async () => {
-        const createNodeUptimeEventWithClient = jest.spyOn(
-          eventsService,
-          'createNodeUptimeEventWithClient',
-        );
+        const createNodeUptimeEventWithClient = jest
+          .spyOn(eventsService, 'createNodeUptimeEventWithClient')
+          .mockResolvedValue(435);
+
         const decrementCountedHoursWithClient = jest
           .spyOn(nodeUptimesService, 'decrementCountedHoursWithClient')
           .mockImplementationOnce(jest.fn());
+
         const user = await setupUser();
+
         const uptime = await prisma.nodeUptime.create({
           data: {
             user_id: user.id,
-            total_hours: NODE_UPTIME_CREDIT_HOURS,
+            total_hours: NODE_UPTIME_CREDIT_HOURS * 2 + 1,
           },
         });
         const occurredAt = new Date();
 
         await nodeUptimesLoader.createEvent(user, occurredAt);
+
         expect(createNodeUptimeEventWithClient).toHaveBeenCalledTimes(1);
         expect(createNodeUptimeEventWithClient).toHaveBeenCalledWith(
           user,
           occurredAt,
+          uptime,
           expect.anything(),
         );
+
         expect(decrementCountedHoursWithClient).toHaveBeenCalledTimes(1);
-        expect(decrementCountedHoursWithClient).toHaveBeenLastCalledWith(
+        expect(decrementCountedHoursWithClient).toHaveBeenCalledWith(
           uptime,
+          12 * 435,
           expect.anything(),
         );
       });

--- a/src/node-uptimes/node-uptimes.jobs.controller.ts
+++ b/src/node-uptimes/node-uptimes.jobs.controller.ts
@@ -24,6 +24,7 @@ export class NodeUptimesJobsController {
     occurredAt,
   }: CreateNodeUptimeEventOptions): Promise<GraphileWorkerHandlerResponse> {
     const user = await this.usersService.find(userId);
+
     if (!user) {
       this.loggerService.error(`No user found for '${userId}'`, '');
       return { requeue: false };

--- a/src/node-uptimes/node-uptimes.service.spec.ts
+++ b/src/node-uptimes/node-uptimes.service.spec.ts
@@ -127,17 +127,18 @@ describe('NodeUptimesService', () => {
       const uptime = await prisma.nodeUptime.create({
         data: {
           user_id: user.id,
-          total_hours: 12,
+          total_hours: 24,
         },
       });
 
       const result = await nodeUptimesService.decrementCountedHoursWithClient(
         uptime,
+        12,
         prisma,
       );
 
       assert(result);
-      expect(result.total_hours).toBe(0);
+      expect(result.total_hours).toBe(12);
     });
   });
 });

--- a/src/node-uptimes/node-uptimes.service.ts
+++ b/src/node-uptimes/node-uptimes.service.ts
@@ -34,6 +34,7 @@ export class NodeUptimesService {
       );
 
       let uptime = await this.getWithClient(user, prisma);
+
       if (uptime && uptime.last_checked_in >= lastCheckinCutoff) {
         return uptime;
       }
@@ -59,13 +60,12 @@ export class NodeUptimesService {
     });
 
     if (uptime.total_hours >= NODE_UPTIME_CREDIT_HOURS) {
-      const userId = user.id;
       await this.graphileWorkerService.addJob(
         GraphileWorkerPattern.CREATE_NODE_UPTIME_EVENT,
-        { userId, occurredAt: now },
+        { userId: user.id, occurredAt: now },
         {
           queueName: `update_node_uptime`,
-          jobKey: `update_node_uptime_for_${userId}`,
+          jobKey: `update_node_uptime_for_${user.id}`,
         },
       );
     }
@@ -90,6 +90,7 @@ export class NodeUptimesService {
 
   async decrementCountedHoursWithClient(
     uptime: NodeUptime,
+    hours: number = NODE_UPTIME_CHECKIN_HOURS,
     client: BasePrismaClient,
   ): Promise<NodeUptime> {
     return client.nodeUptime.update({
@@ -98,7 +99,7 @@ export class NodeUptimesService {
       },
       data: {
         total_hours: {
-          decrement: NODE_UPTIME_CREDIT_HOURS,
+          decrement: hours,
         },
       },
     });

--- a/src/node-uptimes/node-uptimes.service.ts
+++ b/src/node-uptimes/node-uptimes.service.ts
@@ -63,7 +63,10 @@ export class NodeUptimesService {
       await this.graphileWorkerService.addJob(
         GraphileWorkerPattern.CREATE_NODE_UPTIME_EVENT,
         { userId, occurredAt: now },
-        { queueName: `update_node_uptime_for_${userId}` },
+        {
+          queueName: `update_node_uptime`,
+          jobKey: `update_node_uptime_for_${userId}`,
+        },
       );
     }
 


### PR DESCRIPTION
## Summary

This limits CREATE_NODE_UPTIME_EVENT jobs to 1 per user instead of 1 queue per user, and many jobs per user.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
