### PR TITLE
Use actions with NodeJS 16

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v3.12.12
+      - uses: akhileshns/heroku-deploy@v3.12.13
         with:
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME_TESTNET }}
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
## Summary
Upgrading action to use node 16 since node 12 is being deprecated this summer

https://github.com/AkhileshNS/heroku-deploy/releases/tag/v3.12.13

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
