### PR TITLE
chore: reset db at start of each test file

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: 'node',
   testRegex: '.spec.ts$',
+  setupFilesAfterEnv: ['./src/test/setup.ts'],
 }

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -39,17 +39,4 @@ describe('HealthController', () => {
       });
     });
   });
-
-  describe('GET /health/deposit', () => {
-    it('returns a 200 status code', async () => {
-      const { body } = await request(app.getHttpServer())
-        .get('/health/deposit')
-        .set('Authorization', `Bearer ${API_KEY}`)
-        .expect(HttpStatus.OK);
-
-      expect(body).toMatchObject({
-        mismatched_deposits: expect.any(Number),
-      });
-    });
-  });
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Prisma, PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const tables = Prisma.dmmf.datamodel.models
+  .map((model) => model.dbName)
+  .filter((table) => table);
+
+global.beforeAll(async () => {
+  await prisma.$transaction([
+    ...tables.map((table) =>
+      prisma.$executeRawUnsafe(table ? `TRUNCATE ${table} CASCADE;` : ''),
+    ),
+  ]);
+});


### PR DESCRIPTION
## Summary
DB data shouldn't bleed between test suites, this makes sure that doesn't happen.

## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
