### PR TITLE
feat: watchlist screening success/failure integration

### DIFF
--- a/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
+++ b/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
@@ -87,6 +87,17 @@ export type ImageChecksLabel =
   | 'PRECONDITION_NOT_FULFILLED'
   | 'TECHNICAL_ERROR';
 
+export type WatchlistScreeningLabels =
+  | 'NOT_ENOUGH_DATA'
+  | 'VALIDATION_FAILED'
+  | 'INVALID_MERCHANT_SETTINGS'
+  | 'TECHNICAL_ERROR'
+  | 'EXTRACTION_NOT_DONE'
+  | 'NO_VALID_ID_CREDENTIAL'
+  | 'PRECONDITION_NOT_FULFILLED'
+  | 'OK'
+  | 'ALERT';
+
 export type ImageCheck = {
   id: string;
   credentials: {
@@ -102,8 +113,30 @@ export type ImageCheck = {
   data: {
     faceSearchFindings: {
       status: string;
-      findings: string[];
+      findings?: string[];
     };
+  };
+};
+
+export type WatchlistScreenCheck = {
+  id: string;
+  credentials: {
+    id: string;
+    category: string;
+  }[];
+  decision: {
+    type: 'PASSED' | 'WARNING' | 'NOT_EXECUTED';
+    details: {
+      label: WatchlistScreeningLabels;
+    };
+  };
+  data: {
+    searchDate: string;
+    searchResults: number;
+    searchId: string;
+    searchResultUrl: string;
+    searchReference: string;
+    searchStatus: 'DONE' | 'NOT_DONE' | 'ERROR' | 'SUCCESS';
   };
 };
 
@@ -128,6 +161,7 @@ export interface JumioTransactionRetrieveResponse {
   workflow: {
     id: string;
     definitionKey: string;
+    userReference: string;
     status: 'INITIATED' | 'PROCESSED' | 'SESSION_EXPIRED' | 'TOKEN_EXPIRED';
     customerInternalReference: string;
   };
@@ -192,7 +226,7 @@ export interface JumioTransactionRetrieveResponse {
       id: string;
       credentials: [
         {
-          id: 'fakecredentialsid';
+          id: string;
           category: 'ID';
         },
       ];
@@ -226,8 +260,8 @@ export interface JumioTransactionRetrieveResponse {
         dateOfBirth: string;
         expiryDate: string;
         documentNumber: string;
-        optionalMrzField1: string;
-        optionalMrzField2: string;
+        optionalMrzField1?: string;
+        optionalMrzField2?: string;
         currentAge: string;
       };
     }[];
@@ -247,5 +281,6 @@ export interface JumioTransactionRetrieveResponse {
       };
     }[];
     imageChecks: ImageCheck[];
+    watchlistScreening: WatchlistScreenCheck[];
   };
 }

--- a/src/jumio-kyc/fixtures/watch-list.ts
+++ b/src/jumio-kyc/fixtures/watch-list.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { WatchlistScreenCheck } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+
+export const WATCHLIST_SCREEN_FIXTURE = (
+  decisionLabel = 'OK',
+  searchResults = 0,
+): WatchlistScreenCheck => {
+  return {
+    id: 'c2edb5ae-73ae-400b-a102-3008827b4aaa',
+    credentials: [
+      {
+        id: 'c01e3433-7e82-4a9e-8686-856af8e903f2',
+        category: 'ID',
+      },
+    ],
+    decision: {
+      type: 'PASSED',
+      details: {
+        label: decisionLabel,
+      },
+    },
+    data: {
+      searchDate: '2023-03-09T21:51:12.000Z',
+      searchId: '1231916038',
+      searchReference: '1678398672-eqPQV8pR',
+      searchResultUrl:
+        'https://app.complyadvantage.com/public/search/1678398672-eqPQV8pR/9fc65fef73fb',
+      searchResults: searchResults,
+      searchStatus: 'SUCCESS',
+    },
+  } as WatchlistScreenCheck;
+};

--- a/src/jumio-kyc/fixtures/workflow.ts
+++ b/src/jumio-kyc/fixtures/workflow.ts
@@ -5,8 +5,10 @@ import { DecisionStatus } from '@prisma/client';
 import {
   ImageCheck,
   JumioTransactionRetrieveResponse,
+  WatchlistScreenCheck,
 } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
 import { IMAGE_CHECK_FIXTURE } from './image-check';
