### PR TITLE
feat: sanctions screening response updates (1/3)

### DIFF
--- a/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
+++ b/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
@@ -87,6 +87,17 @@ export type ImageChecksLabel =
   | 'PRECONDITION_NOT_FULFILLED'
   | 'TECHNICAL_ERROR';
 
+export type WatchlistScreeningLabels =
+  | 'NOT_ENOUGH_DATA'
+  | 'VALIDATION_FAILED'
+  | 'INVALID_MERCHANT_SETTINGS'
+  | 'TECHNICAL_ERROR'
+  | 'EXTRACTION_NOT_DONE'
+  | 'NO_VALID_ID_CREDENTIAL'
+  | 'PRECONDITION_NOT_FULFILLED'
+  | 'OK'
+  | 'ALERT';
+
 export type ImageCheck = {
   id: string;
   credentials: {
@@ -247,5 +258,25 @@ export interface JumioTransactionRetrieveResponse {
       };
     }[];
     imageChecks: ImageCheck[];
+    watchlistScreening: {
+      id: string;
+      credentials: {
+        id: string;
+        category: string;
+      }[];
+      decision: {
+        type: 'PASSED' | 'WARNING' | 'NOT_EXECUTED';
+        details: {
+          label: WatchlistScreeningLabels;
+        };
+      };
+      data: {
+        searchDate: string;
+        searchResults: number;
+        searchResultUrl: string;
+        searchReference: string;
+        searchStatus: 'DONE' | 'NOT_DONE' | 'ERROR';
+      };
+    }[];
   };
 }

--- a/src/jumio-kyc/fixtures/workflow.ts
+++ b/src/jumio-kyc/fixtures/workflow.ts
@@ -5,6 +5,7 @@ import { DecisionStatus } from '@prisma/client';
 import {
   ImageCheck,
   JumioTransactionRetrieveResponse,
+  WatchlistScreeningLabels,
 } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
 import { IMAGE_CHECK_FIXTURE } from './image-check';
 
@@ -14,6 +15,7 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
   decisionStatus: DecisionStatus,
   userId = '1',
   imageCheck: ImageCheck = IMAGE_CHECK_FIXTURE,
+  screeningLabel: WatchlistScreeningLabels = 'OK',
 ): JumioTransactionRetrieveResponse => {
   return {
     workflow: {
@@ -244,6 +246,30 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
             details: {
               label: 'OK',
             },
+          },
+        },
+      ],
+      watchlistScreening: [
+        {
+          id: 'fakeid',
+          credentials: [
+            {
+              id: 'fakeid',
+              category: 'fakecategory',
+            },
+          ],
+          decision: {
+            type: 'PASSED',
+            details: {
+              label: screeningLabel,
+            },
+          },
+          data: {
+            searchDate: '2021-03-12T15:47:17.234Z',
+            searchResults: 123,
+            searchResultUrl: 'http://foo.com',
+            searchReference: 'referenceid',
+            searchStatus: 'DONE',
           },
         },
       ],

--- a/src/redemptions/redemption.service.spec.ts
+++ b/src/redemptions/redemption.service.spec.ts
@@ -312,4 +312,29 @@ describe('RedemptionServiceSpec', () => {
       expect(acceptableFace).toBe(true);
     });
   });
+
+  describe('sanctionScreenFailure', () => {
+    it('returns true when user fails sanction screeinging', () => {
+      const failFixture = WORKFLOW_RETRIEVE_FIXTURE(
+        'PROCESSED',
+        'CHL',
+        DecisionStatus.REJECTED,
+        'fakeaccountid',
+        undefined,
+        'ALERT', // sanction screening label
+      );
+      expect(redemptionService.sanctionScreenFailure(failFixture)).toBe(true);
+    });
+    it('returns false when user passes sanction screeinging', () => {
+      const failFixture = WORKFLOW_RETRIEVE_FIXTURE(
+        'PROCESSED',
+        'CHL',
+        DecisionStatus.REJECTED,
+        'fakeaccountid',
+        undefined,
+        'OK', // sanction screening label
+      );
+      expect(redemptionService.sanctionScreenFailure(failFixture)).toBe(false);
+    });
+  });
 });

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -71,6 +71,14 @@ export class RedemptionService {
         idDetails,
       };
     }
+
+    if (this.sanctionScreenFailure(transactionStatus)) {
+      return {
+        status: KycStatus.FAILED,
+        failureMessage: 'Sanction screening failed, ineligible for airdrop.',
+        idDetails,
+      };
+    }
     if (
       transactionStatus.workflow.status === 'SESSION_EXPIRED' ||
       transactionStatus.workflow.status === 'TOKEN_EXPIRED' ||
@@ -142,6 +150,15 @@ export class RedemptionService {
       );
     }
     return repeatedFaceWorkflowIds;
+  }
+
+  sanctionScreenFailure(status: JumioTransactionRetrieveResponse): boolean {
+    for (const screen of status.capabilities.watchlistScreening) {
+      if (screen.decision.details.label === 'ALERT') {
+        return true;
+      }
+    }
+    return false;
   }
 
   async multiAccountFailure(


### PR DESCRIPTION
## Summary
Sanction screening for inline Jumio workflow KYC/Screening (workflow 10032).

## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
