### PR TITLE
Remove worker limits capped by CPU

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -107,8 +107,11 @@ function clusterize(callback: () => Promise<void>): void {
 
     const cpuCount = os.cpus().length;
     const workers = process.env.WORKER_COUNT
-      ? Math.min(Number(process.env.WORKER_COUNT), cpuCount)
+      ? Number(process.env.WORKER_COUNT)
       : cpuCount;
+
+    console.log(`Starting ${workers} using ${cpuCount} cores`);
+
     for (let i = 0; i < workers; i++) {
       cluster.fork();
     }


### PR DESCRIPTION
## Summary

We don't need this cap since we manually tweak this number to try to max the CPU usage and database usage.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
