### PR TITLE
Add an index to faucet and remove transaction

### DIFF
--- a/prisma/migrations/20230222171607_add_faucet_index/migration.sql
+++ b/prisma/migrations/20230222171607_add_faucet_index/migration.sql
@@ -1,11 +1,5 @@
--- DropIndex
-DROP INDEX "index_users_on_graffiti";
-
 -- CreateIndex
 CREATE INDEX "index_faucet_transactions_on_completed_at" ON "faucet_transactions"("completed_at");
 
 -- CreateIndex
 CREATE INDEX "index_faucet_transactions_on_completed_at_and_started_at" ON "faucet_transactions"("started_at", "completed_at");
-
--- CreateIndex
-CREATE INDEX "index_users_on_graffiti" ON "users"("graffiti");

--- a/prisma/migrations/20230222171607_add_faucet_index/migration.sql
+++ b/prisma/migrations/20230222171607_add_faucet_index/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "index_users_on_graffiti";
+
+-- CreateIndex
+CREATE INDEX "index_faucet_transactions_on_completed_at" ON "faucet_transactions"("completed_at");
+
+-- CreateIndex
+CREATE INDEX "index_faucet_transactions_on_completed_at_and_started_at" ON "faucet_transactions"("started_at", "completed_at");
+
+-- CreateIndex
+CREATE INDEX "index_users_on_graffiti" ON "users"("graffiti");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,6 +142,8 @@ model FaucetTransaction {
   @@index([email], map: "index_faucet_transactions_on_email")
   @@index([public_key], map: "index_faucet_transactions_on_public_key")
   @@index([hash], map: "index_faucet_transactions_on_hash")
+  @@index([completed_at], map: "index_faucet_transactions_on_completed_at")
+  @@index([started_at, completed_at], map: "index_faucet_transactions_on_completed_at_and_started_at")
   @@map("faucet_transactions")
 }
 

--- a/src/faucet-transactions/faucet-transactions.service.ts
+++ b/src/faucet-transactions/faucet-transactions.service.ts
@@ -151,29 +151,30 @@ export class FaucetTransactionsService {
   }
 
   async getGlobalStatus(): Promise<FaucetTransactionsStatus> {
-    const [pending, running, completed] = await this.prisma.$transaction([
-      this.prisma.faucetTransaction.count({
-        where: {
-          started_at: null,
-          completed_at: null,
+    const pending = await this.prisma.readClient.faucetTransaction.count({
+      where: {
+        started_at: null,
+        completed_at: null,
+      },
+    });
+
+    const running = await this.prisma.readClient.faucetTransaction.count({
+      where: {
+        started_at: {
+          not: null,
         },
-      }),
-      this.prisma.faucetTransaction.count({
-        where: {
-          started_at: {
-            not: null,
-          },
-          completed_at: null,
+        completed_at: null,
+      },
+    });
+
+    const completed = await this.prisma.readClient.faucetTransaction.count({
+      where: {
+        completed_at: {
+          not: null,
         },
-      }),
-      this.prisma.faucetTransaction.count({
-        where: {
-          completed_at: {
-            not: null,
-          },
-        },
-      }),
-    ]);
+      },
+    });
+
     return {
       completed,
       running,


### PR DESCRIPTION
## Summary

This API is an optional debugging API. I'm moving it to the read only client, removing the transaction (since its on a follower anyway).

Data dog is showing this as the second slowest API, because the table is growing very large.

```
count: 339645
completed: 339647
```

Slowest DB Query
```
SELECT "public"."faucet_transactions"."id",
         "public"."faucet_transactions"."created_at",
         "public"."faucet_transactions"."updated_at",
         "public"."faucet_transactions"."email",
         "public"."faucet_transactions"."public_key",
         "public"."faucet_transactions"."started_at",
         "public"."faucet_transactions"."completed_at",
         "public"."faucet_transactions"."tries",
         "public"."faucet_transactions"."hash"
FROM "public"."faucet_transactions"
WHERE ("public"."faucet_transactions"."started_at" IS NOT NULL
        AND "public"."faucet_transactions"."completed_at" IS NULL)
ORDER BY  "public"."faucet_transactions"."created_at" ASC LIMIT $1 OFFSET $2
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
