### PR TITLE
Fix upsert updating all deposits when no users

### DIFF
--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -292,21 +292,23 @@ export class DepositsUpsertService {
             depositParams = depositParams.filter((d) => users.has(d.graffiti));
 
             // Deposits are shared between blocks, so we need to reassign all the ones on other blocks
-            await prisma.deposit.updateMany({
-              data: {
-                block_hash: blockHash,
-                main: true,
-              },
-              where: {
-                AND: depositParams.map((deposit) => ({
-                  transaction_hash: deposit.transaction_hash,
-                  graffiti: deposit.graffiti,
-                })),
-                network_version: networkVersion,
-              },
-            });
+            if (depositParams.length) {
+              await prisma.deposit.updateMany({
+                data: {
+                  block_hash: blockHash,
+                  main: true,
+                },
+                where: {
+                  AND: depositParams.map((deposit) => ({
+                    transaction_hash: deposit.transaction_hash,
+                    graffiti: deposit.graffiti,
+                  })),
+                  network_version: networkVersion,
+                },
+              });
+            }
 
-            // Now create new not existing deposits
+            // Create new deposits
             await prisma.deposit.createMany({
               data: depositParams,
               skipDuplicates: true,


### PR DESCRIPTION
## Summary

This fixes a very serious API bug that will change the main chain status of all deposits if a deposit comes through with no users found in the DB.

## Testing Plan

Added tests, then fixed the bug.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
