### PR TITLE
feat: add sent ore to redemption for bookkeeping

### DIFF
--- a/prisma/migrations/20230405155127_add_sent_ore_redemption/migration.sql
+++ b/prisma/migrations/20230405155127_add_sent_ore_redemption/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "redemptions" ADD COLUMN     "sent_ore" BIGINT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Redemption {
   public_address   String    @db.VarChar
   hashed_ip_address String?  @db.VarChar
   transaction_hash String?   @db.VarChar
+  sent_ore         BigInt?
   id_details       Json?
   age              Int?
   failure_message  String?   @db.VarChar

--- a/src/jumio-kyc/interfaces/serialized-kyc.ts
+++ b/src/jumio-kyc/interfaces/serialized-kyc.ts
@@ -14,6 +14,7 @@ export interface SerializedKyc {
   jumio_workflow_execution_id: string;
   jumio_web_href: string;
   transaction_hash: string | null;
+  sent_iron: number | null;
   public_address: string;
   can_attempt: boolean;
   can_attempt_reason: string;

--- a/src/jumio-kyc/utils/serialize-kyc.ts
+++ b/src/jumio-kyc/utils/serialize-kyc.ts
@@ -4,6 +4,7 @@
 import { JumioTransaction, Redemption } from '@prisma/client';
 import assert from 'assert';
 import { ApiConfigService } from '../../api-config/api-config.service';
+import { ORE_TO_IRON } from '../../common/constants';
 import { SerializedKyc } from '../interfaces/serialized-kyc';
 
 export function serializeKyc(
@@ -21,6 +22,10 @@ export function serializeKyc(
   const maxAttempts =
     redemption.kyc_max_attempts ?? config.get<number>('KYC_MAX_ATTEMPTS');
 
+  const sentIron = redemption.sent_ore
+    ? Number(redemption.sent_ore) / ORE_TO_IRON
+    : null;
+
   return {
     redemption_id: redemption.id,
     user_id: redemption.user_id,
@@ -32,6 +37,7 @@ export function serializeKyc(
     jumio_workflow_execution_id: transaction.workflow_execution_id,
     jumio_web_href: transaction.web_href,
     transaction_hash: redemption.transaction_hash,
+    sent_iron: sentIron,
     can_attempt: canAttempt,
     can_attempt_reason: canAttemptReason,
     can_create: canCreate,


### PR DESCRIPTION
## Summary
Adds booking field for sent ore as suggested by @danield9tqh when reviewing airdrop spec.
## Testing Plan
tests pass

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
