### PR TITLE
chore: Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @iron-fish/engineering


### PR DESCRIPTION
## Summary

Removes codeowners to stop auto-tagging everyone as a reviewer

## Testing Plan

n/a

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
