### PR TITLE
feat: remove terminal failures on label status checks

### DIFF
--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -104,10 +104,7 @@ export class RedemptionService {
     );
 
     // TODO: HANDLE WARN, use decision.risk.score?
-    const failure =
-      watchlistScreeningFailure ||
-      multiAccountFailure ||
-      this.labelFailure(labels);
+    const failure = watchlistScreeningFailure || multiAccountFailure;
     if (failure) {
       return {
         status: KycStatus.FAILED,
@@ -222,16 +219,6 @@ export class RedemptionService {
       }
     }
     return true;
-  }
-
-  labelFailure(labels: string[]): string | null {
-    const failedLabels = labels.filter((i) =>
-      ['PHOTOCOPY', 'DIGITAL_COPY', 'MANIPULATED', 'BLACK_WHITE'].includes(i),
-    );
-    if (failedLabels.length) {
-      return `Failure due to label presence: ${failedLabels.join(',')}`;
-    }
-    return null;
   }
 
   async findByJumioAccountId(jumioAccountId: string): Promise<Redemption> {


### PR DESCRIPTION
## Summary
Removes terminal failures on failed statuses. These users will likely fail out due to max attempts reached.
## Testing Plan
test pass

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
