### PR TITLE
feat: returns pool iron for user on KYC GET request

### DIFF
--- a/src/jumio-kyc/interfaces/serialized-kyc.ts
+++ b/src/jumio-kyc/interfaces/serialized-kyc.ts
@@ -14,11 +14,14 @@ export interface SerializedKyc {
   jumio_workflow_execution_id: string;
   jumio_web_href: string;
   transaction_hash: string | null;
-  sent_iron: number | null;
   public_address: string;
   can_attempt: boolean;
   can_attempt_reason: string;
   can_create: boolean;
   can_create_reason: string;
   help_url: string;
+  pool_one_iron: number;
+  pool_two_iron: number;
+  pool_three_iron: number;
+  pool_four_iron: number;
 }

--- a/src/jumio-kyc/kyc.service.spec.ts
+++ b/src/jumio-kyc/kyc.service.spec.ts
@@ -113,7 +113,9 @@ describe('KycService', () => {
         data: { pool1_points: 3 },
         where: { user_id: user.id },
       });
-
+      jest
+        .spyOn(redemptionService, 'currentDate')
+        .mockImplementationOnce(() => new Date(1678905869000));
       let { redemption, transaction } = await kycService.attempt(
         user,
         '',
@@ -152,6 +154,9 @@ describe('KycService', () => {
         data: { pool1_points: 3 },
         where: { user_id: user.id },
       });
+      jest
+        .spyOn(redemptionService, 'currentDate')
+        .mockImplementationOnce(() => new Date(1678905869000));
 
       let { redemption } = await kycService.attempt(user, '', '127.0.0.1');
       expect(redemption.kyc_status).toBe(KycStatus.IN_PROGRESS);

--- a/src/jumio-kyc/utils/serialize-kyc.ts
+++ b/src/jumio-kyc/utils/serialize-kyc.ts
@@ -22,9 +22,21 @@ export function serializeKyc(
   const maxAttempts =
     redemption.kyc_max_attempts ?? config.get<number>('KYC_MAX_ATTEMPTS');
 
-  const sentIron = redemption.sent_ore
-    ? Number(redemption.sent_ore) / ORE_TO_IRON
-    : null;
+  const pool_one_iron = redemption.pool_one
+    ? (Number(redemption.pool_one) * 1.0) / ORE_TO_IRON
+    : 0;
+
+  const pool_two_iron = redemption.pool_two
+    ? (Number(redemption.pool_two) * 1.0) / ORE_TO_IRON
+    : 0;
+
+  const pool_three_iron = redemption.pool_three
+    ? (Number(redemption.pool_three) * 1.0) / ORE_TO_IRON
+    : 0;
+
+  const pool_four_iron = redemption.pool_four
+    ? (Number(redemption.pool_four) * 1.0) / ORE_TO_IRON
+    : 0;
 
   return {
     redemption_id: redemption.id,
@@ -37,11 +49,14 @@ export function serializeKyc(
     jumio_workflow_execution_id: transaction.workflow_execution_id,
     jumio_web_href: transaction.web_href,
     transaction_hash: redemption.transaction_hash,
-    sent_iron: sentIron,
     can_attempt: canAttempt,
     can_attempt_reason: canAttemptReason,
     can_create: canCreate,
     can_create_reason: canCreateReason,
     help_url: helpUrl,
+    pool_one_iron,
+    pool_two_iron,
+    pool_three_iron,
+    pool_four_iron,
   };
 }


### PR DESCRIPTION
## Summary
Adds serialized pool iron payouts for each user to the KYC get response.

NOTE:
I had to add a bunch of mocks for the current time because as the KYC deadline has passed, the tests were failing.
## Testing Plan
Tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
