### PR TITLE
feat: add total points for each pool in kyc config

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -75,6 +75,7 @@ export const AIRDROP_CONFIG = {
       kyc_completed_by: KYC_DEADLINE,
       name: 'pool_three',
       pool_name: 'Code Contributions Pool',
+      total_points: 65250,
     },
     {
       airdrop_completed_by: AIRDROP_DEADLINE,
@@ -82,6 +83,7 @@ export const AIRDROP_CONFIG = {
       kyc_completed_by: KYC_DEADLINE,
       name: 'pool_one',
       pool_name: 'Phase 1 Pool',
+      total_points: 9993890,
     },
     {
       airdrop_completed_by: AIRDROP_DEADLINE,
@@ -89,6 +91,7 @@ export const AIRDROP_CONFIG = {
       kyc_completed_by: KYC_DEADLINE,
       name: 'pool_two',
       pool_name: 'Phase 2 Pool',
+      total_points: 67971717,
     },
     {
       airdrop_completed_by: AIRDROP_DEADLINE,
@@ -96,6 +99,7 @@ export const AIRDROP_CONFIG = {
       kyc_completed_by: KYC_DEADLINE,
       name: 'pool_four',
       pool_name: 'Phase 3 Pool',
+      total_points: 93223810,
     },
   ],
 };

--- a/src/jumio-kyc/interfaces/serialized-kyc-config.ts
+++ b/src/jumio-kyc/interfaces/serialized-kyc-config.ts
@@ -8,5 +8,6 @@ export interface SerializedKycConfig {
     kyc_completed_by: Date;
     name: string;
     pool_name: string;
+    total_points: number;
   }[];
 }


### PR DESCRIPTION
## Summary
Total points retrieved by:
```
ironfish-api-mainnet::DATABASE=> select sum(pool1_points), sum(pool2_points), sum(pool3_points), sum(pool4_points) from user_points up join redemptions r on up.user_id = r.user_id where r.kyc_status = 'SUCCESS';
   sum   |   sum    |  sum  |   sum
---------+----------+-------+----------
 9993890 | 67971717 | 65250 | 93223810
```
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
