### PR TITLE
fix(api): Use root domain when setting cookie

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -142,9 +142,10 @@ export class AuthController {
     };
 
     if (!this.config.isLocal()) {
-      cookieOptions.domain = new URL(
-        this.config.get<string>('INCENTIVIZED_TESTNET_URL'),
-      ).host;
+      const host = new URL(this.config.get<string>('INCENTIVIZED_TESTNET_URL'))
+        .host;
+      cookieOptions.domain = `.${host.split('.').slice(-2).join('.')}`;
+
       cookieOptions.sameSite = 'none';
       cookieOptions.secure = true;
     }


### PR DESCRIPTION
## Summary

Correctly use subdomains for cookies

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
