### PR TITLE
Combine methods for calculating workflow status

### DIFF
--- a/src/jumio-api/interfaces/jumio-account-create.ts
+++ b/src/jumio-api/interfaces/jumio-account-create.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export interface JumioAccountCreateResponse {
+  timestamp: string;
   account: {
     id: string;
   };
@@ -13,6 +14,8 @@ export interface JumioAccountCreateResponse {
     id: string;
     credentials: {
       id: string;
+      category: string;
+      allowedChannels: string[];
       api: {
         token: string;
         parts: {

--- a/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
+++ b/src/jumio-api/interfaces/jumio-transaction-retrieve.ts
@@ -237,7 +237,7 @@ export interface JumioTransactionRetrieveResponse {
     };
   };
   capabilities: {
-    similarity: {
+    similarity?: {
       id: string;
       credentials: [
         {
@@ -259,7 +259,7 @@ export interface JumioTransactionRetrieveResponse {
         similarity: string;
       };
     }[];
-    dataChecks: {
+    dataChecks?: {
       id: string;
       credentials: [
         {
@@ -274,8 +274,8 @@ export interface JumioTransactionRetrieveResponse {
         };
       };
     }[];
-    extraction: ExtractionCheck[];
-    usability: {
+    extraction?: ExtractionCheck[];
+    usability?: {
       id: string;
       credentials: [
         {
@@ -290,13 +290,8 @@ export interface JumioTransactionRetrieveResponse {
         };
       };
     }[];
-    imageChecks: ImageCheck[];
-    watchlistScreening: WatchlistScreenCheck[];
-    liveness: LivenessCheck[];
+    imageChecks?: ImageCheck[];
+    watchlistScreening?: WatchlistScreenCheck[];
+    liveness?: LivenessCheck[];
   };
 }
-
-export type JumioTransactionStandaloneSanction = Omit<
-  JumioTransactionRetrieveResponse,
-  'capabilities'
-> & { capabilities: { watchlistScreening: WatchlistScreenCheck[] } };

--- a/src/jumio-api/jumio-api.service.ts
+++ b/src/jumio-api/jumio-api.service.ts
@@ -43,7 +43,7 @@ export class JumioApiService {
       });
 
     // Sanitize extracted values
-    if (sanitize && 'extraction' in response.data.capabilities) {
+    if (sanitize && response.data.capabilities.extraction) {
       for (const extraction of response.data.capabilities.extraction) {
         const sanitized = {
           issuingCountry: extraction.data.issuingCountry,
@@ -170,22 +170,28 @@ export class JumioApiService {
     let lastName = null;
     let dateOfBirth = null;
     let country = null;
-    for (const extraction of status.capabilities.extraction) {
-      if (extraction.data.dateOfBirth) {
-        dateOfBirth = extraction.data.dateOfBirth;
-      }
-      if (extraction.data.firstName) {
-        firstName =
-          extraction.data.firstName === 'N/A' ? '' : extraction.data.firstName;
-      }
-      if (extraction.data.lastName) {
-        lastName =
-          extraction.data.lastName === 'N/A' ? '' : extraction.data.lastName;
-      }
-      if (extraction.data.issuingCountry) {
-        country = extraction.data.issuingCountry;
+
+    if (status.capabilities.extraction) {
+      for (const extraction of status.capabilities.extraction) {
+        if (extraction.data.dateOfBirth) {
+          dateOfBirth = extraction.data.dateOfBirth;
+        }
+        if (extraction.data.firstName) {
+          firstName =
+            extraction.data.firstName === 'N/A'
+              ? ''
+              : extraction.data.firstName;
+        }
+        if (extraction.data.lastName) {
+          lastName =
+            extraction.data.lastName === 'N/A' ? '' : extraction.data.lastName;
+        }
+        if (extraction.data.issuingCountry) {
+          country = extraction.data.issuingCountry;
+        }
       }
     }
+
     if (
       firstName === null ||
       lastName === null ||
@@ -196,6 +202,7 @@ export class JumioApiService {
         'Required user info field not present on transaction',
       );
     }
+
     return {
       firstName,
       lastName,

--- a/src/jumio-kyc/fixtures/jumio-create-response.ts
+++ b/src/jumio-kyc/fixtures/jumio-create-response.ts
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { v4 as uuid } from 'uuid';
+import { JumioAccountCreateResponse } from '../../jumio-api/interfaces/jumio-account-create';
 
-export const JUMIO_CREATE_RESPONSE = {
+export const JUMIO_CREATE_RESPONSE: JumioAccountCreateResponse = {
+  timestamp: '2023-03-10T04:30:53.549Z',
   account: {
     id: uuid(),
   },
@@ -15,6 +17,8 @@ export const JUMIO_CREATE_RESPONSE = {
     credentials: [
       {
         id: uuid(),
+        category: 'DATA',
+        allowedChannels: ['API'],
         api: {
           token: 'faketoken',
           parts: {

--- a/src/jumio-kyc/fixtures/watchlist-create-response.ts
+++ b/src/jumio-kyc/fixtures/watchlist-create-response.ts
@@ -1,10 +1,16 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export const WORKFLOW_CREATE_WATCHLIST_RESPONSE = {
+
+import { JumioAccountCreateResponse } from '../../jumio-api/interfaces/jumio-account-create';
+
+export const WORKFLOW_CREATE_WATCHLIST_RESPONSE: JumioAccountCreateResponse = {
   timestamp: '2023-03-10T04:30:53.549Z',
   account: {
     id: 'aefa1cc2-011a-4615-8e7d-fdcaddb508cd',
+  },
+  web: {
+    href: 'https://api.amer-1.jumio.ai/api/v1/accounts/aefa1cc2-011a-4615-8e7d-fdcaddb508cd',
   },
   workflowExecution: {
     id: 'b94de56f-75b7-4df2-9320-eebba497f138',

--- a/src/jumio-kyc/fixtures/workflow-watchlist-pass.ts
+++ b/src/jumio-kyc/fixtures/workflow-watchlist-pass.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { JumioTransactionStandaloneSanction } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
+import { JumioTransactionRetrieveResponse } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
 
-export const WORKFLOW_RETRIEVE_WATCHLIST_PASS: JumioTransactionStandaloneSanction =
+export const WORKFLOW_RETRIEVE_WATCHLIST_PASS: JumioTransactionRetrieveResponse =
   {
     workflow: {
       id: 'b94de56f-75b7-4df2-9320-eebba497f138',

--- a/src/jumio-kyc/fixtures/workflow-watchlist.ts
+++ b/src/jumio-kyc/fixtures/workflow-watchlist.ts
@@ -3,13 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import {
-  JumioTransactionStandaloneSanction,
+  JumioTransactionRetrieveResponse,
   WatchlistScreeningLabels,
 } from '../../jumio-api/interfaces/jumio-transaction-retrieve';
 
 export const WORKFLOW_RETRIEVE_WATCHLIST = (
   watchlistLabel: WatchlistScreeningLabels,
-): JumioTransactionStandaloneSanction => {
+): JumioTransactionRetrieveResponse => {
   return {
     workflow: {
       id: 'b94de56f-75b7-4df2-9320-eebba497f138',

--- a/src/jumio-kyc/kyc.service.ts
+++ b/src/jumio-kyc/kyc.service.ts
@@ -268,10 +268,9 @@ export class KycService {
       transaction.workflow_execution_id,
     );
 
-    const calculatedStatus =
-      status.workflow.definitionKey !== '10010'
-        ? await this.redemptionService.calculateStatus(status)
-        : this.redemptionService.calculateStandaloneWatchlistStatus(status);
+    const calculatedStatus = await this.redemptionService.calculateStatus(
+      status,
+    );
 
     // Has our user's KYC status changed
     redemption = await this.redemptionService.update(redemption, {


### PR DESCRIPTION
## Summary

We had 2 different functions for calculating status of a workflow result, one for standalone, one for normal. However, the models are designed such that each section is just optional if the workflow doesn't specify that. You can easily combine them if you just check if the section is present, then validate that section.

I also saw a lot of fixtures weren't typed, and were being casted to any. Once you type them you realize fields are missing from them, and you don't need to cast them to any in the tests anymore.

This will be used to return the help url from this function.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
