### PR TITLE
feat(api): Return timestamps for asset descriptions

### DIFF
--- a/src/asset-descriptions/asset-descriptions.controller.spec.ts
+++ b/src/asset-descriptions/asset-descriptions.controller.spec.ts
@@ -165,7 +165,7 @@ describe('AssetDescriptionsController', () => {
             {
               object: 'asset_description',
               id: thirdAssetDescription.id,
-              timestamp: block.timestamp.toISOString(),
+              block_timestamp: block.timestamp.toISOString(),
               transaction_hash: thirdTransaction.hash,
               type: AssetDescriptionType.BURN,
               value: thirdAssetDescription.value.toString(),
@@ -173,7 +173,7 @@ describe('AssetDescriptionsController', () => {
             {
               object: 'asset_description',
               id: secondAssetDescription.id,
-              timestamp: block.timestamp.toISOString(),
+              block_timestamp: block.timestamp.toISOString(),
               transaction_hash: secondTransaction.hash,
               type: AssetDescriptionType.MINT,
               value: secondAssetDescription.value.toString(),

--- a/src/asset-descriptions/asset-descriptions.controller.ts
+++ b/src/asset-descriptions/asset-descriptions.controller.ts
@@ -10,12 +10,13 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AssetsService } from '../assets/assets.service';
+import { BlocksTransactionsService } from '../blocks-transactions/blocks-transactions.service';
 import { PaginatedList } from '../common/interfaces/paginated-list';
 import { TransactionsService } from '../transactions/transactions.service';
 import { AssetDescriptionsService } from './asset-descriptions.service';
 import { AssetDescriptionsQueryDto } from './dto/asset-descriptions-query.dto';
-import { SerializedAssetDescription } from './interfaces/serialized-asset-description';
-import { serializedAssetDescriptionFromRecord } from './utils/asset-descriptions.translator';
+import { SerializedAssetDescriptionWithTimestamp } from './interfaces/serialized-asset-description';
+import { serializedAssetDescriptionWithTimestampFromRecord } from './utils/asset-descriptions.translator';
 
 @ApiTags('AssetDescriptions')
 @Controller('asset_descriptions')
@@ -23,6 +24,7 @@ export class AssetDescriptionsController {
   constructor(
     private readonly assetDescriptionsService: AssetDescriptionsService,
     private readonly assetsService: AssetsService,
+    private readonly blocksTransactionsService: BlocksTransactionsService,
     private readonly transactionsService: TransactionsService,
   ) {}
 
@@ -36,7 +38,7 @@ export class AssetDescriptionsController {
       }),
     )
     { asset: assetIdentifier, after, before, limit }: AssetDescriptionsQueryDto,
-  ): Promise<PaginatedList<SerializedAssetDescription>> {
+  ): Promise<PaginatedList<SerializedAssetDescriptionWithTimestamp>> {
     const asset = await this.assetsService.findByIdentifierOrThrow(
       assetIdentifier,
     );
@@ -48,13 +50,27 @@ export class AssetDescriptionsController {
         limit,
       });
 
-    const serializedData: SerializedAssetDescription[] = [];
+    const serializedData: SerializedAssetDescriptionWithTimestamp[] = [];
     for (const record of data) {
       const transaction = await this.transactionsService.findOrThrow(
         record.transaction_id,
       );
+      const blocks =
+        await this.blocksTransactionsService.findBlocksByTransaction(
+          transaction,
+        );
+      // Skip non main chain descriptions
+      const block = blocks.find((block) => block.main);
+      if (!block) {
+        continue;
+      }
+
       serializedData.push(
-        serializedAssetDescriptionFromRecord(record, transaction),
+        serializedAssetDescriptionWithTimestampFromRecord(
+          record,
+          transaction,
+          block,
+        ),
       );
     }
 

--- a/src/asset-descriptions/asset-descriptions.controller.ts
+++ b/src/asset-descriptions/asset-descriptions.controller.ts
@@ -15,7 +15,7 @@ import { PaginatedList } from '../common/interfaces/paginated-list';
 import { TransactionsService } from '../transactions/transactions.service';
 import { AssetDescriptionsService } from './asset-descriptions.service';
 import { AssetDescriptionsQueryDto } from './dto/asset-descriptions-query.dto';
-import { SerializedAssetDescriptionWithTimestamp } from './interfaces/serialized-asset-description';
+import { SerializedAssetDescription } from './interfaces/serialized-asset-description';
 import { serializedAssetDescriptionWithTimestampFromRecord } from './utils/asset-descriptions.translator';
 
 @ApiTags('AssetDescriptions')
@@ -38,7 +38,7 @@ export class AssetDescriptionsController {
       }),
     )
     { asset: assetIdentifier, after, before, limit }: AssetDescriptionsQueryDto,
-  ): Promise<PaginatedList<SerializedAssetDescriptionWithTimestamp>> {
+  ): Promise<PaginatedList<SerializedAssetDescription>> {
     const asset = await this.assetsService.findByIdentifierOrThrow(
       assetIdentifier,
     );
@@ -50,7 +50,7 @@ export class AssetDescriptionsController {
         limit,
       });
 
