### PR TITLE
feat: exclude users from rankings that have 0 points

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -696,22 +696,6 @@ export class EventsService {
     count: number | null;
     rank: number | null;
   }> {
-    // return early if user doesn't have any points
-    const userPoints = await this.userPointsService.findOrThrow(user.id);
-    const filteredPoints = events
-      .map(
-        (e) =>
-          userPoints[(e.toLowerCase() + '_points') as keyof typeof userPoints],
-      )
-      .reduce((sum, current) => Number(sum) + Number(current), 0);
-    if (filteredPoints === 0) {
-      return {
-        rank: null,
-        points: null,
-        count: null,
-      };
-    }
-
     const queryPoints = events
       .map((e) => e.toLowerCase() + '_points')
       .join(' + ');
@@ -767,13 +751,17 @@ export class EventsService {
     >(query, user.id);
 
     if (rank.length === 0) {
-      throw new Error(`User ${user.id} has no user_points entry`);
+      return {
+        rank: null,
+        points: null,
+        count: null,
+      };
     }
 
     return {
-      rank: rank[0].rank || null,
-      points: rank[0].points || null,
-      count: rank[0].count || null,
+      rank: rank[0].rank,
+      points: rank[0].points,
+      count: rank[0].count,
     };
   }
 

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -702,6 +702,15 @@ export class EventsService {
       .map((e) => e.toLowerCase() + '_last_occurred_at')
       .join(', ');
 
+    // return early if user doesn't have any points
+    const userPoints = await this.userPointsService.findOrThrow(user.id);
+    if (userPoints.total_points === 0) {
+      return {
+        rank: 0,
+        points: 0,
+        count: 0,
+      };
+    }
     const query = `
       WITH user_ranks AS (
         SELECT
@@ -716,10 +725,14 @@ export class EventsService {
           ) as rank
         FROM
           users
-        LEFT JOIN
-          user_points
+        INNER JOIN
+          (
+            SELECT *
+            FROM user_points
+            WHERE total_points != 0
+          ) up
         ON
-          user_points.user_id = users.id
+          up.user_id = users.id
       )
 
       SELECT

--- a/src/events/interfaces/serialized-event-metrics.ts
+++ b/src/events/interfaces/serialized-event-metrics.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export interface SerializedEventMetrics {
-  count: number;
-  points: number;
-  rank?: number;
+  count: number | null;
+  points: number | null;
+  rank?: number | null;
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -349,7 +349,7 @@ describe('UsersController', () => {
           },
         });
       });
-      it('returns 0 for user without any points', async () => {
+      it('returns null for user without any points', async () => {
         const user = await usersService.create({
           email: faker.internet.email(),
           graffiti: uuid(),
@@ -365,10 +365,6 @@ describe('UsersController', () => {
           user_id: user.id,
           granularity: MetricsGranularity.LIFETIME,
           points: 0,
-          node_uptime: {
-            total_hours: 0,
-            last_checked_in: null,
-          },
           pools: {
             main: {
               rank: null,

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -371,14 +371,14 @@ describe('UsersController', () => {
           },
           pools: {
             main: {
-              rank: 0,
-              count: 0,
-              points: 0,
+              rank: null,
+              count: null,
+              points: null,
             },
             code: {
-              rank: 0,
-              count: 0,
-              points: 0,
+              rank: null,
+              count: null,
+              points: null,
             },
           },
         });

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -349,6 +349,40 @@ describe('UsersController', () => {
           },
         });
       });
+      it('returns 0 for user without any points', async () => {
+        const user = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: uuid(),
+          country_code: faker.address.countryCode('alpha-3'),
+        });
+        const { body } = await request(app.getHttpServer())
+          .get(`/users/${user.id}/metrics`)
+          .query({
+            granularity: MetricsGranularity.LIFETIME,
+          });
+
+        expect(body).toMatchObject({
+          user_id: user.id,
+          granularity: MetricsGranularity.LIFETIME,
+          points: 0,
+          node_uptime: {
+            total_hours: 0,
+            last_checked_in: null,
+          },
+          pools: {
+            main: {
+              rank: 0,
+              count: 0,
+              points: 0,
+            },
+            code: {
+              rank: 0,
+              count: 0,
+              points: 0,
+            },
+          },
+        });
+      });
     });
 
     describe('with a valid total request', () => {

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -281,6 +281,41 @@ describe('UsersService', () => {
       expect(records[1].rank).toBe(2);
       expect(records[2].rank).toBe(3);
     });
+    it('excludes users with 0 points', async () => {
+      const graffiti = uuid();
+      const now = new Date();
+
+      const userA = await usersService.create({
+        email: faker.internet.email(),
+        graffiti: graffiti + '-a',
+        country_code: faker.address.countryCode('alpha-3'),
+      });
+
+      await usersService.create({
+        email: faker.internet.email(),
+        graffiti: graffiti + '-b',
+        country_code: faker.address.countryCode('alpha-3'),
+      });
+
+      await eventsService.create({
+        type: EventType.SOCIAL_MEDIA_PROMOTION,
+        userId: userA.id,
+        occurredAt: now,
+        points: 5,
+      });
+      await userPointsService.upsert(
+        await eventsService.getUpsertPointsOptions(userA),
+      );
+
+      const { data: records } = await usersService.listWithRank({
+        eventType: EventType.SOCIAL_MEDIA_PROMOTION,
+        search: graffiti,
+        limit: 3,
+      });
+      expect(records).toHaveLength(1);
+      expect(records[0].id).toEqual(userA.id);
+      expect(records[0].total_points).toBe(5);
+    });
 
     describe(`when 'event_type' is provided`, () => {
       it('returns a chunk of users by event when specified', async () => {

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { User } from '@prisma/client';
 import assert from 'assert';
 import faker from 'faker';
 import { ulid } from 'ulid';
@@ -281,40 +282,54 @@ describe('UsersService', () => {
       expect(records[1].rank).toBe(2);
       expect(records[2].rank).toBe(3);
     });
-    it('excludes users with 0 points', async () => {
+    describe('user filtering', () => {
+      let userA: User;
+      let userB: User;
       const graffiti = uuid();
-      const now = new Date();
+      const noPointsUser = graffiti + '-b';
+      beforeAll(async () => {
+        const now = new Date();
 
-      const userA = await usersService.create({
-        email: faker.internet.email(),
-        graffiti: graffiti + '-a',
-        country_code: faker.address.countryCode('alpha-3'),
+        userA = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: graffiti + '-a',
+          country_code: faker.address.countryCode('alpha-3'),
+        });
+
+        userB = await usersService.create({
+          email: faker.internet.email(),
+          graffiti: noPointsUser,
+          country_code: faker.address.countryCode('alpha-3'),
+        });
+
+        await eventsService.create({
+          type: EventType.SOCIAL_MEDIA_PROMOTION,
+          userId: userA.id,
+          occurredAt: now,
+          points: 5,
+        });
+        await userPointsService.upsert(
+          await eventsService.getUpsertPointsOptions(userA),
+        );
       });
 
-      await usersService.create({
-        email: faker.internet.email(),
-        graffiti: graffiti + '-b',
-        country_code: faker.address.countryCode('alpha-3'),
+      it('excludes 0 point users with no search terms', async () => {
+        const { data: records } = await usersService.listWithRank({
+          eventType: EventType.SOCIAL_MEDIA_PROMOTION,
+        });
+        const ids = records.map((user) => user.id);
+        expect(ids).toContain(userA.id);
+        expect(ids).not.toContain(userB.id);
       });
-
-      await eventsService.create({
-        type: EventType.SOCIAL_MEDIA_PROMOTION,
-        userId: userA.id,
-        occurredAt: now,
-        points: 5,
+      it('includes 0 point user when username is search param', async () => {
+        const { data: records } = await usersService.listWithRank({
+          eventType: EventType.SOCIAL_MEDIA_PROMOTION,
+          search: noPointsUser,
+          limit: 3,
+        });
+        expect(records).toHaveLength(1);
+        expect(records[0].id).toEqual(userB.id);
       });
-      await userPointsService.upsert(
-        await eventsService.getUpsertPointsOptions(userA),
-      );
-
-      const { data: records } = await usersService.listWithRank({
-        eventType: EventType.SOCIAL_MEDIA_PROMOTION,
-        search: graffiti,
-        limit: 3,
-      });
-      expect(records).toHaveLength(1);
-      expect(records[0].id).toEqual(userA.id);
-      expect(records[0].total_points).toBe(5);
     });
 
     describe(`when 'event_type' is provided`, () => {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -253,6 +253,8 @@ export class UsersService {
             )} AS latest_event_occurred_at
           FROM
             user_points
+          WHERE
+            total_points != 0
         ),
         user_ranks as (
           SELECT
@@ -269,7 +271,7 @@ export class UsersService {
             ) AS rank
           FROM
             users
-          JOIN
+          INNER JOIN
             user_latest_events
           ON
             user_latest_events.user_id = users.id

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -253,7 +253,7 @@ export class UsersService {
             )} AS latest_event_occurred_at
           FROM
             user_points
-          ${searchFilter ? '' : 'WHERE total_points != 0'}
+          ${search ? '' : 'WHERE total_points != 0'}
         ),
         user_ranks as (
           SELECT

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -241,19 +241,20 @@ export class UsersService {
     }
 
     const searchFilter = `%${search ?? ''}%`;
+    const totalPointsAt = this.totalPointsAtForUserPoints(eventType);
 
     const query = `
       WITH 
         user_latest_events AS (
           SELECT
             user_id,
-            ${this.totalPointsAtForUserPoints(eventType)} AS total_points,
+            ${totalPointsAt} AS total_points,
             ${this.latestEventOccurredAtForUserPoints(
               eventType,
             )} AS latest_event_occurred_at
           FROM
             user_points
-          ${search ? '' : 'WHERE total_points != 0'}
+          ${search ? '' : 'WHERE ' + totalPointsAt + ' != 0'}
         ),
         user_ranks as (
           SELECT

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -253,8 +253,7 @@ export class UsersService {
             )} AS latest_event_occurred_at
           FROM
             user_points
-          WHERE
-            total_points != 0
+          ${searchFilter ? '' : 'WHERE total_points != 0'}
         ),
         user_ranks as (
           SELECT


### PR DESCRIPTION
## Summary
1. Excludes users from rank list if they have 0 points
2. When user is searched for, return users even if they have no points
3. Lifetime points should return 0 for user (without rank query) if user has no points.

## Testing Plan
Unittest

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
