### PR TITLE
feat(api): Move uptime logic onto Graphile

### DIFF
--- a/src/node-uptimes/node-uptimes-loader.module.ts
+++ b/src/node-uptimes/node-uptimes-loader.module.ts
@@ -3,13 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
 import { EventsModule } from '../events/events.module';
+import { GraphileWorkerModule } from '../graphile-worker/graphile-worker.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { NodeUptimesModule } from './node-uptimes.module';
 import { NodeUptimesLoader } from './node-uptimes-loader';
 
 @Module({
   exports: [NodeUptimesLoader],
-  imports: [EventsModule, NodeUptimesModule, PrismaModule],
+  imports: [
+    EventsModule,
+    GraphileWorkerModule,
+    NodeUptimesModule,
+    PrismaModule,
+  ],
   providers: [NodeUptimesLoader],
 })
 export class NodeUptimesLoaderModule {}

--- a/src/node-uptimes/node-uptimes-loader.ts
+++ b/src/node-uptimes/node-uptimes-loader.ts
@@ -5,6 +5,8 @@ import { Injectable } from '@nestjs/common';
 import { EventType } from '@prisma/client';
 import { NODE_UPTIME_CREDIT_HOURS } from '../common/constants';
 import { EventsService } from '../events/events.service';
+import { GraphileWorkerPattern } from '../graphile-worker/enums/graphile-worker-pattern';
+import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { NodeUptimesService } from './node-uptimes.service';
 import { User } from '.prisma/client';
