### PR TITLE
Change submit deposited job to run on read

### DIFF
--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -198,11 +198,12 @@ export class DepositsUpsertService {
   }
 
   async syncDepositedIron(): Promise<void> {
-    const aggregate = await this.prisma.deposit.aggregate({
+    const aggregate = await this.prisma.readClient.deposit.aggregate({
       _sum: {
         amount: true,
       },
     });
+
     this.influxDbService.writePoints([
       {
         measurement: 'deposited_iron',
@@ -219,8 +220,9 @@ export class DepositsUpsertService {
         timestamp: new Date(),
       },
     ]);
+
     const runAt = new Date();
-    runAt.setMinutes(runAt.getMinutes() + 10);
+    runAt.setHours(runAt.getHours() + 6);
     await this.graphileWorkerService.addJob(
       GraphileWorkerPattern.SUBMIT_DEPOSITED_IRON_TO_TELEMETRY,
       {},


### PR DESCRIPTION
## Summary

This query takes 10 minutes to run.. slow it down and also run it on the read slave.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
