### PR TITLE
feat: workflowDefinitionKey as parameter to jumioApiService (2/3)

### DIFF
--- a/src/jumio-api/jumio-api.service.spec.ts
+++ b/src/jumio-api/jumio-api.service.spec.ts
@@ -34,7 +34,7 @@ describe('JumioApiService', () => {
     describe('when calling jumio', () => {
       it('creates account when jumioAccountId is not present', async () => {
         const postMock = axiosMock();
-        await jumioApiService.createAccountAndTransaction(123, null);
+        await jumioApiService.createAccountAndTransaction(123, null, 10032);
 
         expect(postMock).toHaveBeenCalledWith(
           'https://account.amer-1.jumio.ai/api/v1/accounts',
@@ -65,7 +65,11 @@ describe('JumioApiService', () => {
       it('updates existing account when jumioAccountId is present', async () => {
         const postMock = axiosMock('put');
 
-        await jumioApiService.createAccountAndTransaction(123, 'fooaccount');
+        await jumioApiService.createAccountAndTransaction(
+          123,
+          'fooaccount',
+          10032,
+        );
 
         expect(postMock).toHaveBeenCalledWith(
           'https://account.amer-1.jumio.ai/api/v1/accounts/fooaccount',

--- a/src/jumio-api/jumio-api.service.ts
+++ b/src/jumio-api/jumio-api.service.ts
@@ -53,6 +53,7 @@ export class JumioApiService {
   async createAccountAndTransaction(
     userId: number,
     jumioAccountId: string | null,
+    workflowDefinitionKey: number,
   ): Promise<JumioAccountCreateResponse> {
     let url =
       'https://account.' + this.config.get<string>('JUMIO_URL') + '/accounts';
@@ -69,7 +70,7 @@ export class JumioApiService {
       userReference: `t=${ts},v1=${hmac}`,
       callbackUrl: this.getCallbackUrl(),
       workflowDefinition: {
-        key: this.config.get<number>('JUMIO_WORKFLOW_DEFINITION'),
+        key: workflowDefinitionKey,
         capabilities: {
           watchlistScreening: {
             additionalProperties: '',

--- a/src/jumio-kyc/kyc.controller.spec.ts
+++ b/src/jumio-kyc/kyc.controller.spec.ts
@@ -131,7 +131,7 @@ describe('KycController', () => {
       const user = await mockUser('PRK');
 
       await expect(
-        kycService.attempt(user, 'foo', '127.0.0.1'),
+        kycService.attempt(user, 'foo', '127.0.0.1', 10032),
       ).rejects.toThrow(
         'The country associated with your account is banned: PRK',
       );
@@ -264,6 +264,7 @@ describe('KycController', () => {
         user,
         'foo',
         '127.0.0.1',
+        10032,
       );
 
       const { body } = await request(app.getHttpServer())

--- a/src/jumio-kyc/kyc.controller.ts
+++ b/src/jumio-kyc/kyc.controller.ts
@@ -61,10 +61,14 @@ export class KycController {
     @Req()
     req: Request,
   ): Promise<SerializedKyc> {
+    const workflowDefinitionKey = this.config.get<number>(
+      'JUMIO_WORKFLOW_DEFINITION',
+    );
     const { redemption, transaction } = await this.kycService.attempt(
       user,
       dto.public_address,
       fetchIpAddressFromRequest(req),
+      workflowDefinitionKey,
     );
 
     const { eligible, reason: eligibleReason } =

--- a/src/jumio-kyc/kyc.service.spec.ts
+++ b/src/jumio-kyc/kyc.service.spec.ts
@@ -79,6 +79,7 @@ describe('KycService', () => {
         user,
         '',
         '127.0.0.1',
+        10032,
       );
       expect(redemption.kyc_status).toBe(KycStatus.IN_PROGRESS);
       assert.ok(redemption.jumio_account_id);
@@ -114,7 +115,12 @@ describe('KycService', () => {
         where: { user_id: user.id },
       });
 
-      let { redemption } = await kycService.attempt(user, '', '127.0.0.1');
+      let { redemption } = await kycService.attempt(
+        user,
+        '',
+        '127.0.0.1',
+        10032,
+      );
       expect(redemption.kyc_status).toBe(KycStatus.IN_PROGRESS);
 
       await kycService.markComplete(user);

--- a/src/jumio-kyc/kyc.service.ts
+++ b/src/jumio-kyc/kyc.service.ts
@@ -41,6 +41,7 @@ export class KycService {
     user: User,
     publicAddress: string,
     ipAddress: string,
+    workflowDefinitionKey: number,
   ): Promise<{ redemption: Redemption; transaction: JumioTransaction }> {
     return this.prisma.$transaction(async (prisma) => {
       await prisma.$executeRawUnsafe(
@@ -72,6 +73,7 @@ export class KycService {
       const response = await this.jumioApiService.createAccountAndTransaction(
         user.id,
         redemption.jumio_account_id,
+        workflowDefinitionKey,
       );
 
       redemption = await this.redemptionService.update(

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -72,6 +72,7 @@ export class RedemptionService {
         idDetails,
       };
     }
+
     if (
       transactionStatus.workflow.status === 'SESSION_EXPIRED' ||
       transactionStatus.workflow.status === 'TOKEN_EXPIRED' ||


### PR DESCRIPTION
## Summary
Adds ability to define workflow ID for the `attempt` method of KYC. This will be useful so that we can reuse the `attempt` method for calling a standalone screening Jumio workflow (10010)
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