-    const serializedData: SerializedAssetDescriptionWithTimestamp[] = [];
+    const serializedData: SerializedAssetDescription[] = [];
     for (const record of data) {
       const transaction = await this.transactionsService.findOrThrow(
         record.transaction_id,

--- a/src/asset-descriptions/asset-descriptions.rest.module.ts
+++ b/src/asset-descriptions/asset-descriptions.rest.module.ts
@@ -3,12 +3,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
 import { AssetsModule } from '../assets/assets.module';
+import { BlocksTransactionsModule } from '../blocks-transactions/blocks-transactions.module';
 import { TransactionsModule } from '../transactions/transactions.module';
 import { AssetDescriptionsController } from './asset-descriptions.controller';
 import { AssetDescriptionsModule } from './asset-descriptions.module';
 
 @Module({
   controllers: [AssetDescriptionsController],
-  imports: [AssetDescriptionsModule, AssetsModule, TransactionsModule],
+  imports: [
+    AssetDescriptionsModule,
+    AssetsModule,
+    BlocksTransactionsModule,
+    TransactionsModule,
+  ],
 })
 export class AssetDescriptionsRestModule {}

--- a/src/asset-descriptions/interfaces/serialized-asset-description.ts
+++ b/src/asset-descriptions/interfaces/serialized-asset-description.ts
@@ -9,5 +9,5 @@ export interface SerializedAssetDescription {
   transaction_hash: string;
   type: AssetDescriptionType;
   value: string;
-  timestamp?: string;
+  block_timestamp?: string;
 }

--- a/src/asset-descriptions/interfaces/serialized-asset-description.ts
+++ b/src/asset-descriptions/interfaces/serialized-asset-description.ts
@@ -6,7 +6,12 @@ import { AssetDescriptionType } from '@prisma/client';
 export interface SerializedAssetDescription {
   object: 'asset_description';
   id: number;
+  transaction_hash: string;
   type: AssetDescriptionType;
   value: string;
-  transaction_hash: string;
+}
+
+export interface SerializedAssetDescriptionWithTimestamp
+  extends SerializedAssetDescription {
+  timestamp: string;
 }

--- a/src/asset-descriptions/interfaces/serialized-asset-description.ts
+++ b/src/asset-descriptions/interfaces/serialized-asset-description.ts
@@ -9,9 +9,5 @@ export interface SerializedAssetDescription {
   transaction_hash: string;
   type: AssetDescriptionType;
   value: string;
-}
-
-export interface SerializedAssetDescriptionWithTimestamp
-  extends SerializedAssetDescription {
-  timestamp: string;
+  timestamp?: string;
 }

--- a/src/asset-descriptions/utils/asset-descriptions.translator.ts
+++ b/src/asset-descriptions/utils/asset-descriptions.translator.ts
@@ -1,9 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import {
-  SerializedAssetDescription,
-} from '../interfaces/serialized-asset-description';
+import { SerializedAssetDescription } from '../interfaces/serialized-asset-description';
 import { AssetDescription, Block, Transaction } from '.prisma/client';
 
 export function serializedAssetDescriptionFromRecord(

--- a/src/asset-descriptions/utils/asset-descriptions.translator.ts
+++ b/src/asset-descriptions/utils/asset-descriptions.translator.ts
@@ -1,8 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { SerializedAssetDescription } from '../interfaces/serialized-asset-description';
-import { AssetDescription, Transaction } from '.prisma/client';
+import {
+  SerializedAssetDescription,
+  SerializedAssetDescriptionWithTimestamp,
+} from '../interfaces/serialized-asset-description';
+import { AssetDescription, Block, Transaction } from '.prisma/client';
 
 export function serializedAssetDescriptionFromRecord(
   assetDescription: AssetDescription,
@@ -11,6 +14,21 @@ export function serializedAssetDescriptionFromRecord(
   return {
     object: 'asset_description',
     id: assetDescription.id,
+    transaction_hash: transaction.hash,
+    type: assetDescription.type,
+    value: assetDescription.value.toString(),
+  };
+}
+
+export function serializedAssetDescriptionWithTimestampFromRecord(
+  assetDescription: AssetDescription,
+  transaction: Transaction,
+  block: Block,
+): SerializedAssetDescriptionWithTimestamp {
+  return {
+    object: 'asset_description',
+    id: assetDescription.id,
+    timestamp: block.timestamp.toISOString(),
     transaction_hash: transaction.hash,
     type: assetDescription.type,
     value: assetDescription.value.toString(),

--- a/src/asset-descriptions/utils/asset-descriptions.translator.ts
+++ b/src/asset-descriptions/utils/asset-descriptions.translator.ts
@@ -28,7 +28,7 @@ export function serializedAssetDescriptionWithTimestampFromRecord(
   return {
     object: 'asset_description',
     id: assetDescription.id,
-    timestamp: block.timestamp.toISOString(),
+    block_timestamp: block.timestamp.toISOString(),
     transaction_hash: transaction.hash,
     type: assetDescription.type,
     value: assetDescription.value.toString(),

--- a/src/asset-descriptions/utils/asset-descriptions.translator.ts
+++ b/src/asset-descriptions/utils/asset-descriptions.translator.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
   SerializedAssetDescription,
-  SerializedAssetDescriptionWithTimestamp,
 } from '../interfaces/serialized-asset-description';
 import { AssetDescription, Block, Transaction } from '.prisma/client';
 
@@ -24,7 +23,7 @@ export function serializedAssetDescriptionWithTimestampFromRecord(
   assetDescription: AssetDescription,
   transaction: Transaction,
   block: Block,
-): SerializedAssetDescriptionWithTimestamp {
+): SerializedAssetDescription {
   return {
     object: 'asset_description',
     id: assetDescription.id,


### PR DESCRIPTION
## Summary

Return associated block timestamps for asset transactions

## Testing Plan

Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
