### PR TITLE
fix: bug in date filter for pool4 refresh

### DIFF
--- a/src/user-points/user-points.jobs.controller.ts
+++ b/src/user-points/user-points.jobs.controller.ts
@@ -92,7 +92,8 @@ export class UserPointsJobsController {
           user,
           eventType,
           // Any points after Jan 1, 2023 are by definition from phase 3
-          new Date(2023, 1, 1),
+          // (0 is January in JS date)
+          new Date(2023, 0, 1),
           end,
         );
       }),


### PR DESCRIPTION
## Summary
Javascript date constructor for January is `0` not `1` 🤦 


Discovered this bug by looking at query log in local environment when calling endpoint. Query that was being run on POOL4 refresh was:
```
SELECT SUM("points"),
       COUNT("points"),
       MAX("occurred_at")
FROM
  (SELECT "public"."events"."points",
          "public"."events"."occurred_at"
   FROM "public"."events"
   WHERE ("public"."events"."type" = 'MULTI_ASSET_MINT'
          AND "public"."events"."user_id" = '2'
          AND "public"."events"."occurred_at" >= '2023-02-01 08:00:00'
          AND "public"."events"."occurred_at" < '2023-01-12 16:27:34.129')
     OFFSET '0') AS "sub"
```
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
