### PR TITLE
fix: fix bug standalone watchlist screening for chinese user data

### DIFF
--- a/src/jumio-api/jumio-api.service.spec.ts
+++ b/src/jumio-api/jumio-api.service.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
 import axios from 'axios';
+import { WORKFLOW_RETRIEVE_FIXTURE } from '../jumio-kyc/fixtures/workflow';
 import { bootstrapTestApp } from '../test/test-app';
 import { JumioApiService } from './jumio-api.service';
 
@@ -95,6 +96,49 @@ describe('JumioApiService', () => {
             }),
           },
         );
+      });
+    });
+  });
+
+  describe('getScreeningDataFromRetrieval', () => {
+    it('returns correct names when present', () => {
+      const data = jumioApiService.getScreeningDataFromRetrieval(
+        WORKFLOW_RETRIEVE_FIXTURE(
+          'PROCESSED',
+          'CHL',
+          'PASSED',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'Jason',
+          'Spafford',
+        ),
+      );
+      expect(data).toMatchObject({
+        firstName: 'Jason',
+        lastName: 'Spafford',
+      });
+    });
+    it('returns empty string when names not present', () => {
+      const data = jumioApiService.getScreeningDataFromRetrieval(
+        WORKFLOW_RETRIEVE_FIXTURE(
+          'PROCESSED',
+          'CHL',
+          'PASSED',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'N/A',
+          '房建民',
+        ),
+      );
+      expect(data).toMatchObject({
+        firstName: '',
+        lastName: '房建民',
       });
     });
   });

--- a/src/jumio-api/jumio-api.service.ts
+++ b/src/jumio-api/jumio-api.service.ts
@@ -175,16 +175,23 @@ export class JumioApiService {
         dateOfBirth = extraction.data.dateOfBirth;
       }
       if (extraction.data.firstName) {
-        firstName = extraction.data.firstName;
+        firstName =
+          extraction.data.firstName === 'N/A' ? '' : extraction.data.firstName;
       }
       if (extraction.data.lastName) {
-        lastName = extraction.data.lastName;
+        lastName =
+          extraction.data.lastName === 'N/A' ? '' : extraction.data.lastName;
       }
       if (extraction.data.issuingCountry) {
         country = extraction.data.issuingCountry;
       }
     }
-    if (!firstName || !lastName || !dateOfBirth || !country) {
+    if (
+      firstName === null ||
+      lastName === null ||
+      dateOfBirth === null ||
+      country === null
+    ) {
       throw new BadRequestException(
         'Required user info field not present on transaction',
       );

--- a/src/jumio-kyc/fixtures/workflow.ts
+++ b/src/jumio-kyc/fixtures/workflow.ts
@@ -19,6 +19,8 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
   watchlistCheck: WatchlistScreenCheck = WATCHLIST_SCREEN_FIXTURE(),
   workflowId = 'fakeworkflowid',
   accountId = 'accountId',
+  firstName = 'Jason',
+  lastName = 'Spafford',
 ): JumioTransactionRetrieveResponse => {
   return {
     workflow: {
@@ -125,8 +127,8 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
             type: 'ID_CARD',
             subType: 'NATIONAL_ID',
             issuingCountry: idCountryCode,
-            firstName: 'MUMBO',
-            lastName: 'JUMBO',
+            firstName: firstName,
+            lastName: lastName,
             dateOfBirth: '1970-01-01',
             expiryDate: '2050-01-01',
             documentNumber: '1111111',


### PR DESCRIPTION
## Summary
Jumio returns `N/A` for first name of a Chinese customer, but then does not accept `N/A` in the parts upload. I have tested manually with removing `N/A` and the screening runs successfully.
## Testing Plan
Tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
