### PR TITLE
Add support for `If-Modified-Since` to `/assets`

### DIFF
--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -175,4 +175,13 @@ export class AssetsService {
       },
     });
   }
+
+  async lastUpdate(): Promise<Date | null> {
+    const aggregations = await this.prisma.asset.aggregate({
+      _max: {
+        updated_at: true,
+      },
+    });
+    return aggregations._max.updated_at;
+  }
 }

--- a/src/common/utils/request.ts
+++ b/src/common/utils/request.ts
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Request } from 'express';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Request, Response } from 'express';
 
 export function fetchIpAddressFromRequest(request: Request): string {
   const xForwardedFor = request.header('X-Forwarded-For');
@@ -15,4 +16,24 @@ export function fetchIpAddressFromRequest(request: Request): string {
   // In Heroku, `X-Forwarded-For` will always be set. However, this will be used
   // as a fallback in local development.
   return request.ip;
+}
+
+export function handleIfModifiedSince(
+  lastModified: Date,
+  request: Request,
+  response: Response,
+): void {
+  response.header('Last-Modified', lastModified.toUTCString());
+  const ifModifiedSinceHeader = request.header('If-Modified-Since');
+  if (ifModifiedSinceHeader) {
+    const ifModifiedSince = new Date(ifModifiedSinceHeader);
+    if (ifModifiedSince >= lastModified) {
+      throw new HttpException(
+        {
+          status: HttpStatus.NOT_MODIFIED,
+        },
+        HttpStatus.NOT_MODIFIED,
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

`/assets` now sets the `Last-Modified` header is all responses. If a request has a valid `If-Modified-Since` header, the endpoint may respond with a 304 (Not Modified) response.

## Testing Plan

*   Requesting `/assets` without `If-Modified-Since`:
    ```
    $ curl -sv http://localhost:8003/assets
    *   Trying 127.0.0.1:8003...
    * Connected to localhost (127.0.0.1) port 8003 (#0)
    > GET /assets HTTP/1.1
    > ...
    >
    < HTTP/1.1 200 OK
    < Last-Modified: Wed, 21 Jun 2023 17:58:10 GMT
    < ...
    <
    {"object":"list","data":[...],"metadata":{"has_next":false,"has_previous":false}}
    ```

*   Requesting `/assets` with `If-Modified-Since` after the `Last-Modified` time:
    ```
    $ curl -sv -H 'If-Modified-Since: Wed, 21 Jun 2023 17:58:10 GMT' http://localhost:8003/assets
    *   Trying 127.0.0.1:8003...
    * Connected to localhost (127.0.0.1) port 8003 (#0)
    > GET /assets HTTP/1.1
    > If-Modified-Since: Wed, 21 Jun 2023 17:58:10 GMT
    > ...
    >
    < HTTP/1.1 304 Not Modified
    < Last-Modified: Wed, 21 Jun 2023 17:58:10 GMT
    < ...
    <
    ```

*   Requesting `/assets` with `If-Modified-Since` before the `Last-Modified` time:
    ```
    $ curl -sv -H 'If-Modified-Since: Wed, 21 Jun 2023 17:58:09 GMT' http://localhost:8003/assets
    *   Trying 127.0.0.1:8003...
    * Connected to localhost (127.0.0.1) port 8003 (#0)
    > GET /assets HTTP/1.1
    > If-Modified-Since: Wed, 21 Jun 2023 17:58:09 GMT
    > ...
    >
    < HTTP/1.1 200 OK
    < Last-Modified: Wed, 21 Jun 2023 17:58:10 GMT
    < ...
    <
    {"object":"list","data":[...],"metadata":{"has_next":false,"has_previous":false}}
    ```


## Breaking Change

Not a breaking change