@@ -13,39 +15,62 @@ import { User } from '.prisma/client';
 export class NodeUptimesLoader {
   constructor(
     private readonly eventsService: EventsService,
+    private readonly graphileWorkerService: GraphileWorkerService,
     private readonly nodeUptimesService: NodeUptimesService,
     private readonly prisma: PrismaService,
   ) {}
 
-  async createEvent(user: User, occurredAt: Date): Promise<void> {
-    const uptime = await this.nodeUptimesService.get(user);
+  async incrementUptimeAndCreateEvent(
+    user: User,
+    occurredAt: Date,
+  ): Promise<void> {
+    const uptime = await this.prisma.$transaction(async (prisma) => {
+      const uptime = await this.nodeUptimesService.addUptime(user, prisma);
+      if (uptime.total_hours < NODE_UPTIME_CREDIT_HOURS) {
+        return uptime;
+      }
 
-    if (!uptime || uptime.total_hours < NODE_UPTIME_CREDIT_HOURS) {
-      return;
-    }
+      const createdEventsCount =
+        await this.eventsService.createNodeUptimeEventWithClient(
+          user,
+          occurredAt,
+          uptime,
+          prisma,
+        );
 
-    await this.prisma.$transaction(async (prisma) => {
-      const created = await this.eventsService.createNodeUptimeEventWithClient(
-        user,
-        occurredAt,
-        uptime,
-        prisma,
-      );
-
-      if (!created) {
+      if (!createdEventsCount) {
         throw new Error(`Error creating node uptime event`);
       }
 
       await this.nodeUptimesService.decrementCountedHoursWithClient(
         uptime,
-        created * NODE_UPTIME_CREDIT_HOURS,
+        createdEventsCount * NODE_UPTIME_CREDIT_HOURS,
         prisma,
       );
+
+      return uptime;
     });
+
+    if (!uptime || uptime.total_hours < NODE_UPTIME_CREDIT_HOURS) {
+      return;
+    }
 
     await this.eventsService.addUpdateLatestPointsJob(
       uptime.user_id,
       EventType.NODE_UPTIME,
+    );
+  }
+
+  async addUptime(user: User): Promise<void> {
+    const now = new Date();
+
+    await this.graphileWorkerService.addJob(
+      GraphileWorkerPattern.CREATE_NODE_UPTIME_EVENT,
+      { userId: user.id, occurredAt: now },
+      {
+        queueName: `update_node_uptime`,
+        jobKey: `update_node_uptime_for_${user.id}`,
+      },
     );
   }
 }

--- a/src/node-uptimes/node-uptimes.jobs.controller.spec.ts
+++ b/src/node-uptimes/node-uptimes.jobs.controller.spec.ts
@@ -38,7 +38,10 @@ describe('NodeUptimesJobsController', () => {
   describe('createNodeUptimeEvent', () => {
     describe('with a missing user', () => {
       it('does not update', async () => {
-        const createEvent = jest.spyOn(nodeUptimesLoader, 'createEvent');
+        const createEvent = jest.spyOn(
+          nodeUptimesLoader,
+          'incrementUptimeAndCreateEvent',
+        );
 
         await nodeUptimesJobsController.createNodeUptimeEvent({
           userId: 99999,
@@ -50,7 +53,10 @@ describe('NodeUptimesJobsController', () => {
 
     describe('with a valid user', () => {
       it('creates an event with the loader', async () => {
-        const createEvent = jest.spyOn(nodeUptimesLoader, 'createEvent');
+        const createEvent = jest.spyOn(
+          nodeUptimesLoader,
+          'incrementUptimeAndCreateEvent',
+        );
         const user = await setupUser();
         const occurredAt = new Date();
 

--- a/src/node-uptimes/node-uptimes.jobs.controller.ts
+++ b/src/node-uptimes/node-uptimes.jobs.controller.ts
@@ -24,14 +24,18 @@ export class NodeUptimesJobsController {
     occurredAt,
   }: CreateNodeUptimeEventOptions): Promise<GraphileWorkerHandlerResponse> {
     occurredAt = new Date(occurredAt);
-    const user = await this.usersService.find(userId);
 
+    const user = await this.usersService.find(userId);
     if (!user) {
       this.loggerService.error(`No user found for '${userId}'`, '');
       return { requeue: false };
     }
 
-    await this.nodeUptimesLoader.createEvent(user, occurredAt);
+    await this.nodeUptimesLoader.incrementUptimeAndCreateEvent(
+      user,
+      occurredAt,
+    );
+
     return { requeue: false };
   }
 }

--- a/src/node-uptimes/node-uptimes.module.ts
+++ b/src/node-uptimes/node-uptimes.module.ts
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
-import { GraphileWorkerModule } from '../graphile-worker/graphile-worker.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { NodeUptimesService } from './node-uptimes.service';
 
 @Module({
   exports: [NodeUptimesService],
-  imports: [PrismaModule, GraphileWorkerModule],
+  imports: [PrismaModule],
   providers: [NodeUptimesService],
 })
 export class NodeUptimesModule {}

--- a/src/node-uptimes/node-uptimes.service.spec.ts
+++ b/src/node-uptimes/node-uptimes.service.spec.ts
@@ -41,7 +41,7 @@ describe('NodeUptimesService', () => {
       const now = new Date();
       const user = await createUser();
 
-      const uptime = await nodeUptimesService.addUptime(user);
+      const uptime = await nodeUptimesService.addUptime(user, prisma);
 
       expect(uptime).toMatchObject({
         user_id: user.id,
@@ -67,7 +67,7 @@ describe('NodeUptimesService', () => {
         },
       });
 
-      const uptime = await nodeUptimesService.addUptime(user);
+      const uptime = await nodeUptimesService.addUptime(user, prisma);
 
       expect(uptime).toMatchObject({
         user_id: user.id,
@@ -92,7 +92,7 @@ describe('NodeUptimesService', () => {
         },
       });
 
-      const uptime = await nodeUptimesService.addUptime(user);
+      const uptime = await nodeUptimesService.addUptime(user, prisma);
       expect(uptime).toEqual(existingUptime);
     });
   });

--- a/src/node-uptimes/node-uptimes.service.ts
+++ b/src/node-uptimes/node-uptimes.service.ts
@@ -4,73 +4,42 @@
 
 import { Injectable } from '@nestjs/common';
 import { User } from '@prisma/client';
-import {
-  NODE_UPTIME_CHECKIN_HOURS,
-  NODE_UPTIME_CREDIT_HOURS,
-} from '../common/constants';
-import { GraphileWorkerPattern } from '../graphile-worker/enums/graphile-worker-pattern';
-import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
+import { NODE_UPTIME_CHECKIN_HOURS } from '../common/constants';
 import { PrismaService } from '../prisma/prisma.service';
 import { BasePrismaClient } from '../prisma/types/base-prisma-client';
 import { NodeUptime } from '.prisma/client';
 
 @Injectable()
 export class NodeUptimesService {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly graphileWorkerService: GraphileWorkerService,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
-  async addUptime(user: User): Promise<NodeUptime> {
+  async addUptime(user: User, client: BasePrismaClient): Promise<NodeUptime> {
     const now = new Date();
 
     const lastCheckinCutoff = new Date();
     lastCheckinCutoff.setHours(now.getHours() - NODE_UPTIME_CHECKIN_HOURS);
 
-    const uptime = await this.prisma.$transaction(async (prisma) => {
-      await prisma.$executeRawUnsafe(
-        `SELECT pg_advisory_xact_lock(HASHTEXT($1));`,
-        user.id.toString(),
-      );
-
-      let uptime = await this.getWithClient(user, prisma);
-
-      if (uptime && uptime.last_checked_in >= lastCheckinCutoff) {
-        return uptime;
-      }
-
-      uptime = await prisma.nodeUptime.upsert({
-        where: {
-          user_id: user.id,
-        },
-        update: {
-          last_checked_in: now.toISOString(),
-          total_hours: {
-            increment: 1,
-          },
-        },
-        create: {
-          user_id: user.id,
-          last_checked_in: now.toISOString(),
-          total_hours: 0,
-        },
-      });
-
+    const uptime = await this.getWithClient(user, client);
+    if (uptime && uptime.last_checked_in >= lastCheckinCutoff) {
       return uptime;
-    });
-
-    if (uptime.total_hours >= NODE_UPTIME_CREDIT_HOURS) {
-      await this.graphileWorkerService.addJob(
-        GraphileWorkerPattern.CREATE_NODE_UPTIME_EVENT,
-        { userId: user.id, occurredAt: now },
-        {
-          queueName: `update_node_uptime`,
-          jobKey: `update_node_uptime_for_${user.id}`,
-        },
-      );
     }
 
-    return uptime;
+    return client.nodeUptime.upsert({
+      where: {
+        user_id: user.id,
+      },
+      update: {
+        last_checked_in: now.toISOString(),
+        total_hours: {
+          increment: 1,
+        },
+      },
+      create: {
+        user_id: user.id,
+        last_checked_in: now.toISOString(),
+        total_hours: 0,
+      },
+    });
   }
 
   async get(user: User): Promise<NodeUptime | null> {

--- a/src/telemetry/telemetry.controller.spec.ts
+++ b/src/telemetry/telemetry.controller.spec.ts
@@ -9,7 +9,7 @@ import { ApiConfigService } from '../api-config/api-config.service';
 import { GraphileWorkerPattern } from '../graphile-worker/enums/graphile-worker-pattern';
 import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
 import { InfluxDbService } from '../influxdb/influxdb.service';
-import { NodeUptimesService } from '../node-uptimes/node-uptimes.service';
+import { NodeUptimesLoader } from '../node-uptimes/node-uptimes-loader';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { UsersService } from '../users/users.service';
@@ -51,7 +51,7 @@ describe('TelemetryController', () => {
   let config: ApiConfigService;
   let graphileWorkerService: GraphileWorkerService;
   let influxDbService: InfluxDbService;
-  let nodeUptimesService: NodeUptimesService;
+  let nodeUptimesLoader: NodeUptimesLoader;
   let prisma: PrismaService;
   let usersService: UsersService;
   let versionsService: VersionsService;
@@ -61,7 +61,7 @@ describe('TelemetryController', () => {
     config = app.get(ApiConfigService);
     graphileWorkerService = app.get(GraphileWorkerService);
     influxDbService = app.get(InfluxDbService);
-    nodeUptimesService = app.get(NodeUptimesService);
+    nodeUptimesLoader = app.get(NodeUptimesLoader);
     prisma = app.get(PrismaService);
     usersService = app.get(UsersService);
     versionsService = app.get(VersionsService);
@@ -261,8 +261,8 @@ describe('TelemetryController', () => {
             .spyOn(influxDbService, 'writePoints')
             .mockImplementationOnce(jest.fn());
 
-          const nodeUptimeUpsert = jest
-            .spyOn(nodeUptimesService, 'addUptime')
+          const addUptime = jest
+            .spyOn(nodeUptimesLoader, 'addUptime')
             .mockImplementationOnce(jest.fn());
 
           jest.spyOn(versionsService, 'getLatestAtDate').mockResolvedValue({
@@ -285,8 +285,8 @@ describe('TelemetryController', () => {
             .send({ points, graffiti })
             .expect(HttpStatus.CREATED);
 
-          expect(nodeUptimeUpsert).toHaveBeenCalledTimes(1);
-          expect(nodeUptimeUpsert).toHaveBeenCalledWith(user);
+          expect(addUptime).toHaveBeenCalledTimes(1);
+          expect(addUptime).toHaveBeenCalledWith(user);
         });
 
         it('updates the node uptime if the api returns no version', async () => {
@@ -294,8 +294,8 @@ describe('TelemetryController', () => {
             .spyOn(influxDbService, 'writePoints')
             .mockImplementationOnce(jest.fn());
 
-          const nodeUptimeUpsert = jest
-            .spyOn(nodeUptimesService, 'addUptime')
+          const addUptime = jest
+            .spyOn(nodeUptimesLoader, 'addUptime')
             .mockImplementationOnce(jest.fn());
 
           const graffiti = uuid();
@@ -312,8 +312,8 @@ describe('TelemetryController', () => {
             .send({ points, graffiti })
             .expect(HttpStatus.CREATED);
 
-          expect(nodeUptimeUpsert).toHaveBeenCalledTimes(1);
-          expect(nodeUptimeUpsert).toHaveBeenCalledWith(user);
+          expect(addUptime).toHaveBeenCalledTimes(1);
+          expect(addUptime).toHaveBeenCalledWith(user);
         });
 
         it('updates users points when user has logged enough hours', async () => {
@@ -362,8 +362,8 @@ describe('TelemetryController', () => {
             .spyOn(influxDbService, 'writePoints')
             .mockImplementationOnce(jest.fn());
 
-          const nodeUptimeUpsert = jest
-            .spyOn(nodeUptimesService, 'addUptime')
+          const addUptime = jest
+            .spyOn(nodeUptimesLoader, 'addUptime')
             .mockImplementationOnce(jest.fn());
 
           jest.spyOn(versionsService, 'getLatestAtDate').mockResolvedValue({
@@ -389,7 +389,7 @@ describe('TelemetryController', () => {
             })
             .expect(HttpStatus.CREATED);
 
-          expect(nodeUptimeUpsert).toHaveBeenCalledTimes(0);
+          expect(addUptime).toHaveBeenCalledTimes(0);
         });
       });
 
@@ -397,8 +397,8 @@ describe('TelemetryController', () => {
         it('does not add any uptime', async () => {
           jest.spyOn(config, 'get').mockImplementationOnce(() => false);
 
-          const nodeUptimeUpsert = jest
-            .spyOn(nodeUptimesService, 'addUptime')
+          const addUptime = jest
+            .spyOn(nodeUptimesLoader, 'addUptime')
             .mockImplementationOnce(jest.fn());
 
           const graffiti = uuid();
@@ -413,7 +413,7 @@ describe('TelemetryController', () => {
             .send({ points: [], graffiti })
             .expect(HttpStatus.CREATED);
 
-          expect(nodeUptimeUpsert).not.toHaveBeenCalled();
+          expect(addUptime).not.toHaveBeenCalled();
         });
       });
     });

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -15,7 +15,7 @@ import semver from 'semver';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { InfluxDbService } from '../influxdb/influxdb.service';
 import { CreatePointOptions } from '../influxdb/interfaces/create-point-options';
-import { NodeUptimesService } from '../node-uptimes/node-uptimes.service';
+import { NodeUptimesLoader } from '../node-uptimes/node-uptimes-loader';
 import { UsersService } from '../users/users.service';
 import { VersionsService } from '../versions/versions.service';
 import {
@@ -86,7 +86,7 @@ export class TelemetryController {
   constructor(
     private readonly config: ApiConfigService,
     private readonly influxDbService: InfluxDbService,
-    private readonly nodeUptimes: NodeUptimesService,
+    private readonly nodeUptimesLoader: NodeUptimesLoader,
     private readonly usersService: UsersService,
     private readonly versionsService: VersionsService,
   ) {}
@@ -140,7 +140,7 @@ export class TelemetryController {
       return;
     }
 
-    await this.nodeUptimes.addUptime(user);
+    await this.nodeUptimesLoader.addUptime(user);
   }
 
   private processPoints(points: WriteTelemetryPointDto[]): {

--- a/src/telemetry/telemetry.rest.module.ts
+++ b/src/telemetry/telemetry.rest.module.ts
@@ -4,7 +4,7 @@
 import { Module } from '@nestjs/common';
 import { ApiConfigModule } from '../api-config/api-config.module';
 import { InfluxDbModule } from '../influxdb/influxdb.module';
-import { NodeUptimesModule } from '../node-uptimes/node-uptimes.module';
+import { NodeUptimesLoaderModule } from '../node-uptimes/node-uptimes-loader.module';
 import { UsersModule } from '../users/users.module';
 import { VersionsModule } from '../versions/versions.module';
 import { TelemetryController } from './telemetry.controller';
@@ -14,7 +14,7 @@ import { TelemetryController } from './telemetry.controller';
   imports: [
     ApiConfigModule,
     InfluxDbModule,
-    NodeUptimesModule,
+    NodeUptimesLoaderModule,
     UsersModule,
     VersionsModule,
   ],


### PR DESCRIPTION
## Summary

* Enqueue graphile job every time on telemetry uptime 
* Check for hours in graphile job
* Remove advisory lock since all jobs run in a queue
* Refactor method name and tests

## Testing Plan

Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
