### PR TITLE
fix: remove separate deadlines for pools kyc

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -59,34 +59,36 @@ export const POOL_4_CATEGORIES: Array<EventType> = [
 
 // 2023 Feb 26 12 AM UTC
 export const PHASE_3_END = new Date(Date.UTC(2023, 1, 26, 0, 0, 0));
+export const KYC_DEADLINE = new Date(Date.UTC(2023, 3, 14, 0, 0, 0));
+export const AIRDROP_DEADLINE = new Date(Date.UTC(2023, 3, 21, 0, 0, 0));
 
 export const AIRDROP_CONFIG = {
   data: [
     {
-      airdrop_completed_by: new Date(Date.UTC(2023, 3, 21, 0, 0, 0)),
+      airdrop_completed_by: AIRDROP_DEADLINE,
       coins: 105000,
-      kyc_completed_by: new Date(Date.UTC(2023, 3, 14, 0, 0, 0)),
+      kyc_completed_by: KYC_DEADLINE,
       name: 'pool_three',
       pool_name: 'Code Contributions Pool',
     },
     {
-      airdrop_completed_by: new Date(Date.UTC(2023, 3, 21, 0, 0, 0)),
+      airdrop_completed_by: AIRDROP_DEADLINE,
       coins: 420000,
-      kyc_completed_by: new Date(Date.UTC(2023, 3, 14, 0, 0, 0)),
+      kyc_completed_by: KYC_DEADLINE,
       name: 'pool_one',
       pool_name: 'Phase 1 Pool',
     },
     {
-      airdrop_completed_by: new Date(Date.UTC(2023, 3, 21, 0, 0, 0)),
+      airdrop_completed_by: AIRDROP_DEADLINE,
       coins: 210000,
-      kyc_completed_by: new Date(Date.UTC(2023, 3, 14, 0, 0, 0)),
+      kyc_completed_by: KYC_DEADLINE,
       name: 'pool_two',
       pool_name: 'Phase 2 Pool',
     },
     {
-      airdrop_completed_by: new Date(Date.UTC(2023, 3, 21, 0, 0, 0)),
+      airdrop_completed_by: AIRDROP_DEADLINE,
       coins: 210000,
-      kyc_completed_by: new Date(Date.UTC(2023, 3, 14, 0, 0, 0)),
+      kyc_completed_by: KYC_DEADLINE,
       name: 'pool_four',
       pool_name: 'Phase 3 Pool',
     },

--- a/src/redemptions/redemption.service.spec.ts
+++ b/src/redemptions/redemption.service.spec.ts
@@ -3,10 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
 import { DecisionStatus, KycStatus } from '@prisma/client';
-import assert from 'assert';
 import faker from 'faker';
 import { v4 as uuid } from 'uuid';
-import { AIRDROP_CONFIG } from '../common/constants';
 import { ImageChecksLabel } from '../jumio-api/interfaces/jumio-transaction-retrieve';
 import { EXTRACTION_CHECK_FIXTURE } from '../jumio-kyc/fixtures/extraction-check';
 import { IMAGE_CHECK_FIXTURE } from '../jumio-kyc/fixtures/image-check';
@@ -105,57 +103,6 @@ describe('RedemptionServiceSpec', () => {
         idDetails,
       });
       expect(redemption.id_details).toEqual(idDetails);
-    });
-  });
-
-  describe('userDeadline', () => {
-    it('should return pool2 date if user only has pool2', async () => {
-      const userPoints = await prismaService.userPoints.create({
-        data: {
-          user: {
-            create: {
-              email: faker.internet.email(),
-              graffiti: uuid(),
-              country_code: 'IDN',
-              enable_kyc: true,
-            },
-          },
-          pool2_points: 100,
-        },
-      });
-      const pool2 = AIRDROP_CONFIG.data.find((a) => a.name === 'pool_two');
-      assert.ok(pool2);
-      const calculatedDate = await redemptionService.userDeadline(
-        userPoints.user_id,
-      );
-      expect(calculatedDate).toEqual(pool2?.kyc_completed_by);
-    });
-    it('should return max date if user only has all pools', async () => {
-      const userPoints = await prismaService.userPoints.create({
-        data: {
-          user: {
-            create: {
-              email: faker.internet.email(),
-              graffiti: uuid(),
-              country_code: 'IDN',
-              enable_kyc: true,
-            },
-          },
-          pool1_points: 100,
-          pool2_points: 100,
-          pool3_points: 100,
-          pool4_points: 100,
-        },
-      });
-      const calculatedDate = await redemptionService.userDeadline(
-        userPoints.user_id,
-      );
-      const maxDate = new Date(
-        Math.max(
-          ...AIRDROP_CONFIG.data.map((p) => p.kyc_completed_by.getTime()),
-        ),
-      );
-      expect(calculatedDate).toEqual(maxDate);
     });
   });
 


### PR DESCRIPTION
## Summary
We have consolidated all deadlines to the same value, removing the logic here for separate deadlines.
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
