### PR TITLE
whitelists chain_reorg metric in telemetry

### DIFF
--- a/src/telemetry/telemetry.controller.ts
+++ b/src/telemetry/telemetry.controller.ts
@@ -82,6 +82,7 @@ const TELEMETRY_WHITELIST = new Map<string, true | Array<string>>([
   ['forks_count', true],
   ['chain_db', true],
   ['fee_rate_estimate', true],
+  ['chain_reorg', true],
 ]);
 
 @Controller('telemetry')


### PR DESCRIPTION
## Summary

adds metric useful for monitoring forks, reorgs

see https://github.com/iron-fish/ironfish/pull/3990

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
