### PR TITLE
Change Transaction.fee to float (64bit float)

### DIFF
--- a/prisma/migrations/20221125025815_change_number_type_transaction_fee/migration.sql
+++ b/prisma/migrations/20221125025815_change_number_type_transaction_fee/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "transactions" ALTER COLUMN "fee" SET DATA TYPE DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,7 +95,7 @@ model Transaction {
   updated_at          DateTime           @default(now()) @updatedAt @db.Timestamp(6)
   hash                String             @db.VarChar
   network_version     Int
-  fee                 Int
+  fee                 Float
   size                Int
   notes               Json
   spends              Json


### PR DESCRIPTION
## Summary

A 32 bit integer is not enough to store the fee.

```
Error occurred during query execution: ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Error { kind: ToSql(3), cause: Some(Error { kind: ConversionError("Unable to fit integer value '-4140884682' into an INT4 (32-bit signed integer)."), original_code: None, original_message: None }) }) })
    at RequestHandler.handleRequestError (/app/node_modules/@prisma/client/runtime/index.js:34314:13)
    at RequestHandler.request (/app/node_modules/@prisma/client/runtime/index.js:34293:12)
    at async PrismaService._request (/app/node_modules/@prisma/client/runtime/index.js:35273:16)
    at async TransactionsService.createManyWithClient (/app/build/transactions/transactions.service.js:32:9)
    at async prisma.$transaction.timeout (/app/build/blocks-transactions-loader/blocks-transactions-loader.js:84:38)
    at async Proxy._transactionWithCallback (/app/node_modules/@prisma/client/runtime/index.js:35205:18)
    at async BlocksTransactionsLoader.createMany (/app/build/blocks-transactions-loader/blocks-transactions-loader.js:70:13)
    at async BlocksController.createMany (/app/build/blocks/blocks.controller.js:43:24)
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
