### PR TITLE
Add `Cache-Control` to `/assets`

### DIFF
--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -4,6 +4,7 @@
 import {
   Controller,
   Get,
+  Header,
   HttpStatus,
   NotFoundException,
   Query,
@@ -67,6 +68,7 @@ export class AssetsController {
 
   @ApiOperation({ summary: 'Lists assets' })
   @Get()
+  @Header('Cache-Control', 's-maxage=60, stale-if-error=60')
   async list(
     @Query(
       new ValidationPipe({


### PR DESCRIPTION
## Summary

Responses to the `/assets` endpoint now include the following HTTP header:

    Cache-Control: s-maxage=60, stale-if-error=60

which tells shared caches (e.g. Cloudflare) to do the following:

- `s-maxage=60`: serve responses from the cache for a maximum of 60 seconds;
- `stale-if-errors=60`: if the API server is unavailable, serve stale responses from the cache for 60 more seconds before returning errors to clients.

This change should not affect client caches (e.g. web browser caches).

## Testing Plan

```
$ curl -sv http://localhost:8003/assets
*   Trying 127.0.0.1:8003...
* Connected to localhost (127.0.0.1) port 8003 (#0)
> GET /assets HTTP/1.1
...
< HTTP/1.1 200 OK
...
< Cache-Control: s-maxage=60, stale-if-error=60
...
```

## Breaking Change

Not a breaking change.