### PR TITLE
chore: make ban logic return first

### DIFF
--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -260,16 +260,16 @@ export class RedemptionService {
     redemption?: Redemption | null,
     prisma?: BasePrismaClient,
   ): Promise<{ eligible: boolean; reason: string }> {
+    if (user.ineligible_reason) {
+      return { eligible: false, reason: user.ineligible_reason };
+    }
+
     if (!user.enable_kyc) {
       return {
         eligible: false,
         reason:
           'KYC is not available for you account, please check back later as we continue to open KYC to new users',
       };
-    }
-
-    if (user.ineligible_reason) {
-      return { eligible: false, reason: user.ineligible_reason };
     }
 
     if (redemption) {


### PR DESCRIPTION
## Summary
Raises ban logic ahead of enabled KYC error so that we can start to see if there are any spurious bans.
## Testing Plan
Tests pass

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
