### PR TITLE
feat(api): Return supply properly in response body

### DIFF
--- a/src/supply/supply.controller.spec.ts
+++ b/src/supply/supply.controller.spec.ts
@@ -42,7 +42,7 @@ describe('SupplyController', () => {
       };
       await blocksService.upsert(prisma, options);
 
-      const { text } = await request(app.getHttpServer())
+      const { body } = await request(app.getHttpServer())
         .get('/supply/circulating')
         .expect(HttpStatus.OK);
 
@@ -51,7 +51,7 @@ describe('SupplyController', () => {
         head.sequence,
       );
 
-      expect(text).toBe(circulating.toString());
+      expect(body).toBe(circulating);
     });
   });
 
@@ -71,7 +71,7 @@ describe('SupplyController', () => {
       };
       await blocksService.upsert(prisma, options);
 
-      const { text } = await request(app.getHttpServer())
+      const { body } = await request(app.getHttpServer())
         .get('/supply/total')
         .expect(HttpStatus.OK);
 
@@ -80,7 +80,7 @@ describe('SupplyController', () => {
         head.sequence,
       );
 
-      expect(text).toBe(total.toString());
+      expect(body).toBe(total);
     });
   });
 });

--- a/src/supply/supply.controller.ts
+++ b/src/supply/supply.controller.ts
@@ -4,8 +4,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Res } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
 import { BlocksService } from '../blocks/blocks.service';
 
 @ApiTags('Supply')
@@ -15,21 +16,21 @@ export class SupplyController {
 
   @ApiOperation({ summary: 'Gets the circulating supply of the chain' })
   @Get('circulating')
-  async circulating(): Promise<number> {
+  async circulating(@Res() res: Response): Promise<void> {
     const head = await this.blocksService.head();
     const { circulating } = this.blocksService.totalAndCirculatingSupplies(
       head.sequence,
     );
-    return circulating;
+    res.json(circulating);
   }
 
   @ApiOperation({ summary: 'Gets the total supply of the chain' })
   @Get('total')
-  async total(): Promise<number> {
+  async total(@Res() res: Response): Promise<void> {
     const head = await this.blocksService.head();
     const { total } = this.blocksService.totalAndCirculatingSupplies(
       head.sequence,
     );
-    return total;
+    res.json(total);
   }
 }


### PR DESCRIPTION
## Summary

Seems like NestJS default sets this to the text in the response. Use the body.

## Testing Plan

Unit test.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
