### PR TITLE
feat(api): Check phase 3 when upserting multi asset events

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -56,3 +56,6 @@ export const POOL_4_CATEGORIES: Array<EventType> = [
   EventType.MULTI_ASSET_BURN,
   EventType.MULTI_ASSET_TRANSFER,
 ];
+
+// 2022 Feb 26 12 AM UTC
+export const PHASE_3_END = new Date(Date.UTC(2023, 1, 26, 0, 0, 0));

--- a/src/events/multi-asset.upsert.service.spec.ts
+++ b/src/events/multi-asset.upsert.service.spec.ts
@@ -16,6 +16,7 @@ import {
   UpsertMultiAssetDto,
 } from './dto/upsert-multi-asset.dto';
 import { MultiAssetUpsertService } from './multi-asset.upsert.service';
+
 describe('MultiAssetUpsertService', () => {
   let app: INestApplication;
   let multiAssetHeadService: MultiAssetHeadService;
@@ -68,7 +69,7 @@ describe('MultiAssetUpsertService', () => {
           block: {
             hash: 'multiassetupsertblockhash1',
             previousBlockHash: 'previousblockhash1',
-            timestamp: new Date(),
+            timestamp: new Date('2023-01-01'),
             sequence: 3,
           },
         },
@@ -78,7 +79,7 @@ describe('MultiAssetUpsertService', () => {
           block: {
             hash: 'multiassetupsertblockhash2',
             previousBlockHash: 'previousblockhash2',
-            timestamp: new Date(),
+            timestamp: new Date('2023-01-01'),
             sequence: 4,
           },
         },
@@ -195,6 +196,27 @@ describe('MultiAssetUpsertService', () => {
       expect(user1MultiAsset[0].type).toEqual(EventType.MULTI_ASSET_MINT);
       expect(user1MultiAsset[0].block_hash).toBe(updatedHash);
     });
+
+    describe('on blocks after the phase 3 end', () => {
+      it('returns no events', async () => {
+        await prismaService.multiAssetHead.deleteMany();
+
+        const timestamp = new Date(Date.UTC(2023, 1, 26, 1, 0, 0));
+        const payload = {
+          transactions: [transaction3],
+          type: BlockOperation.CONNECTED,
+          block: {
+            hash: 'multiassetupsertblockhash2',
+            previousBlockHash: 'previousblockhash2',
+            timestamp,
+            sequence: 4,
+          },
+        };
+
+        expect(await multiAssetUpsertService.upsert(payload)).toEqual([]);
+      });
+    });
+
     describe('on DISCONNECTED operations', () => {
       it('removes events', async () => {
         // connected operation
@@ -355,7 +377,7 @@ describe('Weekly transaction limit', () => {
       block: {
         hash: 'goingtodisconnectblock',
         previousBlockHash: head?.block_hash || 'foo',
-        timestamp: new Date('2023/03/01'),
+        timestamp: new Date('2023/02/01'),
         sequence: 1,
       },
     };
@@ -380,7 +402,7 @@ describe('Weekly transaction limit', () => {
       block: {
         hash: 'pointtest2',
         previousBlockHash: head?.block_hash || 'foo',
-        timestamp: new Date('2023/03/01'),
+        timestamp: new Date('2023/02/01'),
         sequence: 2,
       },
     };
@@ -415,7 +437,7 @@ describe('Weekly transaction limit', () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: EventType.MULTI_ASSET_MINT,
-          week: 2773,
+          week: 2769,
         }),
       ]),
     );
@@ -445,7 +467,7 @@ describe('Weekly transaction limit', () => {
       block: {
         hash: 'goingtodisconnectblock',
         previousBlockHash: head?.block_hash || 'foo',
-        timestamp: new Date('2023/03/01'),
+        timestamp: new Date('2023/02/01'),
         sequence: 1,
       },
     };

--- a/src/events/multi-asset.upsert.service.ts
+++ b/src/events/multi-asset.upsert.service.ts
@@ -6,7 +6,7 @@ import { EventType, MultiAsset, User } from '@prisma/client';
 import assert from 'assert';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { BlockOperation } from '../blocks/enums/block-operation';
-import { POINTS_PER_CATEGORY } from '../common/constants';
+import { PHASE_3_END, POINTS_PER_CATEGORY } from '../common/constants';
 import { standardizeHash } from '../common/utils/hash';
 import { LoggerService } from '../logger/logger.service';
 import { MultiAssetHeadService } from '../multi-asset-head/multi-asset-head.service';
@@ -42,6 +42,10 @@ export class MultiAssetUpsertService {
   }
 
   async upsert(operation: UpsertMultiAssetOperationDto): Promise<MultiAsset[]> {
+    if (operation.block.timestamp >= PHASE_3_END) {
+      return [];
+    }
+
     const networkVersion = this.config.get<number>('NETWORK_VERSION');
     const blockHash = standardizeHash(operation.block.hash);
 

--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -13,6 +13,7 @@ import { ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Request } from 'express';
 import semver from 'semver';
 import { ApiConfigService } from '../api-config/api-config.service';
+import { PHASE_3_END } from '../common/constants';
 import { fetchIpAddressFromRequest } from '../common/utils/request';
 import { InfluxDbService } from '../influxdb/influxdb.service';
 import { CreatePointOptions } from '../influxdb/interfaces/create-point-options';
@@ -109,8 +110,9 @@ export class TelemetryController {
   ): Promise<void> {
     const { options, nodeVersion } = this.processPoints(points);
     const ipAddress = fetchIpAddressFromRequest(request);
+    const beforePhase3End = new Date() < PHASE_3_END;
 
-    if (graffiti && nodeVersion) {
+    if (graffiti && nodeVersion && beforePhase3End) {
       await this.addUptime(graffiti, nodeVersion, ipAddress);
     }
 


### PR DESCRIPTION
## Summary

* Check block timestamp for multi asset events
* Don't count online events after phase 3 end

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
