### PR TITLE
fix: success on duplicate faces within an account

### DIFF
--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -115,7 +115,7 @@ export class RedemptionService {
     }
     if (!multiAccountFailure && this.hasOnlyDuplicateFaceFailures(labels)) {
       return {
-        status: KycStatus.SUBMITTED,
+        status: KycStatus.SUCCESS,
         failureMessage: `Benign duplicate faces found`,
         idDetails,
       };


### PR DESCRIPTION
## Summary
Multiface failures resulting from the same jumio account id should not be banned or considered.
This should have been updated with:
https://github.com/iron-fish/ironfish-api/pull/1336
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
