### PR TITLE
feat(ifl-789): verified asset flag

### DIFF
--- a/prisma/migrations/20230502165227_add_verified_at_asset/migration.sql
+++ b/prisma/migrations/20230502165227_add_verified_at_asset/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "assets" ADD COLUMN     "verified_at" TIMESTAMP(6);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -355,6 +355,7 @@ model Asset {
   name                   String
   owner                  String
   supply                 BigInt
+  verified_at            DateTime?          @db.Timestamp(6)
   descriptions           AssetDescription[]
   created_transaction    Transaction        @relation(fields: [created_transaction_id], references: [id])
 

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -138,6 +138,7 @@ describe('AssetsController', () => {
           name: asset.name,
           owner: asset.owner,
           supply: asset.supply.toString(),
+          verified_at: null,
         });
       });
     });
@@ -227,6 +228,7 @@ describe('AssetsController', () => {
             name: secondAsset.name,
             owner: secondAsset.owner,
             supply: secondAsset.supply.toString(),
+            verified_at: null,
           },
           {
             object: 'asset',
@@ -238,6 +240,7 @@ describe('AssetsController', () => {
             name: asset.name,
             owner: asset.owner,
             supply: asset.supply.toString(),
+            verified_at: null,
           },
         ],
         metadata: {

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -61,6 +61,7 @@ export class AssetsController {
       name: asset.name,
       owner: asset.owner,
       supply: asset.supply.toString(),
+      verified_at: asset.verified_at?.toISOString() ?? null,
     };
   }
 
@@ -102,6 +103,7 @@ export class AssetsController {
         name: asset.name,
         owner: asset.owner,
         supply: asset.supply.toString(),
+        verified_at: asset.verified_at?.toISOString() ?? null,
       });
     }
 

--- a/src/assets/interfaces/serialized-asset.ts
+++ b/src/assets/interfaces/serialized-asset.ts
@@ -11,4 +11,5 @@ export interface SerializedAsset {
   name: string;
   owner: string;
   supply: string;
+  verified_at: string | null;
 }


### PR DESCRIPTION
## Summary
Adds verified asset flag to `Asset` model, also returns `verified` data in serialized model.

Plan to run:
```
INSERT INTO assets (name, owner, identifier, metadata, supply, created_transaction_id, verified_at) VALUES ('$IRON', '0000000000000000000000000000000000000000000000000000000000000000', '51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c', 'Iron Fish Native Asset', 0, 56003467, '2023-04-20 09:00:00 PST');
```


Open questions:
1. What should we put for owner?
2. Should we insert a row for `AssetDescriptions`?
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
