### PR TITLE
chore: add phase3 launch timestamp gate

### DIFF
--- a/src/events/multi-asset.upsert.service.spec.ts
+++ b/src/events/multi-asset.upsert.service.spec.ts
@@ -453,4 +453,16 @@ describe('Weekly transaction limit', () => {
       'Transactions should not be sent with disconnected blocks',
     );
   });
+
+  it('returns false for comparison of dates newer than', () => {
+    process.env.PHASE3_LAUNCH_TIMESTAMP = '1674064800000'; // 1pm ET 2023-01-18
+    const beforeLaunch = new Date('2023-01-01');
+    const afterLaunch = new Date('2023-01-20');
+    const beforeLaunchTs = new Date(1674064799999);
+    const afterLaunchTs = new Date(1674064800001);
+    expect(multiAssetService.occurredAfterLaunch(beforeLaunch)).toBe(false);
+    expect(multiAssetService.occurredAfterLaunch(afterLaunch)).toBe(true);
+    expect(multiAssetService.occurredAfterLaunch(beforeLaunchTs)).toBe(false);
+    expect(multiAssetService.occurredAfterLaunch(afterLaunchTs)).toBe(true);
+  });
 });

--- a/src/events/multi-asset.upsert.service.ts
+++ b/src/events/multi-asset.upsert.service.ts
@@ -35,10 +35,19 @@ export class MultiAssetUpsertService {
         operation.type === BlockOperation.CONNECTED ||
         operation.type === BlockOperation.DISCONNECTED;
 
-      if (shouldUpsertMultiAsset) {
+      if (
+        shouldUpsertMultiAsset &&
+        this.occurredAfterLaunch(operation.block.timestamp)
+      ) {
         await this.upsert(operation);
       }
     }
+  }
+
+  private occurredAfterLaunch(comparisonDate: Date): boolean {
+    const timestamp = this.config.get<string>('PHASE3_LAUNCH_TIMESTAMP');
+    const launch = new Date(+timestamp);
+    return launch < comparisonDate;
   }
 
   async upsert(operation: UpsertMultiAssetOperationDto): Promise<MultiAsset[]> {


### PR DESCRIPTION
## Summary
Gate phase 3 block uploads by timestamp on block submitted from syncer (which is a timestamp https://github.com/iron-fish/ironfish/blob/ea718ebc0145f8aef1ecc2214782f8eeadbcbd9c/ironfish/src/rpc/routes/chain/getTransactionStream.ts#L204)

Already added env vars to heroku for api as `PHASE3_LAUNCH_TIMESTAMP=1674064800000`
## Testing Plan
Unittests
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
