### PR TITLE
fix: remove validation on screen number

### DIFF
--- a/src/redemptions/redemption.service.spec.ts
+++ b/src/redemptions/redemption.service.spec.ts
@@ -323,12 +323,20 @@ describe('RedemptionServiceSpec', () => {
       ).not.toBeNull();
     });
 
-    it('should return failure if if label is ok but results were returned', () => {
+    it('should not fail if if label is WARNING', () => {
       expect(
         redemptionService.watchlistScreeningFailure([
-          WATCHLIST_SCREEN_FIXTURE('OK', 1),
+          WATCHLIST_SCREEN_FIXTURE('WARNING', 0),
         ]),
-      ).not.toBeNull();
+      ).toBeNull();
+    });
+
+    it('should not fail if if label is VALIDATION_FAILED', () => {
+      expect(
+        redemptionService.watchlistScreeningFailure([
+          WATCHLIST_SCREEN_FIXTURE('VALIDATION_FAILED', 0),
+        ]),
+      ).toBeNull();
     });
 
     it('should not fail if status is ok and no results were returned', () => {

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -141,10 +141,7 @@ export class RedemptionService {
     watchlistChecks: WatchlistScreenCheck[],
   ): string | null {
     for (const watchlistCheck of watchlistChecks) {
-      if (
-        watchlistCheck.decision.details.label === 'ALERT' ||
-        watchlistCheck.data.searchResults !== 0
-      ) {
+      if (watchlistCheck.decision.details.label === 'ALERT') {
         return 'Watchlist screening failed, you are ineligble for airdrop';
       }
     }


### PR DESCRIPTION
## Summary
When there is a failure to run the screening check, there are optional fields missing from response (that were not labeled optional in API specification).
Example failure/response payload:
```
         "watchlistScreening": [
         {                                                                                                                                                                                          
                 "id": "94362ecf-9a9d-408b-9f09-3db3d4315a4a",                                                                                                                                          
                 "data": {                                                                                                                                                                              
                 },                                                                                                                                                                                     
                 "decision": {                                                                                                                                                                          
                     "type": "NOT_EXECUTED",                                                                                                                                                            
                     "details": {                                                                                                                                                                       
                         "label": "VALIDATION_FAILED"                                                                                                                                                   
                     }                                                                                                                                                                                  
                 },                                                                                                                                                                                     
                 "credentials": [                                                                                                                                                                       
                     {                                                                                                                                                                                  
                         "id": "33487a65-dbd3-4945-a256-4eda54125eab",                                                                                                                                  
                         "category": "ID"                                                                                                                                                               
                     }                                                                                                                                                                                  
                 ]                                                                                                                                                                                      
             }                                                                                                                                                                                          
         ]
```
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
