### PR TITLE
Filter out block_assembled telemetry

### DIFF
--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -79,7 +79,6 @@ const TELEMETRY_WHITELIST = new Map<string, true | Array<string>>([
     ],
   ],
   ['transaction_propagation', true],
-  ['block_assembled', true],
   ['forks_count', true],
   ['fee_rate_estimate', true],
 ]);


### PR DESCRIPTION
## Summary
Filtering out `block_assembled ` since it isn't needed at the moment

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
