### PR TITLE
Add support for the `verified` parameter to the `/assets` endpoint

### DIFF
--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -103,13 +103,20 @@ export class AssetsService {
     const orderBy = { id: SortOrder.DESC };
     const skip = cursor ? 1 : 0;
 
-    let where: Prisma.AssetWhereInput = {};
+    const where: Prisma.AssetWhereInput = {};
     if (options.search) {
-      where = {
-        name: {
-          contains: options.search,
-        },
+      where.name = {
+        contains: options.search,
       };
+    }
+    if (options.verified !== undefined) {
+      if (options.verified) {
+        where.verified_at = {
+          not: null,
+        };
+      } else {
+        where.verified_at = null;
+      }
     }
 
     const data = await this.prisma.readClient.asset.findMany({

--- a/src/assets/dto/assets-query.dto.ts
+++ b/src/assets/dto/assets-query.dto.ts
@@ -1,13 +1,21 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, TransformFnParams } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 import { PaginationArgsDto } from '../../common/dto/pagination-args.dto';
+import { stringToBoolean } from '../../common/utils/boolean';
 
 export class AssetsQueryDto extends PaginationArgsDto {
   @ApiPropertyOptional({ description: 'Keyword search filter' })
   @IsOptional()
   @IsString()
   readonly search?: string;
+
+  @ApiProperty({ description: 'Return only verified or unverified assets' })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }: TransformFnParams) => stringToBoolean(value))
+  readonly verified?: boolean;
 }

--- a/src/assets/interfaces/list-assets-optionts.ts
+++ b/src/assets/interfaces/list-assets-optionts.ts
@@ -5,4 +5,5 @@ import { PaginationOptions } from '../../common/interfaces/pagination-options';
 
 export interface ListAssetsOptions extends PaginationOptions {
   search?: string;
+  verified?: boolean;
 }


### PR DESCRIPTION
## Summary

The new boolean `verified` parameter can be used to get only verified assets, or only unverified assets.

Example usage:

```
curl https://api.ironfish.network/assets                 # returns both verified and unverified assets
curl https://api.ironfish.network/assets?verified=true   # only verified assets
curl https://api.ironfish.network/assets?verified=false  # only unverified assets
```

## Testing Plan

```
$ curl http://localhost:8003/assets | jq
{
  "object": "list",
  "data": [
    {
      "object": "asset",
      ...
      "verified_at": null
    },
    {
      "object": "asset",
      ...
      "verified_at": null
    },
    {
      "object": "asset",
      ...
      "verified_at": null
    },
    {
      "object": "asset",
      ...
      "verified_at": "2023-06-16T23:43:14.138Z"
    }
  ],
  "metadata": {
    "has_next": false,
    "has_previous": false
  }
}
```

```
$ curl http://localhost:8003/assets?verified=true | jq
{
  "object": "list",
  "data": [
    {
      "object": "asset",
      ...
      "verified_at": "2023-06-16T23:43:14.138Z"
    }
  ],
  "metadata": {
    "has_next": false,
    "has_previous": false
  }
}
```

```
$ curl http://localhost:8003/assets?verified=false | jq
{
  "object": "list",
  "data": [
    {
      "object": "asset",
      ...
      "verified_at": null
    },
    {
      "object": "asset",
      ...
      "verified_at": null
    },
    {
      "object": "asset",
      ...
      "verified_at": null
    }
  ],
  "metadata": {
    "has_next": false,
    "has_previous": false
  }
}
```

## Breaking Change

Not a breaking change.