### PR TITLE
feat: allow repeated face error if the repeated face is from same user

### DIFF
--- a/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
+++ b/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
@@ -87,6 +87,26 @@ export type ImageChecksLabel =
   | 'PRECONDITION_NOT_FULFILLED'
   | 'TECHNICAL_ERROR';
 
+export type ImageCheck = {
+  id: string;
+  credentials: {
+    id: string;
+    category: string;
+  }[];
+  decision: {
+    type: string;
+    details: {
+      label: ImageChecksLabel;
+    };
+  };
+  data: {
+    faceSearchFindings: {
+      status: string;
+      findings: string[];
+    };
+  };
+};
+
 export interface JumioTransactionRetrieveResponse {
   account: {
     id: string;
@@ -226,30 +246,6 @@ export interface JumioTransactionRetrieveResponse {
         };
       };
     }[];
-    imageChecks: {
-      id: string;
-      credentials: [
-        {
-          id: string;
-          category: string;
-        },
-        {
-          id: string;
-          category: string;
-        },
-      ];
-      decision: {
-        type: string;
-        details: {
-          label: ImageChecksLabel;
-        };
-      };
-      data: {
-        faceSearchFindings: {
-          status: string;
-          findings: string[];
-        };
-      };
-    }[];
+    imageChecks: ImageCheck[];
   };
 }

--- a/src/jumio-kyc/fixtures/image-check.ts
+++ b/src/jumio-kyc/fixtures/image-check.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ImageChecksLabel } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const IMAGE_CHECK_FIXTURE = {
+  id: '1568893e-5edc-453c-9c50-e47fa10578f8',
+  credentials: [
+    {
+      id: 'fakecredentialsid',
+      category: 'ID',
+    },
+    {
+      id: 'fakecredentialsid',
+      category: 'SELFIE',
+    },
+  ],
+  decision: {
+    type: 'WARNING',
+    details: {
+      label: 'REPEATED_FACE' as ImageChecksLabel,
+    },
+  },
+  data: {
+    faceSearchFindings: {
+      status: 'DONE',
+      findings: [
+        'f7fe3c49-6221-4d87-b8b9-0cd243b65088',
+        '85b26f35-cf4e-4a68-8bce-88c20f06d3ff',
+      ],
+    },
+  },
+};

--- a/src/jumio-kyc/fixtures/workflow.ts
+++ b/src/jumio-kyc/fixtures/workflow.ts
@@ -2,22 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { DecisionStatus } from '@prisma/client';
-import { JumioTransactionRetrieveResponse } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+import {
+  ImageCheck,
+  JumioTransactionRetrieveResponse,
+} from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+import { IMAGE_CHECK_FIXTURE } from './image-check';
 
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export const WORKFLOW_RETRIEVE_FIXTURE = (
   workflowStatus: 'TOKEN_EXPIRED' | 'SESSION_EXPIRED' | 'PROCESSED',
   idCountryCode: string,
   decisionStatus: DecisionStatus,
+  userId = '1',
+  imageCheck: ImageCheck = IMAGE_CHECK_FIXTURE,
 ): JumioTransactionRetrieveResponse => {
   return {
     workflow: {
       id: 'fakeworkflowid',
       status: workflowStatus,
       definitionKey: '10013',
-      customerInternalReference: 'FOO',
+      customerInternalReference: userId,
     },
     account: {
       id: 'fakeaccountid',
@@ -196,36 +199,7 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
           },
         },
       ],
