### PR TITLE
fix: workflow definition key returned as string

### DIFF
--- a/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
+++ b/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
@@ -160,7 +160,7 @@ export interface JumioTransactionRetrieveResponse {
   };
   workflow: {
     id: string;
-    definitionKey: number;
+    definitionKey: string;
     userReference: string;
     status: 'INITIATED' | 'PROCESSED' | 'SESSION_EXPIRED' | 'TOKEN_EXPIRED';
     customerInternalReference: string;

--- a/src/jumio-api/jumio-api.service.spec.ts
+++ b/src/jumio-api/jumio-api.service.spec.ts
@@ -34,7 +34,7 @@ describe('JumioApiService', () => {
     describe('when calling jumio', () => {
       it('creates account when jumioAccountId is not present', async () => {
         const postMock = axiosMock();
-        await jumioApiService.createAccountAndTransaction(123, null, 10032);
+        await jumioApiService.createAccountAndTransaction(123, null, '10032');
 
         expect(postMock).toHaveBeenCalledWith(
           'https://account.amer-1.jumio.ai/api/v1/accounts',
@@ -43,7 +43,7 @@ describe('JumioApiService', () => {
             customerInternalReference: expect.any(Number),
             userReference: expect.any(String),
             workflowDefinition: expect.objectContaining({
-              key: expect.any(Number),
+              key: expect.any(String),
               capabilities: {
                 watchlistScreening: expect.objectContaining({
                   additionalProperties: '',
@@ -68,7 +68,7 @@ describe('JumioApiService', () => {
         await jumioApiService.createAccountAndTransaction(
           123,
           'fooaccount',
-          10032,
+          '10032',
         );
 
         expect(postMock).toHaveBeenCalledWith(
@@ -78,7 +78,7 @@ describe('JumioApiService', () => {
             customerInternalReference: expect.any(Number),
             userReference: expect.any(String),
             workflowDefinition: {
-              key: expect.any(Number),
+              key: expect.any(String),
               capabilities: {
                 watchlistScreening: expect.objectContaining({
                   additionalProperties: '',

--- a/src/jumio-api/jumio-api.service.ts
+++ b/src/jumio-api/jumio-api.service.ts
@@ -59,7 +59,7 @@ export class JumioApiService {
   async createAccountAndTransaction(
     userId: number,
     jumioAccountId: string | null,
-    workflowDefinitionKey: number,
+    workflowDefinitionKey: string,
   ): Promise<JumioAccountCreateResponse> {
     let url =
       'https://account.' + this.config.get<string>('JUMIO_URL') + '/accounts';

--- a/src/jumio-kyc/fixtures/workflow-watchlist-pass.ts
+++ b/src/jumio-kyc/fixtures/workflow-watchlist-pass.ts
@@ -8,7 +8,7 @@ export const WORKFLOW_RETRIEVE_WATCHLIST_PASS: JumioTransactionStandaloneSanctio
     workflow: {
       id: 'b94de56f-75b7-4df2-9320-eebba497f138',
       status: 'PROCESSED',
-      definitionKey: 10010,
+      definitionKey: '10010',
       userReference: 'foo',
       customerInternalReference: 'application',
     },

--- a/src/jumio-kyc/fixtures/workflow-watchlist.ts
+++ b/src/jumio-kyc/fixtures/workflow-watchlist.ts
@@ -14,7 +14,7 @@ export const WORKFLOW_RETRIEVE_WATCHLIST = (
     workflow: {
       id: 'b94de56f-75b7-4df2-9320-eebba497f138',
       status: 'PROCESSED',
-      definitionKey: 10010,
+      definitionKey: '10010',
       userReference: 'foo',
       customerInternalReference: 'application',
     },

--- a/src/jumio-kyc/fixtures/workflow.ts
+++ b/src/jumio-kyc/fixtures/workflow.ts
@@ -24,7 +24,7 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
     workflow: {
       id: workflowId,
       status: workflowStatus,
-      definitionKey: 10013,
+      definitionKey: '10013',
       userReference: 'foobar',
       customerInternalReference: userId,
     },

--- a/src/jumio-kyc/kyc.service.ts
+++ b/src/jumio-kyc/kyc.service.ts
@@ -76,7 +76,7 @@ export class KycService {
       const response = await this.jumioApiService.createAccountAndTransaction(
         user.id,
         redemption.jumio_account_id,
-        this.config.get<number>('JUMIO_WORKFLOW_DEFINITION'),
+        String(this.config.get<number>('JUMIO_WORKFLOW_DEFINITION')),
       );
 
       redemption = await this.redemptionService.update(
@@ -220,7 +220,7 @@ export class KycService {
       await this.jumioApiService.createAccountAndTransaction(
         user.id,
         redemption.jumio_account_id,
-        10010,
+        '10010',
       );
     // get/upload name info
     assert.ok(redemption.jumio_account_id);
@@ -269,7 +269,7 @@ export class KycService {
     );
 
     const calculatedStatus =
-      status.workflow.definitionKey !== 10010
+      status.workflow.definitionKey !== '10010'
         ? await this.redemptionService.calculateStatus(status)
         : this.redemptionService.calculateStandaloneWatchlistStatus(status);
 


### PR DESCRIPTION
## Summary
Workflow definition key returned as string, not number
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
