### PR TITLE
fix: link multiasset to blocks

### DIFF
--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -15,6 +15,7 @@ import { UsersModule } from '../users/users.module';
 import { DepositsService } from './deposits.service';
 import { DepositsUpsertService } from './deposits.upsert.service';
 import { EventsService } from './events.service';
+import { MultiAssetService } from './multi-asset.service';
 import { MultiAssetUpsertService } from './multi-asset.upsert.service';
 
 @Module({
@@ -22,6 +23,7 @@ import { MultiAssetUpsertService } from './multi-asset.upsert.service';
     EventsService,
     DepositsService,
     DepositsUpsertService,
+    MultiAssetService,
     MultiAssetUpsertService,
   ],
   imports: [
@@ -41,6 +43,7 @@ import { MultiAssetUpsertService } from './multi-asset.upsert.service';
     DepositsService,
     DepositsUpsertService,
     MultiAssetUpsertService,
+    MultiAssetService,
   ],
 })
 export class EventsModule {}

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -125,6 +125,16 @@ export class EventsService {
           block_hash: deposit.block_hash,
         };
       }
+      if (record.multi_asset_id) {
+        const multi_asset = await this.prisma.multiAsset.findFirstOrThrow({
+          where: { id: record.multi_asset_id },
+        });
+
+        metadata = {
+          transaction_hash: multi_asset.transaction_hash,
+          block_hash: multi_asset.block_hash,
+        };
+      }
       data.push({
         ...record,
         metadata,

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -27,6 +27,7 @@ import { CreateEventOptions } from './interfaces/create-event-options';
 import { EventWithMetadata } from './interfaces/event-with-metadata';
 import { ListEventsOptions } from './interfaces/list-events-options';
 import { SerializedEventMetrics } from './interfaces/serialized-event-metrics';
+import { MultiAssetService } from './multi-asset.service';
 import { Block, Event, EventType, Prisma, User } from '.prisma/client';
 
 // 2021 December 1 8 PM UTC
@@ -47,6 +48,7 @@ export class EventsService {
     private readonly prisma: PrismaService,
     private readonly userPointsService: UserPointsService,
     private readonly depositsService: DepositsService,
+    private readonly multiAssetService: MultiAssetService,
     private readonly graphileWorkerService: GraphileWorkerService,
   ) {}
 
@@ -126,9 +128,9 @@ export class EventsService {
         };
       }
       if (record.multi_asset_id) {
-        const multi_asset = await this.prisma.multiAsset.findFirstOrThrow({
-          where: { id: record.multi_asset_id },
-        });
+        const multi_asset = await this.multiAssetService.findOrThrow(
+          record.multi_asset_id,
+        );
 
         metadata = {
           transaction_hash: multi_asset.transaction_hash,

--- a/src/events/multi-asset.service.spec.ts
+++ b/src/events/multi-asset.service.spec.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { INestApplication, NotFoundException } from '@nestjs/common';
+import { EventType } from '@prisma/client';
+import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { bootstrapTestApp } from '../test/test-app';
+import { MultiAssetService } from './multi-asset.service';
+
+describe('MultiAssetService', () => {
+  let app: INestApplication;
+  let multiAssetService: MultiAssetService;
+  let graphileWorkerService: GraphileWorkerService;
+  let prismaService: PrismaService;
+  beforeAll(async () => {
+    app = await bootstrapTestApp();
+    multiAssetService = app.get(MultiAssetService);
+    graphileWorkerService = app.get(GraphileWorkerService);
+    prismaService = app.get(PrismaService);
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(graphileWorkerService, 'addJob')
+      .mockImplementationOnce(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('when find user is called', () => {
+    it('finds asset when asset exists', async () => {
+      const multiAsset = await prismaService.multiAsset.create({
+        data: {
+          transaction_hash: 'transactionhash',
+          block_hash: 'blockhash',
+          asset_name: 'customeasset',
+          type: EventType.MULTI_ASSET_MINT,
+          block_sequence: 22,
+          network_version: 1,
+          main: true,
+        },
+      });
+      const foundAsset = await multiAssetService.findOrThrow(multiAsset.id);
+      expect(foundAsset.id).toEqual(multiAsset.id);
+    });
+    it('throws when asset id does not exist', async () => {
+      await expect(multiAssetService.findOrThrow(123121232)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/events/multi-asset.service.ts
+++ b/src/events/multi-asset.service.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { MultiAsset } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class MultiAssetService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async find(id: number): Promise<MultiAsset | null> {
+    return this.prisma.readClient.multiAsset.findUnique({
+      where: {
+        id,
+      },
+    });
+  }
+
+  async findOrThrow(id: number): Promise<MultiAsset> {
+    const multiAsset = await this.find(id);
+
+    if (!multiAsset) {
+      throw new NotFoundException();
+    }
+
+    return multiAsset;
+  }
+}


### PR DESCRIPTION
## Summary

Enriching block hash and transaction hash directly from `multi_asset` model.
## Testing Plan
<img width="808" alt="Screen Shot 2023-01-13 at 10 38 38 AM" src="https://user-images.githubusercontent.com/26990067/212395239-a1d0647a-a8b7-41c2-8595-6ab913ec3c59.png">

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
