### PR TITLE
fix: only santizes extractions if they are in object

### DIFF
--- a/src/jumio-api/jumio-api.service.ts
+++ b/src/jumio-api/jumio-api.service.ts
@@ -43,7 +43,7 @@ export class JumioApiService {
       });
 
     // Sanitize extracted values
-    if (sanitize) {
+    if (sanitize && 'extraction' in response.data.capabilities) {
       for (const extraction of response.data.capabilities.extraction) {
         const sanitized = {
           issuingCountry: extraction.data.issuingCountry,


### PR DESCRIPTION
## Summary
Callback run from standalone watchlist workflow (10010) does not have extractions in it, so this fails.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
