### PR TITLE
Remove the last reference to `INCENTIVIZED_TESTNET_URL`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,10 +38,7 @@ async function bootstrap(): Promise<void> {
   const config = app.get(ApiConfigService);
   const logger = app.get(LoggerService);
 
-  const defaultOrigins = [
-    config.get<string>('BLOCK_EXPLORER_URL'),
-    config.get<string>('INCENTIVIZED_TESTNET_URL'),
-  ];
+  const defaultOrigins = [config.get<string>('BLOCK_EXPLORER_URL')];
   const enabledOrigins = config.isStaging()
     ? [
         ...defaultOrigins,


### PR DESCRIPTION
## Summary

`INCENTIVIZED_TESTNET_URL` is not used but it's referenced in `main.js`, which means that by blindly following the instructions in the README, the server won't start.

## Testing Plan

- `yarn start:dev` and verify that the server starts and works correctly
- `yarn test`

## Breaking Change

Not a breaking change