### PR TITLE
Redirect to dashboard after auth

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -190,7 +190,7 @@ describe('AuthController', () => {
           .expect(HttpStatus.FOUND);
 
         expect(header.location).toBe(
-          `${config.get<string>('INCENTIVIZED_TESTNET_URL')}/login`,
+          `${config.get<string>('INCENTIVIZED_TESTNET_URL')}/dashboard`,
         );
         expect(updateLastLoginAt).toHaveBeenCalledTimes(1);
       });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -77,6 +77,11 @@ export class AuthController {
     const redirectUrl = `${this.config.get<string>(
       'INCENTIVIZED_TESTNET_URL',
     )}/login`;
+
+    const dashboardUrl = `${this.config.get<string>(
+      'INCENTIVIZED_TESTNET_URL',
+    )}/dashboard`;
+
     if (this.config.get<boolean>('DISABLE_LOGIN')) {
       res.redirect(`${redirectUrl}?toast=${btoa('Login is disabled')}`);
       return;
@@ -92,7 +97,7 @@ export class AuthController {
       }
 
       this.setResponseHeaders(res, token);
-      res.redirect(redirectUrl);
+      res.redirect(dashboardUrl);
     } catch (error: unknown) {
       if (error instanceof Error) {
         res.redirect(


### PR DESCRIPTION
## Summary
When auth pass, redirect user to dashboard
## Testing Plan
spec
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@rohanjadvani @iron-fish/engineering 