### PR TITLE
feat: make KYC unsuccessful if age below 18

### DIFF
--- a/prisma/migrations/20230314170724_add_age_to_redemption/migration.sql
+++ b/prisma/migrations/20230314170724_add_age_to_redemption/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "redemptions" ADD COLUMN     "age" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Redemption {
   public_address   String    @db.VarChar
   hashed_ip_address String?  @db.VarChar
   id_details       Json?
+  age              Int?
   failure_message  String?   @db.VarChar
   pool1_ore        BigInt?
   pool2_ore        BigInt?

--- a/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
+++ b/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
@@ -173,6 +173,35 @@ export type LivenessCheck = {
     ageConfidenceRange: string;
   };
 };
+
+export type ExtractionCheck = {
+  id: string;
+  decision: {
+    type: 'NOT_EXECUTED' | 'PASSED';
+    details: {
+      label: ExtractionLabel;
+    };
+  };
+  credentials: [
+    {
+      id: string;
+      category: string;
+    },
+  ];
+  data: {
+    type: string;
+    subType: string;
+    issuingCountry: string; // http://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
+    firstName: string;
+    lastName: string;
+    dateOfBirth: string;
+    expiryDate: string;
+    documentNumber: string;
+    optionalMrzField1?: string;
+    optionalMrzField2?: string;
+    currentAge?: string;
+  };
+};
 export interface JumioTransactionRetrieveResponse {
   account: {
     id: string;
@@ -245,34 +274,7 @@ export interface JumioTransactionRetrieveResponse {
         };
       };
     }[];
