### PR TITLE
feat(api): Make `blocks.previous_block_hash` not null

### DIFF
--- a/prisma/migrations/20230420192411_add_not_null_to_blocks_previous_block_hash/migration.sql
+++ b/prisma/migrations/20230420192411_add_not_null_to_blocks_previous_block_hash/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `previous_block_hash` on table `blocks` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "blocks" ALTER COLUMN "previous_block_hash" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,7 +126,7 @@ model Block {
   updated_at               DateTime           @default(now()) @updatedAt @db.Timestamp(6)
   hash                     String             @db.VarChar
   sequence                 Int
-  previous_block_hash      String?            @db.VarChar
+  previous_block_hash      String             @db.VarChar
   main                     Boolean
   network_version          Int
   transactions_count       Int

--- a/src/blocks/dto/upsert-blocks.dto.ts
+++ b/src/blocks/dto/upsert-blocks.dto.ts
@@ -48,7 +48,7 @@ export class BlockDto {
 
   @IsOptional()
   @IsString()
-  readonly previous_block_hash?: string;
+  readonly previous_block_hash!: string;
 
   @Max(Number.MAX_SAFE_INTEGER)
   @IsInt()

--- a/src/blocks/interfaces/upsert-block-options.ts
+++ b/src/blocks/interfaces/upsert-block-options.ts
@@ -13,6 +13,6 @@ export interface UpsertBlockOptions {
   transactionsCount: number;
   graffiti: string;
   size: number;
-  previousBlockHash?: string;
+  previousBlockHash: string;
   timeSinceLastBlockMs?: number;
 }


### PR DESCRIPTION
## Summary

This column is always populated

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
