### PR TITLE
Always return can_attempt in get redemption

### DIFF
--- a/src/jumio-kyc/kyc.controller.spec.ts
+++ b/src/jumio-kyc/kyc.controller.spec.ts
@@ -105,6 +105,7 @@ describe('KycController', () => {
         serializeKyc(redemption, jumioTransaction, false),
       );
     });
+
     it('banned user country gets error', async () => {
       const user = await mockUser('PRK');
 
@@ -119,6 +120,13 @@ describe('KycController', () => {
           public_address: 'foo',
         })
         .expect(HttpStatus.FORBIDDEN);
+
+      const { body } = await request(app.getHttpServer())
+        .get(`/kyc`)
+        .set('Authorization', 'did-token')
+        .expect(HttpStatus.OK);
+
+      expect(body).toMatchObject({ can_attempt: false });
     });
   });
 

--- a/src/jumio-kyc/kyc.controller.spec.ts
+++ b/src/jumio-kyc/kyc.controller.spec.ts
@@ -107,7 +107,10 @@ describe('KycController', () => {
     });
     it('banned user country gets error', async () => {
       const user = await mockUser('PRK');
-      await kycService.attempt(user, 'foo');
+
+      await expect(kycService.attempt(user, 'foo')).rejects.toThrow(
+        'User is from a banned country: PRK',
+      );
 
       await request(app.getHttpServer())
         .post(`/kyc`)

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -188,22 +188,20 @@ export class RedemptionService {
       return 'User has no points';
     }
 
-    if (!redemption) {
-      return null;
-    }
-
     if (REDEMPTION_BAN_LIST.includes(user.country_code)) {
       return `User is from a banned country: ${user.country_code}`;
     }
 
-    const kycMaxAttempts = this.config.get<number>('KYC_MAX_ATTEMPTS');
+    if (redemption) {
+      const kycMaxAttempts = this.config.get<number>('KYC_MAX_ATTEMPTS');
 
-    if (redemption.kyc_attempts >= kycMaxAttempts) {
-      return `Max attempts reached ${redemption.kyc_attempts} / ${kycMaxAttempts}`;
-    }
+      if (redemption.kyc_attempts >= kycMaxAttempts) {
+        return `Max attempts reached ${redemption.kyc_attempts} / ${kycMaxAttempts}`;
+      }
 
-    if (redemption.kyc_status !== KycStatus.TRY_AGAIN) {
-      return `Redemption status is not TRY_AGAIN: ${redemption.kyc_status}`;
+      if (redemption.kyc_status !== KycStatus.TRY_AGAIN) {
+        return `Redemption status is not TRY_AGAIN: ${redemption.kyc_status}`;
+      }
     }
 
     return null;


### PR DESCRIPTION
## Summary

This will always return can_attempt in get kyc endpoint

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
