### PR TITLE
fix: update logic for redemption/attempt checks

### DIFF
--- a/src/jumio-kyc/kyc.controller.spec.ts
+++ b/src/jumio-kyc/kyc.controller.spec.ts
@@ -217,7 +217,7 @@ describe('KycController', () => {
   });
 
   describe('GET /kyc', () => {
-    it('retrieves kyc info when it exists', async () => {
+    it('retrieves kyc info when it exists and shows user is not eligible to start new kyc', async () => {
       const user = await mockUser();
       const { redemption, transaction } = await kycService.attempt(user, 'foo');
 
@@ -227,7 +227,12 @@ describe('KycController', () => {
         .expect(HttpStatus.OK);
 
       expect(body).toMatchObject(
-        serializeKyc(redemption, transaction, true, ''),
+        serializeKyc(
+          redemption,
+          transaction,
+          false,
+          'Redemption status is not TRY_AGAIN: IN_PROGRESS',
+        ),
       );
     });
   });


### PR DESCRIPTION
## Summary
Small updates to logic in kyc endpoints. Please check logic

## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
