### PR TITLE
fix(api): Update average difficulty to decimal type

### DIFF
--- a/prisma/migrations/20230421190321_change_average_difficulty_millis_to_average_difficulty_on_blocks_daily/migration.sql
+++ b/prisma/migrations/20230421190321_change_average_difficulty_millis_to_average_difficulty_on_blocks_daily/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `average_difficulty_millis` on the `blocks_daily` table. All the data in the column will be lost.
+  - Added the required column `average_difficulty` to the `blocks_daily` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "blocks_daily" DROP COLUMN "average_difficulty_millis",
+ADD COLUMN     "average_difficulty" DECIMAL(65,30) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -209,7 +209,7 @@ model BlockDaily {
   blocks_with_graffiti_count Int
   cumulative_unique_graffiti Int
   transactions_count         Int
-  average_difficulty_millis  BigInt
+  average_difficulty         Decimal
   chain_sequence             Int
 
   @@index([date], map: "index_blocks_daily_on_date")

--- a/src/blocks-daily-loader/blocks-daily-loader.spec.ts
+++ b/src/blocks-daily-loader/blocks-daily-loader.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { BlocksService } from '../blocks/blocks.service';
 import { BlocksDailyService } from '../blocks-daily/blocks-daily.service';
 import { bootstrapTestApp } from '../test/test-app';
@@ -30,7 +31,7 @@ describe('BlocksDailyLoader', () => {
       const date = new Date();
       const mockMetrics = {
         averageBlockTimeMs: 0,
-        averageDifficultyMillis: 0n,
+        averageDifficulty: new Prisma.Decimal(0),
         blocksCount: 0,
         blocksWithGraffitiCount: 0,
         chainSequence: 0,

--- a/src/blocks-daily/blocks-daily.service.spec.ts
+++ b/src/blocks-daily/blocks-daily.service.spec.ts
@@ -98,7 +98,7 @@ describe('BlocksDailyService', () => {
       expect(blockDaily).toMatchObject({
         id: expect.any(Number),
         average_block_time_ms: options.averageBlockTimeMs,
-        averageDifficulty: new Prisma.Decimal(0),
+        average_difficulty: new Prisma.Decimal(0),
         blocks_count: options.blocksCount,
         blocks_with_graffiti_count: options.blocksWithGraffitiCount,
         chain_sequence: options.chainSequence,

--- a/src/blocks-daily/blocks-daily.service.spec.ts
+++ b/src/blocks-daily/blocks-daily.service.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { INestApplication } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { getNextDate } from '../common/utils/date';
 import { PrismaService } from '../prisma/prisma.service';
 import { bootstrapTestApp } from '../test/test-app';
@@ -28,7 +29,7 @@ describe('BlocksDailyService', () => {
       await prisma.blockDaily.create({
         data: {
           average_block_time_ms: 1,
-          average_difficulty_millis: 1000,
+          average_difficulty: 1000,
           blocks_count: 1,
           blocks_with_graffiti_count: 1,
           chain_sequence: 1,
@@ -41,7 +42,7 @@ describe('BlocksDailyService', () => {
       await prisma.blockDaily.create({
         data: {
           average_block_time_ms: 1,
-          average_difficulty_millis: 1000,
+          average_difficulty: 1000,
           blocks_count: 1,
           blocks_with_graffiti_count: 1,
           chain_sequence: 1,
@@ -54,7 +55,7 @@ describe('BlocksDailyService', () => {
       await prisma.blockDaily.create({
         data: {
           average_block_time_ms: 1,
-          average_difficulty_millis: 1000,
+          average_difficulty: 1000,
           blocks_count: 1,
           blocks_with_graffiti_count: 1,
           chain_sequence: 1,
@@ -83,7 +84,7 @@ describe('BlocksDailyService', () => {
     it('upserts a BlockDaily record', async () => {
       const options = {
         averageBlockTimeMs: 0,
-        averageDifficultyMillis: 0n,
+        averageDifficulty: new Prisma.Decimal(0),
         blocksCount: 0,
         blocksWithGraffitiCount: 0,
         chainSequence: 0,
@@ -97,7 +98,7 @@ describe('BlocksDailyService', () => {
       expect(blockDaily).toMatchObject({
         id: expect.any(Number),
         average_block_time_ms: options.averageBlockTimeMs,
-        average_difficulty_millis: BigInt(options.averageDifficultyMillis),
+        averageDifficulty: new Prisma.Decimal(0),
         blocks_count: options.blocksCount,
         blocks_with_graffiti_count: options.blocksWithGraffitiCount,
         chain_sequence: options.chainSequence,
@@ -113,7 +114,7 @@ describe('BlocksDailyService', () => {
     it('returns the next date from the last daily snapshot', async () => {
       const options = {
         averageBlockTimeMs: 0,
-        averageDifficultyMillis: 0n,
+        averageDifficulty: new Prisma.Decimal(0),
         blocksCount: 0,
         blocksWithGraffitiCount: 0,
         chainSequence: 0,

--- a/src/blocks-daily/blocks-daily.service.ts
+++ b/src/blocks-daily/blocks-daily.service.ts
@@ -26,7 +26,7 @@ export class BlocksDailyService {
     return this.prisma.blockDaily.upsert({
       create: {
         average_block_time_ms: options.averageBlockTimeMs,
-        average_difficulty_millis: options.averageDifficultyMillis,
+        average_difficulty: options.averageDifficulty,
         blocks_count: options.blocksCount,
         blocks_with_graffiti_count: options.blocksWithGraffitiCount,
         chain_sequence: options.chainSequence,
@@ -37,7 +37,7 @@ export class BlocksDailyService {
       },
       update: {
         average_block_time_ms: options.averageBlockTimeMs,
-        average_difficulty_millis: options.averageDifficultyMillis,
+        average_difficulty: options.averageDifficulty,
         blocks_count: options.blocksCount,
         blocks_with_graffiti_count: options.blocksWithGraffitiCount,
         chain_sequence: options.chainSequence,

--- a/src/blocks-daily/interfaces/create-blocks-daily-options.ts
+++ b/src/blocks-daily/interfaces/create-blocks-daily-options.ts
@@ -1,9 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Prisma } from '@prisma/client';
+
 export interface CreateBlocksDailyOptions {
   averageBlockTimeMs: number;
-  averageDifficultyMillis: bigint;
+  averageDifficulty: Prisma.Decimal;
   blocksCount: number;
   blocksWithGraffitiCount: number;
   chainSequence: number;

--- a/src/blocks/blocks.controller.spec.ts
+++ b/src/blocks/blocks.controller.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { HttpStatus, INestApplication } from '@nestjs/common';
-import { Block } from '@prisma/client';
+import { Block, Prisma } from '@prisma/client';
 import faker from 'faker';
 import request from 'supertest';
 import { v4 as uuid } from 'uuid';
@@ -726,7 +726,7 @@ describe('BlocksController', () => {
         const end = '2021-07-01T00:00:00.000Z';
         await blocksDailyService.upsert({
           averageBlockTimeMs: 0,
-          averageDifficultyMillis: 0n,
+          averageDifficulty: new Prisma.Decimal(0),
           blocksCount: 0,
           blocksWithGraffitiCount: 0,
           chainSequence: 0,

--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -446,7 +446,7 @@ describe('BlocksService', () => {
       const metrics = await blocksService.getDateMetrics(date);
       expect(metrics).toMatchObject({
         averageBlockTimeMs: expect.any(Number),
-        averageDifficultyMillis: expect.anything(),
+        averageDifficulty: expect.anything(),
         blocksCount: expect.any(Number),
         blocksWithGraffitiCount: expect.any(Number),
         chainSequence: expect.any(Number),

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -263,7 +263,7 @@ export class BlocksService {
     const dateMetricsResponse = await this.prisma.$queryRawUnsafe<
       {
         average_block_time_ms: number;
-        average_difficulty_millis: bigint;
+        average_difficulty: Prisma.Decimal;
         blocks_count: bigint;
         blocks_with_graffiti_count: bigint;
         chain_sequence: number;
@@ -274,7 +274,7 @@ export class BlocksService {
       `
       SELECT
         FLOOR(COALESCE(EXTRACT(EPOCH FROM MAX(timestamp) - MIN(timestamp)), 0) * 1000 / GREATEST(COUNT(*), 1)) AS average_block_time_ms,
-        COALESCE(FLOOR(AVG(difficulty) * 1000), 0) AS average_difficulty_millis,
+        COALESCE(AVG(difficulty), 0) AS average_difficulty,
         COUNT(*) AS blocks_count,
         COALESCE(SUM(CASE WHEN graffiti != '' THEN 1 ELSE 0 END), 0) AS blocks_with_graffiti_count,
         COALESCE(MAX(sequence), 0) AS chain_sequence,
@@ -327,7 +327,7 @@ export class BlocksService {
 
     return {
       averageBlockTimeMs: dateMetricsResponse[0].average_block_time_ms,
-      averageDifficultyMillis: dateMetricsResponse[0].average_difficulty_millis,
+      averageDifficulty: dateMetricsResponse[0].average_difficulty,
       blocksCount: Number(dateMetricsResponse[0].blocks_count),
       blocksWithGraffitiCount: Number(
         dateMetricsResponse[0].blocks_with_graffiti_count,

--- a/src/blocks/interfaces/blocks-date-metrics.ts
+++ b/src/blocks/interfaces/blocks-date-metrics.ts
@@ -1,9 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Prisma } from '@prisma/client';
+
 export interface BlocksDateMetrics {
   averageBlockTimeMs: number;
-  averageDifficultyMillis: bigint;
+  averageDifficulty: Prisma.Decimal;
   blocksCount: number;
   blocksWithGraffitiCount: number;
   chainSequence: number;

--- a/src/blocks/utils/blocks-metrics-translator.ts
+++ b/src/blocks/utils/blocks-metrics-translator.ts
@@ -10,7 +10,7 @@ export function serializedBlockMetricsFromRecord(
   return {
     object: 'block_metrics',
     average_block_time_ms: record.average_block_time_ms,
-    average_difficulty: Number(record.average_difficulty_millis / BigInt(1000)),
+    average_difficulty: record.average_difficulty.toNumber(),
     blocks_count: record.blocks_count,
     blocks_with_graffiti_count: record.blocks_with_graffiti_count,
     chain_sequence: record.chain_sequence,


### PR DESCRIPTION
## Summary

BigInts in Prisma don't work if they don't fit into 64 bit integers

## Testing Plan

Manually tested

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
