### PR TITLE
Improve tests for the `/assets` endpoint

### DIFF
--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -36,6 +36,10 @@ describe('AssetsController', () => {
     await app.close();
   });
 
+  beforeEach(async () => {
+    await prisma.asset.deleteMany({});
+  });
+
   async function createRandomAsset(): Promise<{
     block: Block;
     transaction: Transaction;
@@ -167,7 +171,6 @@ describe('AssetsController', () => {
 
       const { body } = await request(app.getHttpServer())
         .get('/assets')
-        .query({ limit: 2 })
         .expect(HttpStatus.OK);
 
       expect(body).toMatchObject({
@@ -199,7 +202,7 @@ describe('AssetsController', () => {
           },
         ],
         metadata: {
-          has_next: true,
+          has_next: false,
           has_previous: false,
         },
       });


### PR DESCRIPTION
## Summary

This improves the tests for the `/assets` endpoint in the following ways:
* Removes some code duplication. This will be particularly helpful as I'm adding more tests in https://github.com/iron-fish/ironfish-api/pull/1538.
* Improves test isolation by partially cleaning up the database before running each test, so that the assets created by one test case do not affect other test cases.

## Testing Plan

```
yarn test
```

## Breaking Change

Not a breaking change.