### PR TITLE
fix: bug in display success vs deadline

### DIFF
--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -298,6 +298,14 @@ export class RedemptionService {
     redemption?: Redemption | null,
     prisma?: BasePrismaClient,
   ): Promise<{ eligible: boolean; reason: string }> {
+    if (
+      redemption &&
+      (redemption.kyc_status === KycStatus.SUBMITTED ||
+        redemption.kyc_status === KycStatus.SUCCESS)
+    ) {
+      return { eligible: true, reason: '' };
+    }
+
     if (user.ineligible_reason) {
       return { eligible: false, reason: user.ineligible_reason };
     }
@@ -315,11 +323,7 @@ export class RedemptionService {
         redemption.kyc_max_attempts ??
         this.config.get<number>('KYC_MAX_ATTEMPTS');
 
-      if (
-        redemption.kyc_attempts >= kycMaxAttempts &&
-        redemption.kyc_status !== KycStatus.SUBMITTED &&
-        redemption.kyc_status !== KycStatus.SUCCESS
-      ) {
+      if (redemption.kyc_attempts >= kycMaxAttempts) {
         return {
           eligible: false,
           reason: `Max KYC attempts reached ${redemption.kyc_attempts} / ${kycMaxAttempts}`,


### PR DESCRIPTION
## Summary
We are currently using eligibility to determine if the user is eligible for KYC in general. If we don't provide explicit case for submitted/success the other checks may erroneously return false.

## Testing Plan
tests pass, related pr: 
https://github.com/iron-fish/ironfish-api/pull/1340
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
