### PR TITLE
feat: add new sanction screening manual trigger endpoint (3/3)

### DIFF
--- a/src/jumio-api/interfaces/jumio-put-standalone-screening.ts
+++ b/src/jumio-api/interfaces/jumio-put-standalone-screening.ts
@@ -1,25 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-export interface JumioAccountCreateResponse {
+export interface JumioPutStandaloneScreening {
+  timestamp: string;
   account: {
     id: string;
   };
-  web: {
-    href: string;
-  };
   workflowExecution: {
     id: string;
-    credentials: {
-      id: string;
-      api: {
-        token: string;
-        parts: {
-          prepared_data: string; // parts upload url
-        };
-        workflowExecution: string;
-      };
-    }[];
   };
 }

--- a/src/jumio-api/interfaces/jumio-standalone-screening-create.ts
+++ b/src/jumio-api/interfaces/jumio-standalone-screening-create.ts
@@ -1,25 +1,16 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-export interface JumioAccountCreateResponse {
+export interface JumioStandaloneUpload {
+  timestamp: string;
   account: {
     id: string;
   };
-  web: {
-    href: string;
-  };
   workflowExecution: {
     id: string;
-    credentials: {
-      id: string;
-      api: {
-        token: string;
-        parts: {
-          prepared_data: string; // parts upload url
-        };
-        workflowExecution: string;
-      };
-    }[];
+  };
+  api: {
+    token: string;
+    workflowExecution: string;
   };
 }

--- a/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
+++ b/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
@@ -160,7 +160,7 @@ export interface JumioTransactionRetrieveResponse {
   };
   workflow: {
     id: string;
-    definitionKey: string;
+    definitionKey: number;
     userReference: string;
     status: 'INITIATED' | 'PROCESSED' | 'SESSION_EXPIRED' | 'TOKEN_EXPIRED';
     customerInternalReference: string;
@@ -284,3 +284,8 @@ export interface JumioTransactionRetrieveResponse {
     watchlistScreening: WatchlistScreenCheck[];
   };
 }
+
+export type JumioTransactionStandaloneSanction = Omit<
+  JumioTransactionRetrieveResponse,
+  'capabilities'
+> & { capabilities: { watchlistScreening: WatchlistScreenCheck[] } };

--- a/src/jumio-api/jumio-api.service.spec.ts
+++ b/src/jumio-api/jumio-api.service.spec.ts
@@ -34,7 +34,7 @@ describe('JumioApiService', () => {
     describe('when calling jumio', () => {
       it('creates account when jumioAccountId is not present', async () => {
         const postMock = axiosMock();
-        await jumioApiService.createAccountAndTransaction(123, null);
+        await jumioApiService.createAccountAndTransaction(123, null, 10032);
 
         expect(postMock).toHaveBeenCalledWith(
           'https://account.amer-1.jumio.ai/api/v1/accounts',
@@ -65,7 +65,11 @@ describe('JumioApiService', () => {
       it('updates existing account when jumioAccountId is present', async () => {
         const postMock = axiosMock('put');
 
-        await jumioApiService.createAccountAndTransaction(123, 'fooaccount');
+        await jumioApiService.createAccountAndTransaction(
+          123,
+          'fooaccount',
+          10032,
+        );
 
         expect(postMock).toHaveBeenCalledWith(
           'https://account.amer-1.jumio.ai/api/v1/accounts/fooaccount',

--- a/src/jumio-api/jumio-api.service.ts
+++ b/src/jumio-api/jumio-api.service.ts
@@ -53,6 +53,7 @@ export class JumioApiService {
   async createAccountAndTransaction(
     userId: number,
     jumioAccountId: string | null,
+    workflowDefinitionKey: number,
   ): Promise<JumioAccountCreateResponse> {
     let url =
       'https://account.' + this.config.get<string>('JUMIO_URL') + '/accounts';
@@ -69,7 +70,7 @@ export class JumioApiService {
       userReference: `t=${ts},v1=${hmac}`,
       callbackUrl: this.getCallbackUrl(),
       workflowDefinition: {
-        key: this.config.get<number>('JUMIO_WORKFLOW_DEFINITION'),
+        key: workflowDefinitionKey,
         capabilities: {
           watchlistScreening: {
             additionalProperties: '',

--- a/src/jumio-kyc/fixtures/jumio-create-response.ts
+++ b/src/jumio-kyc/fixtures/jumio-create-response.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { v4 as uuid } from 'uuid';
+
+export const JUMIO_CREATE_RESPONSE = {
+  account: {
+    id: uuid(),
+  },
+  web: {
+    href: uuid(),
+  },
+  workflowExecution: {
+    id: uuid(),
+    credentials: [
+      {
+        id: uuid(),
+        api: {
+          token: 'faketoken',
+          parts: {
+            prepared_data: 'http://jumio.com/parts',
+          },
+          workflowExecution: 'http://jumio.com/workflow',
+        },
+      },
+    ],
+  },
+};

--- a/src/jumio-kyc/fixtures/watchlist-create-response.ts
+++ b/src/jumio-kyc/fixtures/watchlist-create-response.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const WORKFLOW_CREATE_WATCHLIST_RESPONSE = {
+  timestamp: '2023-03-10T04:30:53.549Z',
+  account: {
+    id: 'aefa1cc2-011a-4615-8e7d-fdcaddb508cd',
+  },
+  workflowExecution: {
+    id: 'b94de56f-75b7-4df2-9320-eebba497f138',
+    credentials: [
+      {
+        id: '0aa24a7c-ce41-4647-8b87-c0ed5d657da7',
+        category: 'DATA',
+        allowedChannels: ['API'],
+        api: {
+          token:
+            'eyJhbGciOiJIUzUxMiIsInppcCI6IkdaSVAifQ.--OX2Dx83871kWe7zkHV-PvbxeMDJCyY2MLYO1AShIWfY4lI36V6MwvcHxGrHQ-UAAAA.ihiFoZ9qso1kcTj0bN8K2pK4s-_nzTW3g8f5Q6m3bd7ul6zubEA_CrUFcdi5n_xItzOAwq3Kgl8Kd3vQKi4OHw',
+          parts: {
+            prepared_data:
+              'https://api.amer-1.jumio.ai/api/v1/accounts/aefa1cc2-011a-4615-8e7d-fdcaddb508cd/workflow-executions/b94de56f-75b7-4df2-9320-eebba497f138/credentials/0aa24a7c-ce41-4647-8b87-c0ed5d657da7/parts/PREPARED_DATA',
+          },
+          workflowExecution:
+            'https://api.amer-1.jumio.ai/api/v1/accounts/aefa1cc2-011a-4615-8e7d-fdcaddb508cd/workflow-executions/b94de56f-75b7-4df2-9320-eebba497f138',
+        },
+      },
+    ],
+  },
+};

--- a/src/jumio-kyc/fixtures/watchlist-put-response.ts
+++ b/src/jumio-kyc/fixtures/watchlist-put-response.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const WATCHLIST_PUT_RESPONSE = {
+  timestamp: '2023-03-10T04:37:21.781Z',
+  account: {
+    id: 'aefa1cc2-011a-4615-8e7d-fdcaddb508cd',
+  },
+  workflowExecution: {
+    id: 'b94de56f-75b7-4df2-9320-eebba497f138',
+  },
+};

--- a/src/jumio-kyc/fixtures/watchlist-upload-response.ts
+++ b/src/jumio-kyc/fixtures/watchlist-upload-response.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const WATCHLIST_DATA_UPLOAD_RESPONSE = {
+  timestamp: '2023-03-10T04:35:59.680Z',
+  account: {
+    id: 'aefa1cc2-011a-4615-8e7d-fdcaddb508cd',
+  },
+  workflowExecution: {
+    id: 'b94de56f-75b7-4df2-9320-eebba497f138',
+  },
+  api: {
+    token:
+      'eyJhbGciOiJIUzUxMiIsInppcCI6IkdaSVAifQ.--OX2Dx83871kWe7zkHV-PvbxeMDJCyY2MLYO1AShIWfY4lI36V6MwvcHxGrHQ-UAAAA.ihiFoZ9qso1kcTj0bN8K2pK4s-_nzTW3g8f5Q6m3bd7ul6zubEA_CrUFcdi5n_xItzOAwq3Kgl8Kd3vQKi4OHw',
+    parts: {},
+    workflowExecution:
+      'https://api.amer-1.jumio.ai/api/v1/accounts/aefa1cc2-011a-4615-8e7d-fdcaddb508cd/workflow-executions/b94de56f-75b7-4df2-9320-eebba497f138',
+  },
+};

--- a/src/jumio-kyc/fixtures/workflow-watchlist-pass.ts
+++ b/src/jumio-kyc/fixtures/workflow-watchlist-pass.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { JumioTransactionStandaloneSanction } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+
+export const WORKFLOW_RETRIEVE_WATCHLIST_PASS: JumioTransactionStandaloneSanction =
+  {
+    workflow: {
+      id: 'b94de56f-75b7-4df2-9320-eebba497f138',
+      status: 'PROCESSED',
+      definitionKey: 10010,
+      userReference: 'foo',
+      customerInternalReference: 'application',
+    },
+    account: {
+      id: 'aefa1cc2-011a-4615-8e7d-fdcaddb508cd',
+    },
+    createdAt: '2023-03-10T04:30:53.529Z',
+    startedAt: '2023-03-10T04:37:21.775Z',
+    completedAt: '2023-03-10T04:37:23.104Z',
+    credentials: [
+      {
+        id: '0aa24a7c-ce41-4647-8b87-c0ed5d657da7',
+        category: 'DATA',
+        parts: [
+          {
+            classifier: 'PREPARED_DATA',
+            href: 'https://retrieval.amer-1.jumio.ai/api/v1/accounts/aefa1cc2-011a-4615-8e7d-fdcaddb508cd/credentials/0aa24a7c-ce41-4647-8b87-c0ed5d657da7/parts/PREPARED_DATA',
+          },
+        ],
+      },
+    ],
+    decision: {
+      type: 'PASSED',
+      details: {
+        label: 'OK',
+      },
+      risk: {
+        score: 0,
+      },
+    },
+    steps: {
+      href: 'https://retrieval.amer-1.jumio.ai/api/v1/accounts/aefa1cc2-011a-4615-8e7d-fdcaddb508cd/workflow-executions/b94de56f-75b7-4df2-9320-eebba497f138/steps',
+    },
+    capabilities: {
+      watchlistScreening: [
+        {
+          id: '17b614a5-6cc4-4d20-a63b-55de146cf1c6',
+          credentials: [
+            {
+              id: '0aa24a7c-ce41-4647-8b87-c0ed5d657da7',
+              category: 'DATA',
+            },
+          ],
+          decision: {
+            type: 'PASSED',
+            details: {
+              label: 'OK',
+            },
+          },
+          data: {
+            searchDate: '2023-03-10T04:37:22.000Z',
+            searchId: '1232090652',
+            searchReference: '1678423042-32DnQzv3',
+            searchResultUrl:
+              'https://app.complyadvantage.com/public/search/13/b0',
+            searchResults: 0,
+            searchStatus: 'SUCCESS',
+          },
+        },
+      ],
+    },
+  };

--- a/src/jumio-kyc/fixtures/workflow-watchlist.ts
+++ b/src/jumio-kyc/fixtures/workflow-watchlist.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  JumioTransactionStandaloneSanction,
+  WatchlistScreeningLabels,
+} from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+
+export const WORKFLOW_RETRIEVE_WATCHLIST = (
+  watchlistLabel: WatchlistScreeningLabels,
+): JumioTransactionStandaloneSanction => {
+  return {
+    workflow: {
+      id: 'b94de56f-75b7-4df2-9320-eebba497f138',
+      status: 'PROCESSED',
+      definitionKey: 10010,
+      userReference: 'foo',
+      customerInternalReference: 'application',
+    },
+    account: {
+      id: 'aefa1cc2-011a-4615-8e7d-fdcaddb508cd',
+    },
+    createdAt: '2023-03-10T04:30:53.529Z',
+    startedAt: '2023-03-10T04:37:21.775Z',
+    completedAt: '2023-03-10T04:37:23.104Z',
+    credentials: [
+      {
+        id: '0aa24a7c-ce41-4647-8b87-c0ed5d657da7',
+        category: 'DATA',
+        parts: [
+          {
+            classifier: 'PREPARED_DATA',
+            href: 'https://retrieval.amer-1.jumio.ai/api/v1/accounts/aefa1cc2-011a-4615-8e7d-fdcaddb508cd/credentials/0aa24a7c-ce41-4647-8b87-c0ed5d657da7/parts/PREPARED_DATA',
+          },
+        ],
+      },
+    ],
+    decision: {
+      type: 'PASSED',
+      details: {
+        label: 'OK',
+      },
+      risk: {
+        score: 50.0,
+      },
+    },
+    steps: {
+      href: 'https://retrieval.amer-1.jumio.ai/api/v1/accounts/aefa1cc2-011a-4615-8e7d-fdcaddb508cd/workflow-executions/b94de56f-75b7-4df2-9320-eebba497f138/steps',
+    },
+    capabilities: {
+      watchlistScreening: [
+        {
+          id: '17b614a5-6cc4-4d20-a63b-55de146cf1c6',
+          credentials: [
+            {
+              id: '0aa24a7c-ce41-4647-8b87-c0ed5d657da7',
+              category: 'DATA',
+            },
+          ],
+          decision: {
+            type: 'WARNING',
+            details: {
+              label: watchlistLabel,
+            },
+          },
+          data: {
+            searchDate: '2023-03-10T04:37:22.000Z',
+            searchId: '1232090652',
+            searchReference: '1678423042-32DnQzv3',
+            searchResultUrl:
+              'https://app.complyadvantage.com/public/search/13/b0',
+            searchResults: 1,
+            searchStatus: 'SUCCESS',
+          },
+        },
+      ],
+    },
+  };
+};

--- a/src/jumio-kyc/fixtures/workflow.ts
+++ b/src/jumio-kyc/fixtures/workflow.ts
@@ -17,17 +17,19 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
   userId = '1',
   imageCheck: ImageCheck = IMAGE_CHECK_FIXTURE,
   watchlistCheck: WatchlistScreenCheck = WATCHLIST_SCREEN_FIXTURE(),
+  workflowId = 'fakeworkflowid',
+  accountId = 'accountId',
 ): JumioTransactionRetrieveResponse => {
   return {
     workflow: {
-      id: 'fakeworkflowid',
+      id: workflowId,
       status: workflowStatus,
-      definitionKey: '10013',
+      definitionKey: 10013,
       userReference: 'foobar',
       customerInternalReference: userId,
     },
     account: {
-      id: 'fakeaccountid',
+      id: accountId,
     },
     createdAt: '2023-03-02T18:48:37.319Z',
     startedAt: '2023-03-02T19:04:42.008Z',

--- a/src/jumio-kyc/interfaces/screening-data.ts
+++ b/src/jumio-kyc/interfaces/screening-data.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export interface ScreeningData {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string; // exampke "1990-01-01"
+  address: {
+    country: string; // 3 letter country code
+  };
+}

--- a/src/jumio-kyc/kyc.controller.ts
+++ b/src/jumio-kyc/kyc.controller.ts
@@ -61,10 +61,14 @@ export class KycController {
     @Req()
     req: Request,
   ): Promise<SerializedKyc> {
+    const workflowDefinitionKey = this.config.get<number>(
+      'JUMIO_WORKFLOW_DEFINITION',
+    );
     const { redemption, transaction } = await this.kycService.attempt(
       user,
       dto.public_address,
       fetchIpAddressFromRequest(req),
+      workflowDefinitionKey,
     );
 
     const { eligible, reason: eligibleReason } =

--- a/src/jumio-kyc/kyc.controller.ts
+++ b/src/jumio-kyc/kyc.controller.ts
@@ -28,6 +28,7 @@ import { GraphileWorkerPattern } from '../graphile-worker/enums/graphile-worker-
 import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
 import { JumioTransactionService } from '../jumio-transactions/jumio-transaction.service';
 import { RedemptionService } from '../redemptions/redemption.service';
+import { UsersService } from '../users/users.service';
 import { CreateKycDto } from './dto/create-kyc.dto';
 import { JumioCallbackData } from './interfaces/jumio-callback-data';
 import { RefreshUserRedemptionOptions } from './interfaces/refresh-user-redemption-options';
@@ -45,6 +46,7 @@ export class KycController {
     private readonly kycService: KycService,
     private readonly graphileWorkerService: GraphileWorkerService,
     private readonly config: ApiConfigService,
+    private readonly usersService: UsersService,
   ) {}
 
   @ApiExcludeEndpoint()
@@ -61,14 +63,10 @@ export class KycController {
     @Req()
     req: Request,
   ): Promise<SerializedKyc> {
-    const workflowDefinitionKey = this.config.get<number>(
-      'JUMIO_WORKFLOW_DEFINITION',
-    );
     const { redemption, transaction } = await this.kycService.attempt(
       user,
       dto.public_address,
       fetchIpAddressFromRequest(req),
-      workflowDefinitionKey,
     );
 
     const { eligible, reason: eligibleReason } =
@@ -183,5 +181,17 @@ export class KycController {
   @UseGuards(MagicLinkGuard)
   async markComplete(@Context() { user }: MagicLinkContext): Promise<void> {
     await this.kycService.markComplete(user);
+  }
+
+  @ApiExcludeEndpoint()
+  @Get('/sanctions/:id')
+  @UseGuards(ApiKeyGuard)
+  async sanctionScreening(
+    @Res() res: Response,
+    @Param('id', new IntIsSafeForPrismaPipe())
+    id: number,
+  ): Promise<void> {
+    await this.kycService.standaloneWatchlist(id);
+    res.status(HttpStatus.OK).send();
   }
 }

--- a/src/jumio-kyc/kyc.rest.module.ts
+++ b/src/jumio-kyc/kyc.rest.module.ts
@@ -6,6 +6,7 @@ import { ApiConfigModule } from '../api-config/api-config.module';
 import { GraphileWorkerModule } from '../graphile-worker/graphile-worker.module';
 import { JumioTransactionModule } from '../jumio-transactions/jumio-transaction.module';
 import { RedemptionModule } from '../redemptions/redemption.module';
+import { UsersModule } from '../users/users.module';
 import { KycController } from './kyc.controller';
 import { KycModule } from './kyc.module';
 
@@ -17,6 +18,7 @@ import { KycModule } from './kyc.module';
     JumioTransactionModule,
     RedemptionModule,
     GraphileWorkerModule,
+    UsersModule,
   ],
 })
 export class KycRestModule {}

--- a/src/jumio-kyc/kyc.service.spec.ts
+++ b/src/jumio-kyc/kyc.service.spec.ts
@@ -79,6 +79,7 @@ describe('KycService', () => {
         user,
         '',
         '127.0.0.1',
+        10032,
       );
       expect(redemption.kyc_status).toBe(KycStatus.IN_PROGRESS);
       assert.ok(redemption.jumio_account_id);
@@ -114,7 +115,12 @@ describe('KycService', () => {
         where: { user_id: user.id },
       });
 
-      let { redemption } = await kycService.attempt(user, '', '127.0.0.1');
+      let { redemption } = await kycService.attempt(
+        user,
+        '',
+        '127.0.0.1',
+        10032,
+      );
       expect(redemption.kyc_status).toBe(KycStatus.IN_PROGRESS);
 
       await kycService.markComplete(user);

--- a/src/jumio-kyc/kyc.service.ts
+++ b/src/jumio-kyc/kyc.service.ts
@@ -41,6 +41,7 @@ export class KycService {
     user: User,
     publicAddress: string,
     ipAddress: string,
+    workflowDefinitionKey: number,
   ): Promise<{ redemption: Redemption; transaction: JumioTransaction }> {
     return this.prisma.$transaction(async (prisma) => {
       await prisma.$executeRawUnsafe(
@@ -72,6 +73,7 @@ export class KycService {
       const response = await this.jumioApiService.createAccountAndTransaction(
         user.id,
         redemption.jumio_account_id,
+        workflowDefinitionKey,
       );
 
       redemption = await this.redemptionService.update(

--- a/src/jumio-transactions/jumio-transaction.service.spec.ts
+++ b/src/jumio-transactions/jumio-transaction.service.spec.ts
@@ -3,10 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication, NotFoundException } from '@nestjs/common';
 import { DecisionStatus, User } from '@prisma/client';
-import assert from 'assert';
 import faker from 'faker';
 import { v4 as uuid } from 'uuid';
-import { WORKFLOW_RETRIEVE_FIXTURE } from '../jumio-kyc/fixtures/workflow';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
 import { UsersService } from '../users/users.service';
@@ -82,58 +80,6 @@ describe('JumioTransactionService', () => {
           jumioTransactionService.findLatestOrThrow(user),
         ).rejects.toThrow(NotFoundException);
       });
-    });
-  });
-
-  describe('scrubExtractionData', () => {
-    it('removes sensitive PII', () => {
-      const fixture = WORKFLOW_RETRIEVE_FIXTURE(
-        'PROCESSED',
-        'CHL',
-        DecisionStatus.PASSED,
-      );
-      const scrubbedFixture =
-        jumioTransactionService.scrubExtractionData(fixture);
-      assert.ok(scrubbedFixture);
-      const zip = <T>(a: T[], b: T[]): [T, T][] => a.map((k, i) => [k, b[i]]);
-      const zipped = zip(
-        fixture.capabilities.extraction,
-        scrubbedFixture?.capabilities.extraction,
-      );
-      // check retained fields are retained and scrubbed fields are scrubbed
-      for (const [originalExtraction, scrubbedExtraction] of zipped) {
-        expect(scrubbedExtraction.data.type).toBe(originalExtraction.data.type);
-        expect(scrubbedExtraction.data.subType).toBe(
-          originalExtraction.data.subType,
-        );
-        expect(scrubbedExtraction.data.issuingCountry).toBe(
-          originalExtraction.data.issuingCountry,
-        );
-        expect(scrubbedExtraction.data.firstName).toBe(
-          originalExtraction.data.firstName,
-        );
-        expect(scrubbedExtraction.data.lastName).toBe(
-          originalExtraction.data.lastName,
-        );
-        expect(scrubbedExtraction.data.expiryDate).toBe(
-          originalExtraction.data.expiryDate,
-        );
-        expect(scrubbedExtraction.data.dateOfBirth).not.toBe(
-          originalExtraction.data.dateOfBirth,
-        );
-        expect(scrubbedExtraction.data.documentNumber).not.toBe(
-          originalExtraction.data.documentNumber,
-        );
-        expect(scrubbedExtraction.data.optionalMrzField1).not.toBe(
-          originalExtraction.data.optionalMrzField1,
-        );
-        expect(scrubbedExtraction.data.optionalMrzField2).not.toBe(
-          originalExtraction.data.optionalMrzField2,
-        );
-        expect(scrubbedExtraction.data.currentAge).not.toBe(
-          originalExtraction.data.currentAge,
-        );
-      }
     });
   });
 });

--- a/src/jumio-transactions/jumio-transaction.service.ts
+++ b/src/jumio-transactions/jumio-transaction.service.ts
@@ -58,9 +58,10 @@ export class JumioTransactionService {
   async findByWorkflowExecutionId(
     workflowExecutionId: string,
   ): Promise<JumioTransaction | null> {
-    return await this.prisma.jumioTransaction.findFirst({
+    const workflows = await this.prisma.jumioTransaction.findMany({
       where: { workflow_execution_id: workflowExecutionId },
     });
+    return workflows[workflows.length - 1];
   }
 
   async update(
@@ -76,49 +77,13 @@ export class JumioTransactionService {
     return this.prisma.jumioTransaction.update({
       data: {
         decision_status: data.decisionStatus,
-        last_workflow_fetch: instanceToPlain(
-          this.scrubExtractionData(data.lastWorkflowFetch),
-        ),
+        last_workflow_fetch: instanceToPlain(data.lastWorkflowFetch),
         last_callback: instanceToPlain(data.lastCallback),
         last_callback_at: data.lastCallbackAt,
         failure_message: data.failureMessage,
       },
       where: { id: transaction.id },
     });
-  }
-
-  scrubExtractionData(
-    lastWorkflowFetch: JumioTransactionRetrieveResponse | undefined,
-  ): JumioTransactionRetrieveResponse | undefined {
-    if (lastWorkflowFetch === undefined) {
-      return undefined;
-    }
-    const cleanExtractions = [];
-    for (const extraction of lastWorkflowFetch.capabilities.extraction) {
-      cleanExtractions.push({
-        ...extraction,
-        data: {
-          type: extraction.data.type,
-          subType: extraction.data.subType,
-          issuingCountry: extraction.data.issuingCountry,
-          firstName: extraction.data.firstName,
-          lastName: extraction.data.lastName,
-          expiryDate: extraction.data.expiryDate,
-          dateOfBirth: '1600-01-01',
-          documentNumber: '-1',
-          optionalMrzField1: '-1',
-          optionalMrzField2: '-1',
-          currentAge: '80',
-        },
-      });
-    }
-    return {
-      ...lastWorkflowFetch,
-      capabilities: {
-        ...lastWorkflowFetch.capabilities,
-        extraction: cleanExtractions,
-      },
-    };
   }
 
   async create(

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -72,6 +72,14 @@ export class RedemptionService {
         idDetails,
       };
     }
+
+    if (this.sanctionScreenFailure(transactionStatus)) {
+      return {
+        status: KycStatus.FAILED,
+        failureMessage: 'Sanction screening failed, ineligible for airdrop.',
+        idDetails,
+      };
+    }
     if (
       transactionStatus.workflow.status === 'SESSION_EXPIRED' ||
       transactionStatus.workflow.status === 'TOKEN_EXPIRED' ||
@@ -162,6 +170,15 @@ export class RedemptionService {
       }
     }
     return repeatedFaceWorkflowIds;
+  }
+
+  sanctionScreenFailure(status: JumioTransactionRetrieveResponse): boolean {
+    for (const screen of status.capabilities.watchlistScreening) {
+      if (screen.decision.details.label === 'ALERT') {
+        return true;
+      }
+    }
+    return false;
   }
 
   async multiAccountFailure(

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -10,6 +10,7 @@ import { AIRDROP_CONFIG } from '../common/constants';
 import {
   ImageCheck,
   JumioTransactionRetrieveResponse,
+  JumioTransactionStandaloneSanction,
   WatchlistScreenCheck,
 } from '../jumio-api/interfaces/jumio-transaction-retrieve';
 import { IdDetails } from '../jumio-kyc/kyc.service';
@@ -73,13 +74,6 @@ export class RedemptionService {
       };
     }
 
-    if (this.sanctionScreenFailure(transactionStatus)) {
-      return {
-        status: KycStatus.FAILED,
-        failureMessage: 'Sanction screening failed, ineligible for airdrop.',
-        idDetails,
-      };
-    }
     if (
       transactionStatus.workflow.status === 'SESSION_EXPIRED' ||
       transactionStatus.workflow.status === 'TOKEN_EXPIRED' ||
@@ -134,6 +128,33 @@ export class RedemptionService {
       idDetails,
     };
   }
+
+  // this response will only be a subset of JumioTransactionRetrieveResponse
+  calculateStandaloneWatchlistStatus(
+    transactionStatus: JumioTransactionStandaloneSanction,
+  ): {
+    status: KycStatus;
+    failureMessage: string | null;
+    idDetails: undefined;
+  } {
+    if (
+      this.watchlistScreeningFailure(
+        transactionStatus.capabilities.watchlistScreening,
+      )
+    ) {
+      return {
+        status: KycStatus.FAILED,
+        failureMessage: 'Sanction screening failed, ineligible for airdrop.',
+        idDetails: undefined,
+      };
+    }
+    return {
+      status: KycStatus.SUCCESS,
+      failureMessage: '',
+      idDetails: undefined,
+    };
+  }
+
   getTransactionLabels(status: JumioTransactionRetrieveResponse): string[] {
     return [
       ...status.capabilities.dataChecks.map((i) => i.decision.details.label),
@@ -170,15 +191,6 @@ export class RedemptionService {
       }
     }
     return repeatedFaceWorkflowIds;
-  }
-
-  sanctionScreenFailure(status: JumioTransactionRetrieveResponse): boolean {
-    for (const screen of status.capabilities.watchlistScreening) {
-      if (screen.decision.details.label === 'ALERT') {
-        return true;
-      }
-    }
-    return false;
   }
 
   async multiAccountFailure(


### PR DESCRIPTION
## Summary
1. Adds endpoint for manually triggering standalone sanction screening workflows by userId.
2. Adds a method to create/submit standalone screening
   a. POST: Create new workflow (10010) with existing `accountId`
   b. GET: Retrieve PII from Jumio hosted workflow
   b. POST:  push search data (name, dob, country) to workflow from 2a
   c. PUT: force search initiation 
4. Callback will optionally run `redemption.calculateStandaloneSanctionStatus` if the workflow for the callback was `10010`


## Testing Plan
tests pass
NOTE: I tested this via true integration locally and it worked.
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
