### PR TITLE
sorting latest by created at

### DIFF
--- a/src/versions/versions.service.spec.ts
+++ b/src/versions/versions.service.spec.ts
@@ -48,8 +48,8 @@ describe('VersionsService', () => {
 
     describe('with multiple records', () => {
       it('returns the latest version', async () => {
-        const latestVersion = await versionsService.create('0.1.21');
-        await versionsService.create('0.1.20');
+        await versionsService.create('0.1.21');
+        const latestVersion = await versionsService.create('0.1.20');
 
         const version = await versionsService.getLatest();
         expect(version).toMatchObject(latestVersion);

--- a/src/versions/versions.service.ts
+++ b/src/versions/versions.service.ts
@@ -21,6 +21,12 @@ export class VersionsService {
     });
   }
 
+  /**
+   * We don't order by version because when comparing 1.9.0 to 1.10.0, 1.9.0 is greater than 1.10.0.
+   * Instead, we order by created_at, which is a timestamp.
+   *
+   * @returns The latest version, or null if there are no versions
+   */
   async getLatest(): Promise<Version | null> {
     return this.prisma.version.findFirst({
       orderBy: {

--- a/src/versions/versions.service.ts
+++ b/src/versions/versions.service.ts
@@ -23,7 +23,8 @@ export class VersionsService {
 
   /**
    * We don't order by version because when comparing 1.9.0 to 1.10.0, 1.9.0 is greater than 1.10.0.
-   * Instead, we order by created_at, which is a timestamp.
+   * Instead, we order by created_at, which is a timestamp. The assumption is that the latest version
+   * will always be the latest created.
    *
    * @returns The latest version, or null if there are no versions
    */

--- a/src/versions/versions.service.ts
+++ b/src/versions/versions.service.ts
@@ -24,7 +24,7 @@ export class VersionsService {
   async getLatest(): Promise<Version | null> {
     return this.prisma.version.findFirst({
       orderBy: {
-        version: 'desc',
+        created_at: 'desc',
       },
     });
   }


### PR DESCRIPTION
## Summary

The previous version didn't work when comparing v1.9.0 vs v1.10.0

An alternative would be to get all versions and then order them by a custom function. I went with the easier route, but I'm happy to change it. 

1. Sorting version by createdAt date 
2. Updating tests to reflect the above change

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