+import { WATCHLIST_SCREEN_FIXTURE } from './watch-list';
 
 export const WORKFLOW_RETRIEVE_FIXTURE = (
   workflowStatus: 'TOKEN_EXPIRED' | 'SESSION_EXPIRED' | 'PROCESSED',
@@ -14,12 +16,14 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
   decisionStatus: DecisionStatus,
   userId = '1',
   imageCheck: ImageCheck = IMAGE_CHECK_FIXTURE,
+  watchlistCheck: WatchlistScreenCheck = WATCHLIST_SCREEN_FIXTURE(),
 ): JumioTransactionRetrieveResponse => {
   return {
     workflow: {
       id: 'fakeworkflowid',
       status: workflowStatus,
       definitionKey: '10013',
+      userReference: 'foobar',
       customerInternalReference: userId,
     },
     account: {
@@ -247,6 +251,7 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
           },
         },
       ],
+      watchlistScreening: [watchlistCheck],
     },
   };
 };

--- a/src/jumio-kyc/kyc.controller.spec.ts
+++ b/src/jumio-kyc/kyc.controller.spec.ts
@@ -211,7 +211,7 @@ describe('KycController', () => {
         .expect(HttpStatus.OK);
 
       redemption = await redemptionService.findOrThrow(user);
-      expect(redemption.kyc_status).toBe(KycStatus.SUBMITTED);
+      expect(redemption.kyc_status).toBe(KycStatus.SUCCESS);
     });
 
     describe('with an invalid signature', () => {

--- a/src/jumio-kyc/kyc.service.spec.ts
+++ b/src/jumio-kyc/kyc.service.spec.ts
@@ -90,7 +90,7 @@ describe('KycService', () => {
       await kycService.refresh(redemption, transaction);
 
       redemption = await redemptionService.findOrThrow(user);
-      expect(redemption.kyc_status).toBe(KycStatus.SUBMITTED);
+      expect(redemption.kyc_status).toBe(KycStatus.SUCCESS);
 
       transaction = await jumioTransactionService.findOrThrow(transaction.id);
       expect(transaction.decision_status).toBe('PASSED');

--- a/src/redemptions/redemption.service.spec.ts
+++ b/src/redemptions/redemption.service.spec.ts
@@ -8,6 +8,7 @@ import faker from 'faker';
 import { v4 as uuid } from 'uuid';
 import { AIRDROP_CONFIG } from '../common/constants';
 import { ImageChecksLabel } from '../jumio-api/interfaces/jumio-transaction-retrieve';
+import { WATCHLIST_SCREEN_FIXTURE } from '../jumio-kyc/fixtures/watch-list';
 import { WORKFLOW_RETRIEVE_FIXTURE } from '../jumio-kyc/fixtures/workflow';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
@@ -58,7 +59,7 @@ describe('RedemptionServiceSpec', () => {
       const fixture = WORKFLOW_RETRIEVE_FIXTURE('PROCESSED', 'CHL', 'PASSED');
       const status = await redemptionService.calculateStatus(fixture);
       expect(status).toEqual({
-        status: KycStatus.SUBMITTED,
+        status: KycStatus.SUCCESS,
         failureMessage: null,
         idDetails: [
           {
@@ -310,6 +311,32 @@ describe('RedemptionServiceSpec', () => {
       const acceptableFace =
         redemptionService.hasOnlyDuplicateFaceFailures(labels);
       expect(acceptableFace).toBe(true);
+    });
+  });
+
+  describe('watchlistScreeningFailure', () => {
+    it('should return failure if user has alerted status', () => {
+      expect(
+        redemptionService.watchlistScreeningFailure([
+          WATCHLIST_SCREEN_FIXTURE('ALERT', 0),
+        ]),
+      ).not.toBeNull();
+    });
+
+    it('should return failure if if label is ok but results were returned', () => {
+      expect(
+        redemptionService.watchlistScreeningFailure([
+          WATCHLIST_SCREEN_FIXTURE('OK', 1),
+        ]),
+      ).not.toBeNull();
+    });
+
+    it('should not fail if status is ok and no results were returned', () => {
+      expect(
+        redemptionService.watchlistScreeningFailure([
+          WATCHLIST_SCREEN_FIXTURE('OK', 0),
+        ]),
+      ).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
1. If the user has `searchResults!==0` returned OR jumio has an `ALERT` label on one of the watchlist entries we fail the user indefinitely for KYC.
2. If the whole workflow is successful now, we can move user to `SUCCESS` label rather than `SUBMITTED`
## Testing Plan
Tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
