### PR TITLE
Revert `public` and `max-age` directives for `/assets`

### DIFF
--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -71,7 +71,7 @@ export class AssetsController {
 
   @ApiOperation({ summary: 'Lists assets' })
   @Get()
-  @Header('Cache-Control', 'public, max-age=60, s-maxage=60, stale-if-error=60')
+  @Header('Cache-Control', 's-maxage=60, stale-if-error=60')
   async list(
     @Query(
       new ValidationPipe({


### PR DESCRIPTION
## Summary

These directives did not have the intended behavior of enabling Cloudflare's cache behavior, hence reverting.

The reason why the directives did not have the intended behavior is that Cloudflare enables the default cache behavior [only for certain file extensions](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/#default-cached-file-extensions). Therefore, we *must* use page rules to enable the cache behavior, there's no other way.

Reverting these directives is not necessary, but `max-age` has an effect on end-user's browsers, and it would increase propagation delays for them.

This reverts commits:
- 412c65e4d8e48bcd331b9ac04856d7a813f9a01a
- 0916f3afa28a92e71dee949c458d6a64323284ed

## Testing Plan

```
curl -v http://localhost:8003/assets |& grep -i cache-control
```

## Breaking Change

Not a breaking change.