### PR TITLE
feat(api): Return pool points

### DIFF
--- a/src/users/interfaces/serialized-user-metrics.ts
+++ b/src/users/interfaces/serialized-user-metrics.ts
@@ -28,4 +28,7 @@ export interface SerializedUserMetrics {
     total_hours: number;
     last_checked_in: string | null;
   };
+  pool_points?: {
+    [pool: string]: number;
+  };
 }

--- a/src/users/interfaces/serialized-user-metrics.ts
+++ b/src/users/interfaces/serialized-user-metrics.ts
@@ -29,6 +29,9 @@ export interface SerializedUserMetrics {
     last_checked_in: string | null;
   };
   pool_points?: {
-    [pool: string]: number;
+    pool_one: number;
+    pool_two: number;
+    pool_three: number;
+    pool_four: number;
   };
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -29,6 +29,7 @@ describe('UsersController', () => {
   let eventsJobsController: EventsJobsController;
   let userPointsJobsController: UserPointsJobsController;
   let userRankService: UserRanksService;
+  let userPointsService: UserPointsService;
   let recaptchaVerificationService: RecaptchaVerificationService;
 
   beforeAll(async () => {
@@ -38,6 +39,7 @@ describe('UsersController', () => {
     eventsService = app.get(EventsService);
     eventsJobsController = app.get(EventsJobsController);
     userPointsJobsController = app.get(UserPointsJobsController);
+    userPointsService = app.get(UserPointsService);
     userRankService = app.get(UserRanksService);
     recaptchaVerificationService = app.get(RecaptchaVerificationService);
 
@@ -338,6 +340,13 @@ describe('UsersController', () => {
         });
         await userRankService.updateRanks();
 
+        const userPoints = await userPointsService.findOrThrow(user.id);
+        await userPointsService.upsertPreviousPools(userPoints, {
+          pool1: 10,
+          pool2: 20,
+          pool3: 30,
+        });
+
         const { body } = await request(app.getHttpServer())
           .get(`/users/${user.id}/metrics`)
           .query({
@@ -363,6 +372,12 @@ describe('UsersController', () => {
               count: expect.any(Number),
               points: 500,
             },
+          },
+          pool_points: {
+            pool_one: 10,
+            pool_two: 20,
+            pool_three: 30,
+            pool_four: 100,
           },
           metrics: {
             blocks_mined: {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -121,7 +121,7 @@ export class UsersController {
     let eventMetrics: Record<EventType, SerializedEventMetrics>;
     let points: number;
     let pools: Record<MetricsPool, SerializedEventMetrics> | undefined;
-    let poolPoints: Record<string, number> | undefined;
+    let poolPoints;
     let nodeUptime: SerializedUserMetrics['node_uptime'];
 
     if (query.granularity === MetricsGranularity.LIFETIME) {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -121,6 +121,7 @@ export class UsersController {
     let eventMetrics: Record<EventType, SerializedEventMetrics>;
     let points: number;
     let pools: Record<MetricsPool, SerializedEventMetrics> | undefined;
+    let poolPoints: Record<string, number> | undefined;
     let nodeUptime: SerializedUserMetrics['node_uptime'];
 
     if (query.granularity === MetricsGranularity.LIFETIME) {
@@ -139,6 +140,13 @@ export class UsersController {
           user,
           EventType.PULL_REQUEST_MERGED,
         ),
+      };
+
+      poolPoints = {
+        pool_one: userPoints.pool1_points ?? 0,
+        pool_two: userPoints.pool2_points ?? 0,
+        pool_three: userPoints.pool3_points ?? 0,
+        pool_four: userPoints.pool4_points,
       };
 
       const uptime = await this.nodeUptimeService.get(user);
@@ -167,6 +175,7 @@ export class UsersController {
       points,
       pools,
       node_uptime: nodeUptime,
+      pool_points: poolPoints,
       metrics: {
         blocks_mined: eventMetrics[EventType.BLOCK_MINED],
         bugs_caught: eventMetrics[EventType.BUG_CAUGHT],


### PR DESCRIPTION
## Summary

Return cached values from previous pools in metrics request.

I chose to add a new field to the response instead of updating the existing `pools` field because the testnet UI is using that and it felt weird to set the count to NULL since that value isn't populated. It seemed cleaner to just return just the points altogether, but open to changing.

## Testing Plan

Unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
