### PR TITLE
feat(api): add average_block_size to the block_metrics API

### DIFF
--- a/prisma/migrations/20230427184323_add_average_block_size_to_blocks_daily/migration.sql
+++ b/prisma/migrations/20230427184323_add_average_block_size_to_blocks_daily/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "blocks_daily" ADD COLUMN     "average_block_size" DECIMAL(65,30) NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -210,6 +210,7 @@ model BlockDaily {
   cumulative_unique_graffiti Int
   transactions_count         Int
   average_difficulty         Decimal
+  average_block_size         Decimal @default(0)
   chain_sequence             Int
 
   @@index([date], map: "index_blocks_daily_on_date")

--- a/src/blocks-daily-loader/blocks-daily-loader.spec.ts
+++ b/src/blocks-daily-loader/blocks-daily-loader.spec.ts
@@ -32,6 +32,7 @@ describe('BlocksDailyLoader', () => {
       const mockMetrics = {
         averageBlockTimeMs: 0,
         averageDifficulty: new Prisma.Decimal(0),
+        averageBlockSize: new Prisma.Decimal(0),
         blocksCount: 0,
         blocksWithGraffitiCount: 0,
         chainSequence: 0,

--- a/src/blocks-daily/blocks-daily.service.spec.ts
+++ b/src/blocks-daily/blocks-daily.service.spec.ts
@@ -30,6 +30,7 @@ describe('BlocksDailyService', () => {
         data: {
           average_block_time_ms: 1,
           average_difficulty: 1000,
+          average_block_size: 1000,
           blocks_count: 1,
           blocks_with_graffiti_count: 1,
           chain_sequence: 1,
@@ -43,6 +44,7 @@ describe('BlocksDailyService', () => {
         data: {
           average_block_time_ms: 1,
           average_difficulty: 1000,
+          average_block_size: 1000,
           blocks_count: 1,
           blocks_with_graffiti_count: 1,
           chain_sequence: 1,
@@ -56,6 +58,7 @@ describe('BlocksDailyService', () => {
         data: {
           average_block_time_ms: 1,
           average_difficulty: 1000,
+          average_block_size: 1000,
           blocks_count: 1,
           blocks_with_graffiti_count: 1,
           chain_sequence: 1,
@@ -85,6 +88,7 @@ describe('BlocksDailyService', () => {
       const options = {
         averageBlockTimeMs: 0,
         averageDifficulty: new Prisma.Decimal(0),
+        averageBlockSize: new Prisma.Decimal(0),
         blocksCount: 0,
         blocksWithGraffitiCount: 0,
         chainSequence: 0,
@@ -99,6 +103,7 @@ describe('BlocksDailyService', () => {
         id: expect.any(Number),
         average_block_time_ms: options.averageBlockTimeMs,
         average_difficulty: new Prisma.Decimal(0),
+        average_block_size: new Prisma.Decimal(0),
         blocks_count: options.blocksCount,
         blocks_with_graffiti_count: options.blocksWithGraffitiCount,
         chain_sequence: options.chainSequence,
@@ -115,6 +120,7 @@ describe('BlocksDailyService', () => {
       const options = {
         averageBlockTimeMs: 0,
         averageDifficulty: new Prisma.Decimal(0),
+        averageBlockSize: new Prisma.Decimal(0),
         blocksCount: 0,
         blocksWithGraffitiCount: 0,
         chainSequence: 0,

--- a/src/blocks-daily/blocks-daily.service.ts
+++ b/src/blocks-daily/blocks-daily.service.ts
@@ -27,6 +27,7 @@ export class BlocksDailyService {
       create: {
         average_block_time_ms: options.averageBlockTimeMs,
         average_difficulty: options.averageDifficulty,
+        average_block_size: options.averageBlockSize,
         blocks_count: options.blocksCount,
         blocks_with_graffiti_count: options.blocksWithGraffitiCount,
         chain_sequence: options.chainSequence,
@@ -38,6 +39,7 @@ export class BlocksDailyService {
       update: {
         average_block_time_ms: options.averageBlockTimeMs,
         average_difficulty: options.averageDifficulty,
+        average_block_size: options.averageBlockSize,
         blocks_count: options.blocksCount,
         blocks_with_graffiti_count: options.blocksWithGraffitiCount,
         chain_sequence: options.chainSequence,

--- a/src/blocks-daily/interfaces/create-blocks-daily-options.ts
+++ b/src/blocks-daily/interfaces/create-blocks-daily-options.ts
@@ -6,6 +6,7 @@ import { Prisma } from '@prisma/client';
 export interface CreateBlocksDailyOptions {
   averageBlockTimeMs: number;
   averageDifficulty: Prisma.Decimal;
+  averageBlockSize: Prisma.Decimal;
   blocksCount: number;
   blocksWithGraffitiCount: number;
   chainSequence: number;

--- a/src/blocks/blocks.controller.spec.ts
+++ b/src/blocks/blocks.controller.spec.ts
@@ -728,6 +728,7 @@ describe('BlocksController', () => {
         await blocksDailyService.upsert({
           averageBlockTimeMs: 0,
           averageDifficulty: new Prisma.Decimal(0),
+          averageBlockSize: new Prisma.Decimal(0),
           blocksCount: 0,
           blocksWithGraffitiCount: 0,
           chainSequence: 0,

--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -448,6 +448,7 @@ describe('BlocksService', () => {
       expect(metrics).toMatchObject({
         averageBlockTimeMs: expect.any(Number),
         averageDifficulty: expect.anything(),
+        averageBlockSize: expect.any(Number),
         blocksCount: expect.any(Number),
         blocksWithGraffitiCount: expect.any(Number),
         chainSequence: expect.any(Number),

--- a/src/blocks/blocks.service.spec.ts
+++ b/src/blocks/blocks.service.spec.ts
@@ -448,7 +448,7 @@ describe('BlocksService', () => {
       expect(metrics).toMatchObject({
         averageBlockTimeMs: expect.any(Number),
         averageDifficulty: expect.anything(),
-        averageBlockSize: expect.any(Number),
+        averageBlockSize: expect.anything(),
         blocksCount: expect.any(Number),
         blocksWithGraffitiCount: expect.any(Number),
         chainSequence: expect.any(Number),

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -267,6 +267,7 @@ export class BlocksService {
       {
         average_block_time_ms: number;
         average_difficulty: Prisma.Decimal;
+        average_block_size: Prisma.Decimal;
         blocks_count: bigint;
         blocks_with_graffiti_count: bigint;
         chain_sequence: number;
@@ -278,6 +279,7 @@ export class BlocksService {
       SELECT
         FLOOR(COALESCE(EXTRACT(EPOCH FROM MAX(timestamp) - MIN(timestamp)), 0) * 1000 / GREATEST(COUNT(*), 1)) AS average_block_time_ms,
         COALESCE(AVG(difficulty), 0) AS average_difficulty,
+        COALESCE(AVG(size), 0) AS average_block_size,
         COUNT(*) AS blocks_count,
         COALESCE(SUM(CASE WHEN graffiti != '' THEN 1 ELSE 0 END), 0) AS blocks_with_graffiti_count,
         COALESCE(MAX(sequence), 0) AS chain_sequence,
@@ -331,6 +333,7 @@ export class BlocksService {
     return {
       averageBlockTimeMs: dateMetricsResponse[0].average_block_time_ms,
       averageDifficulty: dateMetricsResponse[0].average_difficulty,
+      averageBlockSize: dateMetricsResponse[0].average_block_size,
       blocksCount: Number(dateMetricsResponse[0].blocks_count),
       blocksWithGraffitiCount: Number(
         dateMetricsResponse[0].blocks_with_graffiti_count,

--- a/src/blocks/interfaces/blocks-date-metrics.ts
+++ b/src/blocks/interfaces/blocks-date-metrics.ts
@@ -6,6 +6,7 @@ import { Prisma } from '@prisma/client';
 export interface BlocksDateMetrics {
   averageBlockTimeMs: number;
   averageDifficulty: Prisma.Decimal;
+  averageBlockSize: Prisma.Decimal;
   blocksCount: number;
   blocksWithGraffitiCount: number;
   chainSequence: number;

--- a/src/blocks/interfaces/serialized-block-metrics.ts
+++ b/src/blocks/interfaces/serialized-block-metrics.ts
@@ -5,6 +5,7 @@ export interface SerializedBlockMetrics {
   object: 'block_metrics';
   average_block_time_ms: number;
   average_difficulty: number;
+  average_block_size: number;
   blocks_count: number;
   blocks_with_graffiti_count: number;
   chain_sequence: number;

--- a/src/blocks/utils/blocks-metrics-translator.ts
+++ b/src/blocks/utils/blocks-metrics-translator.ts
@@ -11,6 +11,7 @@ export function serializedBlockMetricsFromRecord(
     object: 'block_metrics',
     average_block_time_ms: record.average_block_time_ms,
     average_difficulty: record.average_difficulty.toNumber(),
+    average_block_size: record.average_block_size.toNumber(),
     blocks_count: record.blocks_count,
     blocks_with_graffiti_count: record.blocks_with_graffiti_count,
     chain_sequence: record.chain_sequence,


### PR DESCRIPTION
## Summary
Adds `average_block_size` to the `block_metrics` API. This unblocks creating charts for block size in the explorer.

Closes IFL-767

## Testing Plan
Updated appropriate unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
