### PR TITLE
fix: bigint for deposit amount in postgres

### DIFF
--- a/prisma/migrations/20221122194723_deposit_amount_bigint/migration.sql
+++ b/prisma/migrations/20221122194723_deposit_amount_bigint/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "deposits" ALTER COLUMN "amount" SET DATA TYPE BIGINT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -237,7 +237,7 @@ model Deposit {
   block_sequence   Int
   network_version  Int
   main             Boolean
-  amount           Int
+  amount           BigInt
   event            Event?
 
   @@unique([transaction_hash, graffiti], name: "uq_deposits_on_transaction_hash_and_graffiti", map: "uq_deposits_on_transaction_hash_and_graffiti")


### PR DESCRIPTION
## Summary
Bigint for amount
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
