### PR TITLE
fix: makes read calls where possible for telemetry endpoint

### DIFF
--- a/src/telemetry/telemetry.rest.module.ts
+++ b/src/telemetry/telemetry.rest.module.ts
@@ -5,6 +5,7 @@ import { Module } from '@nestjs/common';
 import { ApiConfigModule } from '../api-config/api-config.module';
 import { InfluxDbModule } from '../influxdb/influxdb.module';
 import { NodeUptimesModule } from '../node-uptimes/node-uptimes.module';
+import { PrismaModule } from '../prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
 import { VersionsModule } from '../versions/versions.module';
 import { TelemetryController } from './telemetry.controller';
@@ -15,6 +16,7 @@ import { TelemetryController } from './telemetry.controller';
     ApiConfigModule,
     InfluxDbModule,
     NodeUptimesModule,
+    PrismaModule,
     UsersModule,
     VersionsModule,
   ],

--- a/src/versions/versions.service.ts
+++ b/src/versions/versions.service.ts
@@ -4,6 +4,7 @@
 
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { BasePrismaClient } from '../prisma/types/base-prisma-client';
 import { Version } from '.prisma/client';
 
 @Injectable()
@@ -28,8 +29,12 @@ export class VersionsService {
     });
   }
 
-  async getLatestAtDate(date: Date): Promise<Version | null> {
-    return this.prisma.version.findFirst({
+  async getLatestAtDate(
+    date: Date,
+    prisma?: BasePrismaClient,
+  ): Promise<Version | null> {
+    const client = prisma ?? this.prisma;
+    return client.version.findFirst({
       orderBy: {
         version: 'desc',
       },


### PR DESCRIPTION
## Summary
Changes the `POST: /telemetry` endpoint to pull data from read replica when:
1) Looking up user graffiti
2) Looking up version
## Testing Plan
Tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
