### PR TITLE
chore: change block relationship to events 1-to-many (1/2)

### DIFF
--- a/prisma/migrations/20230113030603_many_event_to_one_block/migration.sql
+++ b/prisma/migrations/20230113030603_many_event_to_one_block/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "uq_events_on_block_id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,7 +18,7 @@ model Event {
   user_id        Int
   week           Int?
   deposit_id     Int?        @unique(map: "uq_events_on_deposit_id")
-  block_id       Int?        @unique(map: "uq_events_on_block_id")
+  block_id       Int?        
   deposit        Deposit?    @relation(fields: [deposit_id], references: [id])
   block          Block?      @relation(fields: [block_id], references: [id])
   user           User        @relation(fields: [user_id], references: [id])
@@ -30,7 +30,6 @@ model Event {
   // currently unique not null isn't supported in prisma: https://github.com/prisma/prisma/issues/3387
   // leaving the line below will cause yarn db:migrate to try adding new migration everytime
   // @@unique([user_id, type, week], name: "uq_multi_asset_on_user_id_type_week", map: "uq_multi_asset_on_user_id_type_week")
-
   @@index([deposit_id], name: "index_events_on_deposit_id")
   @@index([multi_asset_id], name: "index_events_on_multi_asset_id")
   @@index([block_id], name: "index_events_on_block_id")
@@ -86,7 +85,7 @@ model Block {
   size                     Int?
   difficulty               BigInt
   blocks_transactions      BlockTransaction[]
-  event                    Event?
+  events                    Event[]
 
   @@unique([hash, network_version], name: "uq_blocks_on_hash_and_network_version", map: "uq_blocks_on_hash_and_network_version")
   @@index([hash], name: "index_blocks_on_hash")

--- a/src/events/deposits.upsert.service.ts
+++ b/src/events/deposits.upsert.service.ts
@@ -65,7 +65,7 @@ export class DepositsUpsertService {
       });
 
       if (event) {
-        await this.eventsService.deleteWithClient(event, prisma);
+        await this.eventsService.deleteWithClient([event], prisma);
       }
     }
 

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -101,6 +101,6 @@ export class EventsController {
     id: number,
   ): Promise<void> {
     const event = await this.eventsService.findOrThrow(id);
-    await this.eventsService.delete(event);
+    await this.eventsService.delete([event]);
   }
 }

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -714,7 +714,7 @@ describe('EventsService', () => {
         });
         assert(event);
         const eventToDelete = await eventsService.findOrThrow(event.id);
-        await eventsService.delete(eventToDelete);
+        await eventsService.delete([eventToDelete]);
 
         const newPoints = 500;
         const event2 = await eventsService.create({
@@ -836,13 +836,6 @@ describe('EventsService', () => {
   });
 
   describe('deleteBlockMined', () => {
-    describe('when the event does not exist', () => {
-      it('returns null', async () => {
-        const { block } = await setupBlockMined();
-        expect(await eventsService.deleteBlockMined(block)).toBeNull();
-      });
-    });
-
     describe('when the event exists', () => {
       it('deletes the record', async () => {
         const { block, event } = await setupBlockMinedWithEvent();
@@ -895,7 +888,7 @@ describe('EventsService', () => {
     it('subtracts points from the user total points', async () => {
       const { event, user } = await setupBlockMinedWithEvent();
       const currentUserPoints = await userPointsService.findOrThrow(user.id);
-      await eventsService.delete(event);
+      await eventsService.delete([event]);
       await eventsJobsController.updateLatestPoints({
         userId: user.id,
         type: EventType.BLOCK_MINED,
@@ -924,7 +917,7 @@ describe('EventsService', () => {
     it('subtracts points from user_points total points', async () => {
       const { event, user } = await setupBlockMinedWithEvent();
       const currentUserPoints = await userPointsService.findOrThrow(user.id);
-      await eventsService.delete(event);
+      await eventsService.delete([event]);
       await eventsJobsController.updateLatestPoints({
         userId: user.id,
         type: EventType.BLOCK_MINED,


### PR DESCRIPTION
## Summary
Enriching block hash and transaction hash directly from `multi_asset` model.


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
