### PR TITLE
Send back eligibility in can_attempt

### DIFF
--- a/src/jumio-kyc/kyc.controller.spec.ts
+++ b/src/jumio-kyc/kyc.controller.spec.ts
@@ -180,7 +180,7 @@ describe('KycController', () => {
         .set('Authorization', 'did-token')
         .expect(HttpStatus.OK);
 
-      expect(body).toMatchObject(serializeKyc(redemption, transaction, false));
+      expect(body).toMatchObject(serializeKyc(redemption, transaction, true));
     });
   });
 

--- a/src/jumio-kyc/kyc.controller.ts
+++ b/src/jumio-kyc/kyc.controller.ts
@@ -63,17 +63,16 @@ export class KycController {
   ): Promise<SerializedKyc | { can_attempt: boolean }> {
     const redemption = await this.redemptionService.find(user);
 
-    const canAttemptError = await this.redemptionService.isEligible(user);
-    const canAttempt = !canAttemptError;
+    const eligibleError = await this.redemptionService.isEligible(user);
 
     if (!redemption) {
-      return { can_attempt: canAttempt };
+      return { can_attempt: !eligibleError };
     }
 
     const jumioTransaction =
       await this.jumioTransactionService.findLatestOrThrow(user);
 
-    return serializeKyc(redemption, jumioTransaction, canAttempt);
+    return serializeKyc(redemption, jumioTransaction, !eligibleError);
   }
 
   @ApiExcludeEndpoint()

--- a/src/jumio-kyc/kyc.controller.ts
+++ b/src/jumio-kyc/kyc.controller.ts
@@ -63,11 +63,7 @@ export class KycController {
   ): Promise<SerializedKyc | { can_attempt: boolean }> {
     const redemption = await this.redemptionService.find(user);
 
-    const canAttemptError = await this.redemptionService.canAttempt(
-      redemption,
-      user,
-    );
-
+    const canAttemptError = await this.redemptionService.isEligible(user);
     const canAttempt = !canAttemptError;
 
     if (!redemption) {

--- a/src/jumio-kyc/utils/serialize-kyc.ts
+++ b/src/jumio-kyc/utils/serialize-kyc.ts
@@ -8,7 +8,7 @@ import { SerializedKyc } from '../interfaces/serialized-kyc';
 export function serializeKyc(
   redemption: Redemption,
   transaction: JumioTransaction,
-  can_attempt: boolean,
+  canAttempt: boolean,
 ): SerializedKyc {
   assert.ok(redemption.jumio_account_id);
 
@@ -21,6 +21,6 @@ export function serializeKyc(
     public_address: redemption.public_address,
     jumio_workflow_execution_id: transaction.workflow_execution_id,
     jumio_web_href: transaction.web_href,
-    can_attempt: can_attempt,
+    can_attempt: canAttempt,
   };
 }

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -167,8 +167,7 @@ export class RedemptionService {
     });
   }
 
-  async canAttempt(
-    redemption: Redemption | null,
+  async isEligible(
     user: User,
     prisma?: BasePrismaClient,
   ): Promise<string | null> {
@@ -190,6 +189,20 @@ export class RedemptionService {
 
     if (REDEMPTION_BAN_LIST.includes(user.country_code)) {
       return `User is from a banned country: ${user.country_code}`;
+    }
+
+    return null;
+  }
+
+  async canAttempt(
+    redemption: Redemption | null,
+    user: User,
+    prisma?: BasePrismaClient,
+  ): Promise<string | null> {
+    const eligibleError = await this.isEligible(user, prisma);
+
+    if (eligibleError) {
+      return eligibleError;
     }
 
     if (redemption) {


### PR DESCRIPTION
## Summary

This will not send back if you can attempt a KYC flow, now it will send back if you are eligible.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
