### PR TITLE
fix: bug in pool 4 refresh (2/2)

### DIFF
--- a/src/events/multi-asset.upsert.service.ts
+++ b/src/events/multi-asset.upsert.service.ts
@@ -148,6 +148,15 @@ export class MultiAssetUpsertService {
             },
           });
           const currentPhase3Week = phase3Week(operation.block.timestamp);
+
+          const blocks = await this.prisma.block.findMany({
+            where: {
+              hash: {
+                in: multiAssets.map((m) => m.block_hash),
+              },
+            },
+          });
+          const blockMap = new Map(blocks.map((b) => [b.hash, b.id]));
           const eventPayloads = multiAssets.map((multiAsset) => {
             const user = users.get(multiAsset.asset_name);
             assert(user);
@@ -159,6 +168,7 @@ export class MultiAssetUpsertService {
               week: currentPhase3Week,
               points: POINTS_PER_CATEGORY[multiAsset.type],
               multi_asset_id: multiAsset.id,
+              block_id: blockMap.get(multiAsset.block_hash),
             };
           });
 

--- a/src/user-points/user-points.jobs.controller.ts
+++ b/src/user-points/user-points.jobs.controller.ts
@@ -92,7 +92,8 @@ export class UserPointsJobsController {
           user,
           eventType,
           // Any points after Jan 1, 2023 are by definition from phase 3
-          new Date(2023, 1, 1),
+          // (0 is January in JS date)
+          new Date(2023, 0, 1),
           end,
         );
       }),


### PR DESCRIPTION
## Summary

Part 1:

Part 2/2

block information wasn't being returned with the `/event` list endpoint because the event had no `block_id` linked to it. This links block id.

Caveat is that this will only work if the `syncer` syncs the block to the API before the `multi-asset-syncer` syncs the multiasset info to the API.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
