### PR TITLE
feat(api): Add new block template construction duration measurement to Influx whitelist

### DIFF
--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -33,6 +33,7 @@ const TELEMETRY_WHITELIST = new Map<string, true | Array<string>>([
   [
     'node_stats',
     [
+      'create_new_block_template_duration',
       'heap_total',
       'heap_used',
       'peers_count',


### PR DESCRIPTION
## Summary
See title. 

[This accompanying PR](https://github.com/iron-fish/ironfish/pull/3147) in the `ironfish` repo pushes the `create_new_block_template_duration` measurement to the API. 

## Testing Plan
Build successful
```
➜  ironfish-api git:(holahula/feat/influx-block-template-support) yarn build
yarn run v1.22.19
$ tsc -b
✨  Done in 2.05s.
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