-    extraction: {
-      id: string;
-      decision: {
-        type: 'NOT_EXECUTED' | 'PASSED';
-        details: {
-          label: ExtractionLabel;
-        };
-      };
-      credentials: [
-        {
-          id: string;
-          category: string;
-        },
-      ];
-      data: {
-        type: string;
-        subType: string;
-        issuingCountry: string; // http://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
-        firstName: string;
-        lastName: string;
-        dateOfBirth: string;
-        expiryDate: string;
-        documentNumber: string;
-        optionalMrzField1?: string;
-        optionalMrzField2?: string;
-        currentAge: string;
-      };
-    }[];
+    extraction: ExtractionCheck[];
     usability: {
       id: string;
       credentials: [

--- a/src/jumio-api/jumio-api.service.spec.ts
+++ b/src/jumio-api/jumio-api.service.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
 import axios from 'axios';
+import { EXTRACTION_CHECK_FIXTURE } from '../jumio-kyc/fixtures/extraction-check';
 import { WORKFLOW_RETRIEVE_FIXTURE } from '../jumio-kyc/fixtures/workflow';
 import { bootstrapTestApp } from '../test/test-app';
 import { JumioApiService } from './jumio-api.service';
@@ -103,7 +104,12 @@ describe('JumioApiService', () => {
   describe('getScreeningDataFromRetrieval', () => {
     it('returns correct names when present', () => {
       const data = jumioApiService.getScreeningDataFromRetrieval(
-        WORKFLOW_RETRIEVE_FIXTURE({ firstName: 'Jason', lastName: 'Spafford' }),
+        WORKFLOW_RETRIEVE_FIXTURE({
+          extractionCheck: EXTRACTION_CHECK_FIXTURE({
+            firstName: 'Jason',
+            lastName: 'Spafford',
+          }),
+        }),
       );
       expect(data).toMatchObject({
         firstName: 'Jason',
@@ -112,7 +118,12 @@ describe('JumioApiService', () => {
     });
     it('returns empty string when names not present', () => {
       const data = jumioApiService.getScreeningDataFromRetrieval(
-        WORKFLOW_RETRIEVE_FIXTURE({ firstName: 'N/A', lastName: '房建民' }),
+        WORKFLOW_RETRIEVE_FIXTURE({
+          extractionCheck: EXTRACTION_CHECK_FIXTURE({
+            firstName: 'N/A',
+            lastName: '房建民',
+          }),
+        }),
       );
       expect(data).toMatchObject({
         firstName: '',

--- a/src/jumio-kyc/fixtures/extraction-check.ts
+++ b/src/jumio-kyc/fixtures/extraction-check.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ExtractionCheck } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+
+type ExtractionFixtureProps = {
+  firstName?: string;
+  lastName?: string;
+  idCountryCode?: string;
+  age?: number;
+};
+
+export const EXTRACTION_CHECK_FIXTURE = ({
+  firstName = 'Jason',
+  lastName = 'Spafford',
+  idCountryCode = 'CHL',
+  age = 70,
+}: ExtractionFixtureProps = {}): ExtractionCheck => {
+  return {
+    id: '40cb204c-f7ff-43e7-864b-064dcc8aba85',
+    credentials: [
+      {
+        id: 'fakecredentialsid',
+        category: 'ID',
+      },
+    ],
+    decision: {
+      type: 'PASSED',
+      details: {
+        label: 'OK',
+      },
+    },
+    data: {
+      type: 'ID_CARD',
+      subType: 'NATIONAL_ID',
+      issuingCountry: idCountryCode,
+      firstName: firstName,
+      lastName: lastName,
+      dateOfBirth: '1970-01-01',
+      expiryDate: '2050-01-01',
+      documentNumber: '1111111',
+      optionalMrzField1: 'Z11',
+      optionalMrzField2: '11111111',
+      currentAge: String(age),
+    },
+  };
+};

--- a/src/jumio-kyc/fixtures/workflow.ts
+++ b/src/jumio-kyc/fixtures/workflow.ts
@@ -3,43 +3,41 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { DecisionStatus } from '@prisma/client';
 import {
+  ExtractionCheck,
   ImageCheck,
   JumioTransactionRetrieveResponse,
   LivenessCheck,
   WatchlistScreenCheck,
   WorkflowStatus,
 } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+import { EXTRACTION_CHECK_FIXTURE } from './extraction-check';
 import { IMAGE_CHECK_FIXTURE } from './image-check';
 import { LIVENESS_CHECK_FIXTURE } from './liveness-check';
 import { WATCHLIST_SCREEN_FIXTURE } from './watch-list';
 
 export type JumioWorkflowRetrieveParams = {
   workflowStatus?: WorkflowStatus;
-  idCountryCode?: string;
   workflowId?: string;
   accountId?: string;
-  firstName?: string;
-  lastName?: string;
   decisionStatus?: DecisionStatus;
   userId?: string;
   imageCheck?: ImageCheck;
   watchlistCheck?: WatchlistScreenCheck;
   livenessCheck?: LivenessCheck;
+  extractionCheck?: ExtractionCheck;
   riskScore?: number;
 };
 export const WORKFLOW_RETRIEVE_FIXTURE = ({
   workflowStatus = 'PROCESSED',
-  idCountryCode = 'CHL',
   decisionStatus = DecisionStatus.PASSED,
-  userId = '1',
-  imageCheck = IMAGE_CHECK_FIXTURE(),
-  watchlistCheck = WATCHLIST_SCREEN_FIXTURE(),
+  riskScore = 50,
   workflowId = 'eb776622-26a2-499b-b824-6449c92d1617',
   accountId = '684fcf21-bcf3-4916-b007-35dc70102f56',
-  firstName = 'Jason',
-  lastName = 'Spafford',
+  userId = '1',
+  extractionCheck = EXTRACTION_CHECK_FIXTURE(),
+  imageCheck = IMAGE_CHECK_FIXTURE(),
+  watchlistCheck = WATCHLIST_SCREEN_FIXTURE(),
   livenessCheck = LIVENESS_CHECK_FIXTURE(),
-  riskScore = 50,
 }: JumioWorkflowRetrieveParams = {}): JumioTransactionRetrieveResponse => {
   return {
     workflow: {
@@ -127,36 +125,7 @@ export const WORKFLOW_RETRIEVE_FIXTURE = ({
       href: 'https://retrieval.amer-1.jumio.ai/api/v1/accounts/fakeaccountid/workflow-executions/fakeworkflowid/steps',
     },
     capabilities: {
-      extraction: [
-        {
-          id: '40cb204c-f7ff-43e7-864b-064dcc8aba85',
-          credentials: [
-            {
-              id: 'fakecredentialsid',
-              category: 'ID',
-            },
-          ],
-          decision: {
-            type: 'PASSED',
-            details: {
-              label: 'OK',
-            },
-          },
-          data: {
-            type: 'ID_CARD',
-            subType: 'NATIONAL_ID',
-            issuingCountry: idCountryCode,
-            firstName: firstName,
-            lastName: lastName,
-            dateOfBirth: '1970-01-01',
-            expiryDate: '2050-01-01',
-            documentNumber: '1111111',
-            optionalMrzField1: 'Z11',
-            optionalMrzField2: '11111111',
-            currentAge: '70',
-          },
-        },
-      ],
+      extraction: [extractionCheck],
       similarity: [
         {
           id: '594b92df-ae55-4123-883e-ce2724bda94d',

--- a/src/jumio-kyc/kyc.service.ts
+++ b/src/jumio-kyc/kyc.service.ts
@@ -274,13 +274,13 @@ export class KycService {
         : this.redemptionService.calculateStandaloneWatchlistStatus(status);
 
     // Has our user's KYC status changed
-    if (redemption.kyc_status !== calculatedStatus.status) {
-      redemption = await this.redemptionService.update(redemption, {
-        kycStatus: calculatedStatus.status,
-        failureMessage: calculatedStatus.failureMessage ?? undefined,
-        idDetails: calculatedStatus.idDetails,
-      });
-    }
+    redemption = await this.redemptionService.update(redemption, {
+      kycStatus: calculatedStatus.status,
+      failureMessage: calculatedStatus.failureMessage ?? undefined,
+      idDetails: calculatedStatus.idDetails,
+      age: calculatedStatus.age,
+    });
+
     await this.jumioTransactionService.update(transaction, {
       decisionStatus: status.decision.type,
       lastWorkflowFetch: status,


### PR DESCRIPTION
## Summary
Two things:
1. On callback, KYC attempt is marked `TRY_AGAIN` with failure message telling user is below age requirement
2. On eligibility check, users can be eligible to attempt if age is below requirement, but warned their parents must be custodian (will be set to `TRY_AGAIN` if kyc is attempted).


Backfill script (very slow response, no need to rate limit):
```python
import requests

tsv = 'passed_users.tsv'
out = 'output.txt'
token = ''

def retrieve_age():
    base_url = "https://retrieval.amer-1.jumio.ai/api/v1/accounts/{}/workflow-executions/{}"
    headers = {
        'Accept': 'application/json',
        'Content-Type': 'application/json',
        'User-Agent': 'IronFish Website/v1.0',
        'Authorization': f'Basic {token}'
    }

    num = 0

    data = []
    with open(tsv) as f:
        for row in f.readlines():
            print(row.split())
            data.append(row.split())

    with open(out, 'a') as f:
        for account_id, workflow_execution_id, user_id in data:
            print(f'processing {num}')
            url = base_url.format(account_id, workflow_execution_id)
            response = requests.get(url, headers=headers)
            if response.status_code == 200:
                ages = [int(e['data'].get('currentAge', -1)) for e in response.json()['capabilities']['extraction']]
                age = min(ages)
                if (age < 18):
                    f.write(f'UPDATE redemptions set kyc_status = TRY_AGAIN, age = {age} where user_id = {user_id}')
                else:
                    print(f'Age: {age}')
            else:
                print("Error: Could not retrieve credentials for account_id {} and workflow_execution_id {}".format(account_id, workflow_execution_id))
            num += 1


retrieve_age()
```
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
