### PR TITLE
Set public in Cache-Control directive for `/assets`

### DIFF
--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -71,7 +71,7 @@ export class AssetsController {
 
   @ApiOperation({ summary: 'Lists assets' })
   @Get()
-  @Header('Cache-Control', 'max-age=60, s-maxage=60, stale-if-error=60')
+  @Header('Cache-Control', 'public, max-age=60, s-maxage=60, stale-if-error=60')
   async list(
     @Query(
       new ValidationPipe({


### PR DESCRIPTION
## Summary

After [changing `Cache-Control` to include `max-age`](https://github.com/iron-fish/ironfish-api/pull/1552), Cloudflare is still returning responses with `cf-cache-status: DYNAMIC`, meaning that caching is not working.

The [Cloudflare documentation](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/) states that both `public` and `max-age` are required in order to enable the default cache behavior.

[`public` should be implied if there is no `Authorization` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control), which is why the previous pull request did not include `public`. However, given that the current Cache-Control is not having the desired behavior, it seems that Cloudflare seems to require the explicit presence of `public` in order to enable the default cache behavior.

**Note:** if this endpoint is ever going to return results that depend on authentication, then this change is potentially insecure.

## Testing Plan

```
curl -sv https://testnet.api.ironfish.network/assets |& grep -w -e cache -e modified
```

should return:

```
< cache-control: public, max-age=60, s-maxage=60, stale-if-error=60
< last-modified: Mon, 26 Jun 2023 18:21:02 GMT
< cf-cache-status: MISS|HIT
```

It should NOT return `cf-cache-status: DYNAMIC`.

## Breaking Change

Not a breaking change.