### PR TITLE
feat: add allocations table

### DIFF
--- a/prisma/migrations/20230308230847_add_pool_allocation_columns/migration.sql
+++ b/prisma/migrations/20230308230847_add_pool_allocation_columns/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "redemptions" ADD COLUMN     "pool1_ore" BIGINT,
+ADD COLUMN     "pool2_ore" BIGINT,
+ADD COLUMN     "pool3_ore" BIGINT,
+ADD COLUMN     "pool4_ore" BIGINT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,10 @@ model Redemption {
   public_address   String    @db.VarChar
   id_details       Json?
   failure_message  String?   @db.VarChar
+  pool1_ore        BigInt?
+  pool2_ore        BigInt?
+  pool3_ore        BigInt?
+  pool4_ore        BigInt?
   @@index([jumio_account_id], name: "index_redemption_jumio_account_id")
   @@index([user_id], name: "index_redemption_on_user_id")
   @@map("redemptions")


### PR DESCRIPTION
## Summary
Adds allocations table, I am planning on calculating this via graphile job that will be triggered by protected endpoint. If the allocations exist, I will throw error and require user to wipe table manually if they want to regenerate.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