-      imageChecks: [
-        {
-          id: '1568893e-5edc-453c-9c50-e47fa10578f8',
-          credentials: [
-            {
-              id: 'fakecredentialsid',
-              category: 'ID',
-            },
-            {
-              id: 'fakecredentialsid',
-              category: 'SELFIE',
-            },
-          ],
-          decision: {
-            type: 'WARNING',
-            details: {
-              label: 'REPEATED_FACE',
-            },
-          },
-          data: {
-            faceSearchFindings: {
-              status: 'DONE',
-              findings: [
-                'f7fe3c49-6221-4d87-b8b9-0cd243b65088',
-                '85b26f35-cf4e-4a68-8bce-88c20f06d3ff',
-              ],
-            },
-          },
-        },
-      ],
+      imageChecks: [imageCheck],
       usability: [
         {
           id: 'ab66e806-87a7-4132-a677-8ae594d21fbd',

--- a/src/jumio-kyc/kyc.service.ts
+++ b/src/jumio-kyc/kyc.service.ts
@@ -212,7 +212,9 @@ export class KycService {
       transaction.workflow_execution_id,
     );
 
-    const calculatedStatus = this.redemptionService.calculateStatus(status);
+    const calculatedStatus = await this.redemptionService.calculateStatus(
+      status,
+    );
 
     // Has our user's KYC status changed
     if (redemption.kyc_status !== calculatedStatus.status) {

--- a/src/jumio-transactions/jumio-transaction.service.ts
+++ b/src/jumio-transactions/jumio-transaction.service.ts
@@ -31,6 +31,14 @@ export class JumioTransactionService {
     });
   }
 
+  async findByWorkflowIds(
+    workflowExecutionIds: string[],
+  ): Promise<JumioTransaction[]> {
+    return await this.prisma.jumioTransaction.findMany({
+      where: { workflow_execution_id: { in: workflowExecutionIds } },
+    });
+  }
+
   async findLatestOrThrow(user: User): Promise<JumioTransaction> {
     const jumioTransactions = await this.getList(user);
     if (!jumioTransactions.length) {

--- a/src/redemptions/redemption.module.ts
+++ b/src/redemptions/redemption.module.ts
@@ -3,13 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
 import { ApiConfigModule } from '../api-config/api-config.module';
+import { JumioTransactionModule } from '../jumio-transactions/jumio-transaction.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { UserPointsModule } from '../user-points/user-points.module';
 import { RedemptionService } from './redemption.service';
 
 @Module({
   exports: [RedemptionService],
-  imports: [PrismaModule, UserPointsModule, ApiConfigModule],
+  imports: [
+    PrismaModule,
+    UserPointsModule,
+    JumioTransactionModule,
+    ApiConfigModule,
+  ],
   providers: [RedemptionService],
 })
 export class RedemptionModule {}

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -6,8 +6,12 @@ import { DecisionStatus, KycStatus, Redemption, User } from '@prisma/client';
 import { instanceToPlain } from 'class-transformer';
 import { ApiConfigService } from '../api-config/api-config.service';
 import { AIRDROP_CONFIG } from '../common/constants';
-import { JumioTransactionRetrieveResponse } from '../jumio-api/interfaces/jumio-transaction-retrieve';
+import {
+  ImageCheck,
+  JumioTransactionRetrieveResponse,
+} from '../jumio-api/interfaces/jumio-transaction-retrieve';
 import { IdDetails } from '../jumio-kyc/kyc.service';
+import { JumioTransactionService } from '../jumio-transactions/jumio-transaction.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { BasePrismaClient } from '../prisma/types/base-prisma-client';
 import { UserPointsService } from '../user-points/user-points.service';
@@ -17,6 +21,7 @@ export class RedemptionService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly userPointsService: UserPointsService,
+    private readonly jumioTransactionService: JumioTransactionService,
     private readonly config: ApiConfigService,
   ) {}
 
@@ -34,11 +39,15 @@ export class RedemptionService {
     });
   }
 
