### PR TITLE
fix: default to submitted status rather than try again

### DIFF
--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -93,7 +93,7 @@ export class RedemptionService {
     }
 
     return {
-      status: KycStatus.TRY_AGAIN,
+      status: KycStatus.SUBMITTED,
       failureMessage: null,
       idDetails,
     };


### PR DESCRIPTION
## Summary
If we bypass all the checks in `calculateStatus` we currently default to `TRY_AGAIN`. This caused issue in a tested transaction for a user.

In order to make this switch we need to verify the blocking logic for the `TRY_AGAIN`/`FAILURE` statuses here is sufficient.
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
