### PR TITLE
feat: add airdrop_transaction_hash to serialized kyc response

### DIFF
--- a/src/jumio-kyc/interfaces/serialized-kyc.ts
+++ b/src/jumio-kyc/interfaces/serialized-kyc.ts
@@ -24,4 +24,5 @@ export interface SerializedKyc {
   pool_two_iron: number;
   pool_three_iron: number;
   pool_four_iron: number;
+  airdrop_transaction_hash: string | null;
 }

--- a/src/jumio-kyc/utils/serialize-kyc.ts
+++ b/src/jumio-kyc/utils/serialize-kyc.ts
@@ -58,5 +58,6 @@ export function serializeKyc(
     pool_two_iron,
     pool_three_iron,
     pool_four_iron,
+    airdrop_transaction_hash: redemption.transaction_hash,
   };
 }


### PR DESCRIPTION
## Summary
Adds transaction hash that will be populated in db once airdrop completed, currently is null for all users.
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