-  calculateStatus(transactionStatus: JumioTransactionRetrieveResponse): {
+  async calculateStatus(
+    transactionStatus: JumioTransactionRetrieveResponse,
+  ): Promise<{
     status: KycStatus;
     failureMessage: string | null;
     idDetails: IdDetails[];
-  } {
+  }> {
+    const userId = Number(transactionStatus.workflow.customerInternalReference);
+    const labels = this.getTransactionLabels(transactionStatus);
     // deal with banned countries
     const idDetails: IdDetails[] =
       transactionStatus.capabilities.extraction.map((extraction) => {
@@ -78,13 +87,16 @@ export class RedemptionService {
         idDetails,
       };
     }
+    const repeatedFaceWorkflowIds = this.getRepeatedFaceWorkflowIds(
+      transactionStatus.capabilities.imageChecks,
+    );
+    const multiAccountFailure = await this.multiAccountFailure(
+      userId,
+      repeatedFaceWorkflowIds,
+    );
+
     // TODO: HANDLE WARN, use decision.risk.score?
-    const failure =
-      this.livenessStatus(transactionStatus) ||
-      this.similarityStatus(transactionStatus) ||
-      this.dataChecksStatus(transactionStatus) ||
-      this.extractionStatus(transactionStatus) ||
-      this.usabilityStatus(transactionStatus);
+    const failure = multiAccountFailure || this.labelFailure(labels);
     if (failure) {
       return {
         status: KycStatus.FAILED,
@@ -92,48 +104,81 @@ export class RedemptionService {
         idDetails,
       };
     }
-
+    if (!multiAccountFailure && this.hasOnlyDuplicateFaceFailures(labels)) {
+      return {
+        status: KycStatus.SUBMITTED,
+        failureMessage: `Benign duplicate faces found`,
+        idDetails,
+      };
+    }
     return {
       status: KycStatus.TRY_AGAIN,
       failureMessage: null,
       idDetails,
     };
   }
-
-  similarityStatus(_response: JumioTransactionRetrieveResponse): string | null {
-    return null;
+  getTransactionLabels(status: JumioTransactionRetrieveResponse): string[] {
+    return [
+      ...status.capabilities.dataChecks.map((i) => i.decision.details.label),
+      ...status.capabilities.extraction.map((i) => i.decision.details.label),
+      ...status.capabilities.imageChecks.map((i) => i.decision.details.label),
+      ...status.capabilities.liveness.map((i) => i.decision.details.label),
+      ...status.capabilities.similarity.map((i) => i.decision.details.label),
+      ...status.capabilities.usability.map((i) => i.decision.details.label),
+    ];
   }
 
-  livenessStatus(response: JumioTransactionRetrieveResponse): string | null {
-    for (const check of response.capabilities.liveness) {
-      if (
-        ['PHOTOCOPY', 'DIGITAL_COPY', 'MANIPULATED', 'BLACK_WHITE'].includes(
-          check.decision.details.label,
-        )
-      ) {
-        return `Liveness check failed: ${check.decision.details.label}`;
+  getRepeatedFaceWorkflowIds(imageChecks: ImageCheck[]): string[] {
+    // for imageChecks, only duplicate face should pass
+    let repeatedFaceWorkflowIds: string[] = [];
+    for (const imageCheck of imageChecks) {
+      if (imageCheck.decision.details.label !== 'REPEATED_FACE') {
+        continue;
+      }
+      repeatedFaceWorkflowIds = repeatedFaceWorkflowIds.concat(
+        imageCheck.data.faceSearchFindings.findings,
+      );
+    }
+    return repeatedFaceWorkflowIds;
+  }
+
+  async multiAccountFailure(
+    userId: number,
+    repeatedFaceWorkflowIds: string[],
+  ): Promise<string | null> {
+    if (!repeatedFaceWorkflowIds.length) {
+      return null;
+    }
+    // lookup workflows returned as matching
+    const foundWorkflows = await this.jumioTransactionService.findByWorkflowIds(
+      repeatedFaceWorkflowIds,
+    );
+
+    // If any are found and don't match current user, ban the current user for scamming
+    for (const foundWorkflow of foundWorkflows) {
+      if (foundWorkflow.user_id !== userId) {
+        return `User with multiple accounts detected (alternate user id=${foundWorkflow.user_id} , current user id=${userId}), this transaction matches face from different account in transaction_id=${foundWorkflow.workflow_execution_id}`;
       }
     }
-
     return null;
   }
 
-  dataChecksStatus(_response: JumioTransactionRetrieveResponse): string | null {
-    return null;
-  }
-
-  extractionStatus(_response: JumioTransactionRetrieveResponse): string | null {
-    return null;
-  }
-
-  usabilityStatus(response: JumioTransactionRetrieveResponse): string | null {
-    for (const check of response.capabilities.usability) {
-      if (
-        check.decision.details.label === 'PHOTOCOPY' ||
-        check.decision.details.label === 'BLACK_WHITE'
-      ) {
-        return `Usability check failed: ${check.decision.details.label}`;
+  hasOnlyDuplicateFaceFailures(labels: string[]): boolean {
+    // if any other check failed, we can't pass
+    for (const label of labels) {
+      if (!['MATCH', 'REPEATED_FACE', 'OK'].includes(label)) {
+        return false;
       }
+    }
+    return true;
+  }
+
+  labelFailure(labels: string[]): string | null {
+    const failedLabels = labels.filter((i) =>
+      ['PHOTOCOPY', 'DIGITAL_COPY', 'MANIPULATED', 'BLACK_WHITE'].includes(i),
+    );
+    if (failedLabels.length) {
+      return `Failure due to label presence: ${failedLabels.join(',')}`;
     }
     return null;
   }


### PR DESCRIPTION
## Summary
When a user submits a KYC attempt, if they fail they will be flagged in subsequent transactions as duplicate face detected.

Here we check to make sure all duplicate faces that are detected are associated with users account associated with the current callback context.
## Testing Plan
Tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
