### PR TITLE
Set max-age in Cache-Control directive for `/assets`

### DIFF
--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -68,7 +68,7 @@ export class AssetsController {
 
   @ApiOperation({ summary: 'Lists assets' })
   @Get()
-  @Header('Cache-Control', 's-maxage=60, stale-if-error=60')
+  @Header('Cache-Control', 'max-age=60, s-maxage=60, stale-if-error=60')
   async list(
     @Query(
       new ValidationPipe({


### PR DESCRIPTION
## Summary

This will make Cloudflare cache `/assets` by default, without using any custom page rule.

As stated in the [documentation](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/), Cloudflare requires `max-age` in order to trigger the default cache behavior. The alternative is to enable caching using custom page rules, which I've tried (they work) but that would be harder to maintain.

One advantage of this is that web browsers can now cache responses for 1 minute, which may result in a better user experience. The downside is that propagation delays increase by 1 minute (going from ~1 minute to ~2 minutes).

## Testing Plan

Local testing:

```
$ curl -sv http://localhost:8003/assets
...
< HTTP/1.1 200 OK
...
< Cache-Control: s-maxage=60, stale-if-error=60
...
```

Once deployed, we should start seeing the `cf-cache-status` header changing from `DYNAMIC` to `HIT`/`MISS`.

## Breaking Change

Not a breaking change