### PR TITLE
Add transaction expiration field

### DIFF
--- a/prisma/migrations/20230526002547_add_expiration_and_serialized_to_transaction/migration.sql
+++ b/prisma/migrations/20230526002547_add_expiration_and_serialized_to_transaction/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "transactions" ADD COLUMN     "expiration" INTEGER,
+ADD COLUMN     "serialized" TEXT;

--- a/prisma/migrations/20230526002547_add_expiration_and_serialized_to_transaction/migration.sql
+++ b/prisma/migrations/20230526002547_add_expiration_and_serialized_to_transaction/migration.sql
@@ -1,3 +1,0 @@
--- AlterTable
-ALTER TABLE "transactions" ADD COLUMN     "expiration" INTEGER,
-ADD COLUMN     "serialized" TEXT;

--- a/prisma/migrations/20230526195600_add_expiration_sequence_to_transaction/migration.sql
+++ b/prisma/migrations/20230526195600_add_expiration_sequence_to_transaction/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "transactions" ADD COLUMN     "expiration" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,10 +39,12 @@ model Transaction {
   updated_at          DateTime           @default(now()) @updatedAt @db.Timestamp(6)
   hash                String             @db.VarChar
   fee                 Float
+  expiration          Int?
   size                Int
   notes               Json
   spends              Json
   network_version     Int
+  serialized          String?
   asset_descriptions  AssetDescription[]
   created_assets      Asset[]
   blocks_transactions BlockTransaction[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,7 +44,6 @@ model Transaction {
   notes               Json
   spends              Json
   network_version     Int
-  serialized          String?
   asset_descriptions  AssetDescription[]
   created_assets      Asset[]
   blocks_transactions BlockTransaction[]

--- a/src/transactions/dto/upsert-transactions.dto.ts
+++ b/src/transactions/dto/upsert-transactions.dto.ts
@@ -53,10 +53,6 @@ export class TransactionDto {
   @IsArray()
   @ValidateNested({ each: true })
   readonly burns!: BurnDto[];
-
-  @IsString()
-  @IsOptional()
-  readonly serialized?: string;
 }
 
 export class UpsertTransactionsDto {

--- a/src/transactions/dto/upsert-transactions.dto.ts
+++ b/src/transactions/dto/upsert-transactions.dto.ts
@@ -8,6 +8,7 @@ import {
   ArrayMinSize,
   IsArray,
   IsInt,
+  IsOptional,
   IsString,
   Max,
   ValidateNested,
@@ -31,6 +32,12 @@ export class TransactionDto {
   @Type(() => Number)
   readonly size!: number;
 
+  @Max(Number.MAX_SAFE_INTEGER)
+  @IsInt()
+  @Type(() => Number)
+  @IsOptional()
+  readonly expiration?: number;
+
   @IsArray()
   @ValidateNested({ each: true })
   readonly notes!: NoteDto[];
@@ -46,6 +53,10 @@ export class TransactionDto {
   @IsArray()
   @ValidateNested({ each: true })
   readonly burns!: BurnDto[];
+
+  @IsString()
+  @IsOptional()
+  readonly serialized?: string;
 }
 
 export class UpsertTransactionsDto {

--- a/src/transactions/interfaces/serialized-transaction.ts
+++ b/src/transactions/interfaces/serialized-transaction.ts
@@ -8,6 +8,7 @@ export interface SerializedTransaction {
   id: number;
   hash: string;
   fee: string;
+  expiration?: number;
   size: number;
   notes: JsonValue;
   spends: JsonValue;

--- a/src/transactions/interfaces/upsert-transaction-options.ts
+++ b/src/transactions/interfaces/upsert-transaction-options.ts
@@ -8,7 +8,6 @@ export interface UpsertTransactionOptions {
   size: number;
   notes: Note[];
   spends: Spend[];
-  serialized?: string;
 }
 
 interface Note {

--- a/src/transactions/interfaces/upsert-transaction-options.ts
+++ b/src/transactions/interfaces/upsert-transaction-options.ts
@@ -4,9 +4,11 @@
 export interface UpsertTransactionOptions {
   hash: string;
   fee: number;
+  expiration?: number;
   size: number;
   notes: Note[];
   spends: Spend[];
+  serialized?: string;
 }
 
 interface Note {

--- a/src/transactions/transactions.controller.spec.ts
+++ b/src/transactions/transactions.controller.spec.ts
@@ -394,20 +394,24 @@ describe('TransactionsController', () => {
         hash: uuid(),
         fee: faker.datatype.number(),
         size: faker.datatype.number(),
+        expiration: faker.datatype.number(),
         notes: [{ commitment: uuid() }],
         spends: [{ nullifier: uuid() }],
         mints: [],
         burns: [],
+        serialized: faker.datatype.string(),
       };
 
       const transaction2 = {
         hash: uuid(),
         fee: faker.datatype.number(),
+        expiration: faker.datatype.number(),
         size: faker.datatype.number(),
         notes: [{ commitment: uuid() }],
         spends: [{ nullifier: uuid() }],
         mints: [],
         burns: [],
+        serialized: faker.datatype.string(),
       };
 
       const API_KEY = 'test';
@@ -425,6 +429,7 @@ describe('TransactionsController', () => {
       expect(body1.notes).toStrictEqual(transaction1.notes);
       expect(body1.spends).toStrictEqual(transaction1.spends);
       expect(body1.hash).toStrictEqual(transaction1.hash);
+      expect(body1.expiration).toStrictEqual(transaction1.expiration);
 
       const { body: body2 } = await request(app.getHttpServer())
         .get('/transactions/find')
@@ -434,6 +439,54 @@ describe('TransactionsController', () => {
       expect(body2.notes).toStrictEqual(transaction2.notes);
       expect(body2.spends).toStrictEqual(transaction2.spends);
       expect(body2.hash).toStrictEqual(transaction2.hash);
+      expect(body2.expiration).toStrictEqual(transaction2.expiration);
     });
+  });
+
+  it('uploads bulk transactions without expiration or serialized', async () => {
+    const transaction1 = {
+      hash: uuid(),
+      fee: faker.datatype.number(),
+      size: faker.datatype.number(),
+      notes: [{ commitment: uuid() }],
+      spends: [{ nullifier: uuid() }],
+      mints: [],
+      burns: [],
+    };
+
+    const transaction2 = {
+      hash: uuid(),
+      fee: faker.datatype.number(),
+      size: faker.datatype.number(),
+      notes: [{ commitment: uuid() }],
+      spends: [{ nullifier: uuid() }],
+      mints: [],
+      burns: [],
+    };
+
+    const API_KEY = 'test';
+    await request(app.getHttpServer())
+      .post('/transactions')
+      .set('Authorization', `Bearer ${API_KEY}`)
+      .send({ transactions: [transaction1, transaction2] })
+      .expect(HttpStatus.CREATED);
+
+    const { body: body1 } = await request(app.getHttpServer())
+      .get('/transactions/find')
+      .query({ hash: transaction1.hash })
+      .expect(HttpStatus.OK);
+
+    expect(body1.notes).toStrictEqual(transaction1.notes);
+    expect(body1.spends).toStrictEqual(transaction1.spends);
+    expect(body1.hash).toStrictEqual(transaction1.hash);
+
+    const { body: body2 } = await request(app.getHttpServer())
+      .get('/transactions/find')
+      .query({ hash: transaction2.hash })
+      .expect(HttpStatus.OK);
+
+    expect(body2.notes).toStrictEqual(transaction2.notes);
+    expect(body2.spends).toStrictEqual(transaction2.spends);
+    expect(body2.hash).toStrictEqual(transaction2.hash);
   });
 });

--- a/src/transactions/transactions.controller.spec.ts
+++ b/src/transactions/transactions.controller.spec.ts
@@ -399,7 +399,6 @@ describe('TransactionsController', () => {
         spends: [{ nullifier: uuid() }],
         mints: [],
         burns: [],
-        serialized: faker.datatype.string(),
       };
 
       const transaction2 = {
@@ -411,7 +410,6 @@ describe('TransactionsController', () => {
         spends: [{ nullifier: uuid() }],
         mints: [],
         burns: [],
-        serialized: faker.datatype.string(),
       };
 
       const API_KEY = 'test';

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -39,7 +39,6 @@ export class TransactionsService {
         size: tx.size,
         notes: classToPlain(tx.notes),
         spends: classToPlain(tx.spends),
-        serialized: tx.serialized,
       })),
       skipDuplicates: true,
     });

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -35,9 +35,11 @@ export class TransactionsService {
         hash: standardizeHash(tx.hash),
         network_version: networkVersion,
         fee: tx.fee,
+        expiration: tx.expiration,
         size: tx.size,
         notes: classToPlain(tx.notes),
         spends: classToPlain(tx.spends),
+        serialized: tx.serialized,
       })),
       skipDuplicates: true,
     });

--- a/src/transactions/utils/transaction-translator.ts
+++ b/src/transactions/utils/transaction-translator.ts
@@ -26,6 +26,7 @@ export function serializedTransactionFromRecord(
     id: transaction.id,
     hash: transaction.hash,
     fee: transaction.fee.toString(),
+    ...(transaction.expiration ? { expiration: transaction.expiration } : {}),
     size: transaction.size,
     notes: transaction.notes,
     spends: transaction.spends,


### PR DESCRIPTION
## Summary
Adding an optional `expiration` field and `serialized` field to transaction model. We're planning on syncing pending transaction (not on blocks) to the explorer. With this we will want to know if the transaction is expired or not. We may also need the full transaction data at some point in the future either for decryption or other purposes. Since the transaction is not on a block if we don't sync that data and it never makes it into a block then the full data will be forever lost.

## Testing Plan
Ran unit tests. Planning on testing on testnet api + network before full deploy to mainnet

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
