### PR TITLE
feat: return informative help messages and urls for KYC

### DIFF
--- a/src/jumio-kyc/fixtures/image-check.ts
+++ b/src/jumio-kyc/fixtures/image-check.ts
@@ -8,6 +8,10 @@ import { ImageChecksLabel } from '../../jumio-api/interfaces/jumio-transaction-r
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export const IMAGE_CHECK_FIXTURE = (
   label: ImageChecksLabel = 'REPEATED_FACE',
+  faceSearchFindings: string[] = [
+    'f7fe3c49-6221-4d87-b8b9-0cd243b65088',
+    '85b26f35-cf4e-4a68-8bce-88c20f06d3ff',
+  ],
 ) => {
   return {
     id: '1568893e-5edc-453c-9c50-e47fa10578f8',
@@ -30,10 +34,7 @@ export const IMAGE_CHECK_FIXTURE = (
     data: {
       faceSearchFindings: {
         status: 'DONE',
-        findings: [
-          'f7fe3c49-6221-4d87-b8b9-0cd243b65088',
-          '85b26f35-cf4e-4a68-8bce-88c20f06d3ff',
-        ],
+        findings: faceSearchFindings,
       },
     },
   };

--- a/src/jumio-kyc/interfaces/serialized-kyc.ts
+++ b/src/jumio-kyc/interfaces/serialized-kyc.ts
@@ -18,4 +18,5 @@ export interface SerializedKyc {
   can_attempt_reason: string;
   can_create: boolean;
   can_create_reason: string;
+  help_url: string;
 }

--- a/src/jumio-kyc/kyc.controller.spec.ts
+++ b/src/jumio-kyc/kyc.controller.spec.ts
@@ -116,6 +116,7 @@ describe('KycController', () => {
           '',
           false,
           'Redemption status is not TRY_AGAIN: IN_PROGRESS',
+          '',
           config,
         ),
       );
@@ -127,7 +128,7 @@ describe('KycController', () => {
       await expect(
         kycService.attempt(user, 'foo', '127.0.0.1'),
       ).rejects.toThrow(
-        'The country associated with your account is banned: PRK',
+        'The country associated with your graffiti is banned: PRK',
       );
 
       await request(app.getHttpServer())
@@ -362,6 +363,7 @@ describe('KycController', () => {
           '',
           false,
           'Redemption status is not TRY_AGAIN: IN_PROGRESS',
+          '',
           config,
         ),
       );

--- a/src/jumio-kyc/kyc.controller.ts
+++ b/src/jumio-kyc/kyc.controller.ts
@@ -70,8 +70,11 @@ export class KycController {
       fetchIpAddressFromRequest(req),
     );
 
-    const { eligible, reason: eligibleReason } =
-      await this.redemptionService.isEligible(user, redemption);
+    const {
+      eligible,
+      reason: eligibleReason,
+      helpUrl,
+    } = await this.redemptionService.isEligible(user, redemption);
 
     const { attemptable, reason: attemptableReason } =
       await this.redemptionService.canAttempt(redemption, user);
@@ -83,6 +86,7 @@ export class KycController {
       eligibleReason,
       attemptable,
       attemptableReason,
+      helpUrl,
       this.config,
     );
   }
@@ -126,8 +130,11 @@ export class KycController {
   > {
     const redemption = await this.redemptionService.find(user);
 
-    const { eligible, reason: eligibleReason } =
-      await this.redemptionService.isEligible(user, redemption);
+    const {
+      eligible,
+      reason: eligibleReason,
+      helpUrl,
+    } = await this.redemptionService.isEligible(user, redemption);
 
     const { attemptable, reason: attemptableReason } =
       await this.redemptionService.canAttempt(redemption, user);
@@ -151,6 +158,7 @@ export class KycController {
       eligibleReason,
       attemptable,
       attemptableReason,
+      helpUrl,
       this.config,
     );
   }

--- a/src/jumio-kyc/utils/serialize-kyc.ts
+++ b/src/jumio-kyc/utils/serialize-kyc.ts
@@ -13,6 +13,7 @@ export function serializeKyc(
   canAttemptReason: string,
   canCreate: boolean,
   canCreateReason: string,
+  helpUrl: string,
   config: ApiConfigService,
 ): SerializedKyc {
   assert.ok(redemption.jumio_account_id);
@@ -34,5 +35,6 @@ export function serializeKyc(
     can_attempt_reason: canAttemptReason,
     can_create: canCreate,
     can_create_reason: canCreateReason,
+    help_url: helpUrl,
   };
 }

--- a/src/redemptions/redemption.module.ts
+++ b/src/redemptions/redemption.module.ts
@@ -6,6 +6,7 @@ import { ApiConfigModule } from '../api-config/api-config.module';
 import { JumioTransactionModule } from '../jumio-transactions/jumio-transaction.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { UserPointsModule } from '../user-points/user-points.module';
+import { UsersModule } from '../users/users.module';
 import { RedemptionService } from './redemption.service';
 
 @Module({
@@ -13,6 +14,7 @@ import { RedemptionService } from './redemption.service';
   imports: [
     PrismaModule,
     UserPointsModule,
+    UsersModule,
     JumioTransactionModule,
     ApiConfigModule,
   ],

--- a/src/redemptions/redemption.service.ts
+++ b/src/redemptions/redemption.service.ts
@@ -18,6 +18,7 @@ import { JumioTransactionService } from '../jumio-transactions/jumio-transaction
 import { PrismaService } from '../prisma/prisma.service';
 import { BasePrismaClient } from '../prisma/types/base-prisma-client';
 import { UserPointsService } from '../user-points/user-points.service';
+import { UsersService } from '../users/users.service';
 
 export const AIRDROP_BANNED_COUNTRIES = ['IRN', 'PRK', 'AFG', 'CUB'];
 @Injectable()
@@ -27,6 +28,7 @@ export class RedemptionService {
     private readonly userPointsService: UserPointsService,
     private readonly jumioTransactionService: JumioTransactionService,
     private readonly config: ApiConfigService,
+    private readonly usersService: UsersService,
   ) {}
 
   async findOrThrow(user: User): Promise<Redemption> {
@@ -330,17 +332,21 @@ export class RedemptionService {
     user: User,
     redemption?: Redemption | null,
     prisma?: BasePrismaClient,
-  ): Promise<{ eligible: boolean; reason: string }> {
+  ): Promise<{ eligible: boolean; reason: string; helpUrl: string }> {
     if (
       redemption &&
       (redemption.kyc_status === KycStatus.SUBMITTED ||
         redemption.kyc_status === KycStatus.SUCCESS)
     ) {
-      return { eligible: true, reason: '' };
+      return { eligible: true, reason: '', helpUrl: '' };
     }
 
     if (user.ineligible_reason) {
-      return { eligible: false, reason: user.ineligible_reason };
+      return {
+        eligible: false,
+        reason: user.ineligible_reason,
+        helpUrl: 'https://coda.io/d/_dte_X_jrtqj/KYC-FAQ_su_vf#_luFte',
+      };
     }
 
     if (!user.enable_kyc) {
@@ -348,6 +354,7 @@ export class RedemptionService {
         eligible: false,
         reason:
           'KYC will open for your account soon, please be patient and check back later.',
+        helpUrl: '',
       };
     }
 
@@ -360,6 +367,7 @@ export class RedemptionService {
         return {
           eligible: false,
           reason: `Max KYC attempts reached ${redemption.kyc_attempts} / ${kycMaxAttempts}`,
+          helpUrl: 'https://coda.io/d/_dte_X_jrtqj/KYC-FAQ_su_vf#_luJAy',
         };
       }
 
@@ -367,6 +375,27 @@ export class RedemptionService {
         return {
           eligible: true,
           reason: this.minorAgeMessage(redemption.age),
+          helpUrl: 'https://coda.io/d/_dte_X_jrtqj/KYC-FAQ_su_vf#_luqdC',
+        };
+      }
+
+      let hasBannedCountry = null;
+      let kycCountries = null;
+      if (redemption.id_details) {
+        kycCountries = redemption.id_details as Array<{
+          id_issuing_country: string;
+        }>;
+        hasBannedCountry = kycCountries
+          .map((c) => this.hasBannedCountry(c.id_issuing_country))
+          .some((c) => c);
+      }
+      if (kycCountries && hasBannedCountry) {
+        return {
+          eligible: false,
+          reason: `A country associated with your KYC attempt is banned: ${kycCountries
+            .map((c) => c.id_issuing_country)
+            .join(', ')}`,
+          helpUrl: '',
         };
       }
     }
@@ -375,6 +404,7 @@ export class RedemptionService {
       return {
         eligible: false,
         reason: `Your final deadline for kyc has passed: ${KYC_DEADLINE.toUTCString()}`,
+        helpUrl: '',
       };
     }
 
@@ -390,17 +420,60 @@ export class RedemptionService {
       return {
         eligible: false,
         reason: 'Your account has no points, you are not eligible for airdrop',
+        helpUrl: '',
       };
     }
 
     if (this.hasBannedCountry(user.country_code)) {
       return {
         eligible: false,
-        reason: `The country associated with your account is banned: ${user.country_code}`,
+        reason: `The country associated with your graffiti is banned: ${user.country_code}`,
+        helpUrl: '',
       };
     }
 
-    return { eligible: true, reason: '' };
+    const transaction = await this.jumioTransactionService.findLatest(user);
+    const transactionStatus = transaction
+      ? (transaction.last_workflow_fetch as unknown as JumioTransactionRetrieveResponse)
+      : null;
+
+    const watchlistScreeningFailure = transactionStatus
+      ? this.watchlistScreeningFailure(
+          transactionStatus.capabilities.watchlistScreening,
+        )
+      : null;
+    if (watchlistScreeningFailure) {
+      return {
+        eligible: false,
+        reason: watchlistScreeningFailure,
+        helpUrl: 'https://coda.io/d/_dte_X_jrtqj/KYC-FAQ_su_vf#_luOvv',
+      };
+    }
+
+    const repeatedFaceWorkflowIds = transactionStatus
+      ? this.getRepeatedFaceWorkflowIds(
+          transactionStatus.capabilities.imageChecks,
+        )
+      : null;
+    if (repeatedFaceWorkflowIds) {
+      const transactions = await this.jumioTransactionService.findByWorkflowIds(
+        repeatedFaceWorkflowIds,
+      );
+      const users = await this.usersService.findManyById(
+        transactions.map((t) => t.user_id),
+      );
+      const graffitis = users.map((u) => u.graffiti);
+      return {
+        eligible: false,
+        reason: `You cannot KYC for more than one account. 
+        You have completed KYC with other graffitis${
+          graffitis ? ': ' + graffitis.join(', ') : ''
+        }`,
+        helpUrl: '',
+      };
+    }
+
+    return { eligible: true, reason: '', helpUrl: '' };
   }
 
   currentDate(): Date {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -72,6 +72,16 @@ export class UsersService {
     return results;
   }
 
+  async findManyById(ids: number[]): Promise<User[]> {
+    return this.prisma.user.findMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+    });
+  }
+
   async findByGraffitiOrThrow(graffiti: string): Promise<User> {
     const record = await this.findByGraffiti(graffiti);
     if (!record) {


### PR DESCRIPTION
## Summary
1. Returns better/more discrete error messages for users when calculating eligibility.
2. Returns associated `help_url` if merited
## Testing Plan
tests pass/test in staging
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
