### PR TITLE
feat: allow liveness warnings to pass on low risk KYC

### DIFF
--- a/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
+++ b/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
@@ -140,6 +140,31 @@ export type WatchlistScreenCheck = {
   };
 };
 
+export type LivenessCheck = {
+  id: string;
+  validFaceMapForAuthentication: string;
+  credentials: [
+    {
+      id: string;
+      category: string;
+    },
+    {
+      id: string;
+      category: string;
+    },
+  ];
+  decision: {
+    type: 'NOT_EXECUTED' | 'PASSED' | 'REJECTED' | 'WARNING';
+    details: {
+      label: LivenessLabel;
+    };
+  };
+  data: {
+    type: string;
+    predictedAge: number;
+    ageConfidenceRange: string;
+  };
+};
 export interface JumioTransactionRetrieveResponse {
   account: {
     id: string;
@@ -175,31 +200,6 @@ export interface JumioTransactionRetrieveResponse {
     };
   };
   capabilities: {
-    liveness: {
-      id: string;
-      validFaceMapForAuthentication: string;
-      credentials: [
-        {
-          id: string;
-          category: string;
-        },
-        {
-          id: string;
-          category: string;
-        },
-      ];
-      decision: {
-        type: 'NOT_EXECUTED' | 'PASSED' | 'REJECTED' | 'WARNING';
-        details: {
-          label: LivenessLabel;
-        };
-      };
-      data: {
-        type: string;
-        predictedAge: number;
-        ageConfidenceRange: string;
-      };
-    }[];
     similarity: {
       id: string;
       credentials: [
@@ -282,6 +282,7 @@ export interface JumioTransactionRetrieveResponse {
     }[];
     imageChecks: ImageCheck[];
     watchlistScreening: WatchlistScreenCheck[];
+    liveness: LivenessCheck[];
   };
 }
 

--- a/src/jumio-kyc/fixtures/liveness-check.ts
+++ b/src/jumio-kyc/fixtures/liveness-check.ts
@@ -1,20 +1,25 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ImageChecksLabel } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+import {
+  LivenessCheck,
+  LivenessLabel,
+} from '../../jumio-api/interfaces/jumio-transaction-retrieve';
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export const IMAGE_CHECK_FIXTURE = (
-  label: ImageChecksLabel = 'REPEATED_FACE',
-) => {
+export const LIVENESS_CHECK_FIXTURE = (
+  label: LivenessLabel = 'OK',
+): LivenessCheck => {
   return {
-    id: '1568893e-5edc-453c-9c50-e47fa10578f8',
+    id: '3bfa4f49-148d-4361-acc3-10928f69562a',
+    validFaceMapForAuthentication:
+      'https://retrieval.amer-1.jumio.ai/api/v1/accounts/fakeaccountid/credentials/fakecredentialsid/parts/FACEMAP',
     credentials: [
       {
         id: 'fakecredentialsid',
-        category: 'ID',
+        category: 'FACEMAP',
       },
       {
         id: 'fakecredentialsid',
@@ -22,19 +27,15 @@ export const IMAGE_CHECK_FIXTURE = (
       },
     ],
     decision: {
-      type: 'WARNING',
+      type: 'PASSED',
       details: {
         label: label,
       },
     },
     data: {
-      faceSearchFindings: {
-        status: 'DONE',
-        findings: [
-          'f7fe3c49-6221-4d87-b8b9-0cd243b65088',
-          '85b26f35-cf4e-4a68-8bce-88c20f06d3ff',
-        ],
-      },
+      type: 'IPROOV_STANDARD',
+      predictedAge: 31,
+      ageConfidenceRange: '21-41',
     },
   };
 };

--- a/src/jumio-kyc/fixtures/workflow.ts
+++ b/src/jumio-kyc/fixtures/workflow.ts
@@ -5,9 +5,11 @@ import { DecisionStatus } from '@prisma/client';
 import {
   ImageCheck,
   JumioTransactionRetrieveResponse,
+  LivenessCheck,
   WatchlistScreenCheck,
 } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
 import { IMAGE_CHECK_FIXTURE } from './image-check';
+import { LIVENESS_CHECK_FIXTURE } from './liveness-check';
 import { WATCHLIST_SCREEN_FIXTURE } from './watch-list';
 
 export const WORKFLOW_RETRIEVE_FIXTURE = (
@@ -15,12 +17,14 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
   idCountryCode: string,
   decisionStatus: DecisionStatus,
   userId = '1',
-  imageCheck: ImageCheck = IMAGE_CHECK_FIXTURE,
+  imageCheck: ImageCheck = IMAGE_CHECK_FIXTURE(),
   watchlistCheck: WatchlistScreenCheck = WATCHLIST_SCREEN_FIXTURE(),
   workflowId = 'fakeworkflowid',
   accountId = 'accountId',
   firstName = 'Jason',
   lastName = 'Spafford',
+  livenessCheck: LivenessCheck = LIVENESS_CHECK_FIXTURE(),
+  riskScore = 50,
 ): JumioTransactionRetrieveResponse => {
   return {
     workflow: {
@@ -101,7 +105,7 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
         label: 'PASSED',
       },
       risk: {
-        score: 50,
+        score: riskScore,
       },
     },
     steps: {
@@ -162,34 +166,7 @@ export const WORKFLOW_RETRIEVE_FIXTURE = (
           },
         },
       ],
-      liveness: [
-        {
-          id: '3bfa4f49-148d-4361-acc3-10928f69562a',
-          validFaceMapForAuthentication:
-            'https://retrieval.amer-1.jumio.ai/api/v1/accounts/fakeaccountid/credentials/fakecredentialsid/parts/FACEMAP',
-          credentials: [
-            {
-              id: 'fakecredentialsid',
-              category: 'FACEMAP',
-            },
-            {
-              id: 'fakecredentialsid',
-              category: 'SELFIE',
-            },
-          ],
-          decision: {
-            type: 'PASSED',
-            details: {
-              label: 'OK',
-            },
-          },
-          data: {
-            type: 'IPROOV_STANDARD',
-            predictedAge: 31,
-            ageConfidenceRange: '21-41',
-          },
-        },
-      ],
+      liveness: [livenessCheck],
       dataChecks: [
         {
           id: '07d10b79-b84a-454d-94ac-8b80d53f208a',

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -112,10 +112,14 @@ export class RedemptionService {
         idDetails,
       };
     }
-    if (!multiAccountFailure && this.hasOnlyDuplicateFaceFailures(labels)) {
+    if (
+      !multiAccountFailure &&
+      this.hasOnlyBenignWarnings(labels) &&
+      transactionStatus.decision.risk.score < 50
+    ) {
       return {
         status: KycStatus.SUCCESS,
-        failureMessage: `Benign duplicate faces found`,
+        failureMessage: `Benign warning labels found: ${labels.join(',')}`,
         idDetails,
       };
     }
@@ -211,10 +215,14 @@ export class RedemptionService {
     return null;
   }
 
-  hasOnlyDuplicateFaceFailures(labels: string[]): boolean {
+  hasOnlyBenignWarnings(labels: string[]): boolean {
     // if any other check failed, we can't pass
     for (const label of labels) {
-      if (!['MATCH', 'REPEATED_FACE', 'OK'].includes(label)) {
+      if (
+        !['MATCH', 'REPEATED_FACE', 'LIVENESS_UNDETERMINED', 'OK'].includes(
+          label,
+        )
+      ) {
         return false;
       }
     }


### PR DESCRIPTION
## Summary
We have a list of labels that are considered passable when there are no other failures present.
1. Duplicate face will occur if user has previous KYC attempt that has failed (even for same account).
2. Liveness undetermined is an added check to make sure photograph was not use for face detection, if it can't complete successfully it will give status: `LIVENESS_UNDETERMINED`, which is non-block per Jumio reps. We were told below `risk` of 50, we can disregard this warning.
## Testing Plan
Tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
