### PR TITLE
Remove rank from users/find and users/[id]

### DIFF
--- a/src/users/dto/user-query.dto.ts
+++ b/src/users/dto/user-query.dto.ts
@@ -15,7 +15,4 @@ export class UserQueryDto {
   @ApiPropertyOptional({
     description: 'Whether or not to include user rank in the response',
   })
-  @IsOptional()
-  @Transform(({ value }: TransformFnParams) => stringToBoolean(value))
-  readonly with_rank?: boolean;
 }

--- a/src/users/dto/user-query.dto.ts
+++ b/src/users/dto/user-query.dto.ts
@@ -2,17 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform, TransformFnParams } from 'class-transformer';
-import { IsOptional, IsString } from 'class-validator';
-import { stringToBoolean } from '../../common/utils/boolean';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
 
 export class UserQueryDto {
   @ApiProperty({ description: 'User graffiti' })
   @IsString()
   readonly graffiti!: string;
-
-  @ApiPropertyOptional({
-    description: 'Whether or not to include user rank in the response',
-  })
 }


### PR DESCRIPTION
## Summary

This was removed in the front end

Review with https://github.com/iron-fish/ironfish-api/pull/1144/files?diff=split&w=1

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
