### PR TITLE
feat: add airdrop fee for miners so airdrop transactions will picked

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -99,3 +99,5 @@ export const AIRDROP_CONFIG = {
     },
   ],
 };
+
+export const AIRDROP_ORE_FEE = 10;

--- a/src/jumio-kyc/kyc.service.spec.ts
+++ b/src/jumio-kyc/kyc.service.spec.ts
@@ -9,7 +9,11 @@ import crypto from 'crypto';
 import faker from 'faker';
 import { v4 as uuid } from 'uuid';
 import { ApiConfigService } from '../api-config/api-config.service';
-import { AIRDROP_CONFIG, ORE_TO_IRON } from '../common/constants';
+import {
+  AIRDROP_CONFIG,
+  AIRDROP_ORE_FEE,
+  ORE_TO_IRON,
+} from '../common/constants';
 import { JumioApiService } from '../jumio-api/jumio-api.service';
 import { JumioTransactionService } from '../jumio-transactions/jumio-transaction.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -262,10 +266,16 @@ describe('KycService', () => {
       const user3Redemption = await redemptionService.findOrThrow(user3);
       const user4Redemption = await redemptionService.findOrThrow(user3);
       expect(user1Redemption.pool_one).toBe(
-        BigInt(Math.floor((5 / (11 + 5)) * (pool1.coins * ORE_TO_IRON))),
+        BigInt(
+          Math.floor((5 / (11 + 5)) * (pool1.coins * ORE_TO_IRON)) -
+            AIRDROP_ORE_FEE,
+        ),
       );
       expect(user2Redemption.pool_one).toBe(
-        BigInt(Math.floor((11 / (11 + 5)) * (pool1.coins * ORE_TO_IRON))),
+        BigInt(
+          Math.floor((11 / (11 + 5)) * (pool1.coins * ORE_TO_IRON)) -
+            AIRDROP_ORE_FEE,
+        ),
       );
       expect(user3Redemption.pool_one).toBeNull();
       expect(user4Redemption.pool_one).toBeNull();

--- a/src/jumio-kyc/kyc.service.ts
+++ b/src/jumio-kyc/kyc.service.ts
@@ -13,6 +13,7 @@ import crypto from 'crypto';
 import { ApiConfigService } from '../api-config/api-config.service';
 import {
   AIRDROP_CONFIG,
+  AIRDROP_ORE_FEE,
   ORE_TO_IRON,
   POOL1_TOKENS,
   POOL2_TOKENS,
@@ -362,8 +363,11 @@ export class KycService {
         continue;
       }
 
-      const allocatedOre = Math.floor((userPoolPoints / totalPoints) * poolOre);
-      await this.redemptionService.update(redemption, { [pool]: allocatedOre });
+      const allocatedOre =
+        Math.floor((userPoolPoints / totalPoints) * poolOre) - AIRDROP_ORE_FEE;
+      await this.redemptionService.update(redemption, {
+        [pool]: allocatedOre < 0 ? 0 : allocatedOre,
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
We previously had no fee, this adds a `10 ORE` fee for each airdrop. This will allow us to provide ORE for fee to miners for mining blocks with these transactions.
## Testing Plan
Tests pass

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
