### PR TITLE
Add serialized transaction field and return in API

### DIFF
--- a/prisma/migrations/20231224185350_add_transaction_serialized/migration.sql
+++ b/prisma/migrations/20231224185350_add_transaction_serialized/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "transactions" ADD COLUMN     "serialized" VARCHAR;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Transaction {
   notes               Json
   spends              Json
   network_version     Int
+  serialized          String?            @db.VarChar
   asset_descriptions  AssetDescription[]
   created_assets      Asset[]
   blocks_transactions BlockTransaction[]

--- a/src/transactions/interfaces/serialized-transaction.ts
+++ b/src/transactions/interfaces/serialized-transaction.ts
@@ -12,6 +12,7 @@ export interface SerializedTransaction {
   size: number;
   notes: JsonValue;
   spends: JsonValue;
+  serialized: string | null;
   mints: SerializedAssetDescription[];
   burns: SerializedAssetDescription[];
   object: 'transaction';

--- a/src/transactions/transactions.controller.spec.ts
+++ b/src/transactions/transactions.controller.spec.ts
@@ -65,6 +65,8 @@ describe('TransactionsController', () => {
               size: faker.datatype.number(),
               notes,
               spends,
+              serialized:
+                'U3dh76O7TMnEb+KPrRghTyz4G3lHV/BWfogtW59oUSFKACk56Jl3eMY9Ky9c5uc2nBhePgCo0hIM+ednqYAjoA',
             },
           });
 
@@ -85,6 +87,7 @@ describe('TransactionsController', () => {
             hash: testTransactionHash,
             fee: expect.any(String),
             size: expect.any(Number),
+            serialized: transaction.serialized,
             notes,
             spends,
           });

--- a/src/transactions/utils/transaction-translator.ts
+++ b/src/transactions/utils/transaction-translator.ts
@@ -30,6 +30,7 @@ export function serializedTransactionFromRecord(
     size: transaction.size,
     notes: transaction.notes,
     spends: transaction.spends,
+    serialized: transaction.serialized,
     mints,
     burns,
     object: 'transaction',


### PR DESCRIPTION
## Summary

This adds a new field to Transaction called serialized which will contain the full base64 encoded transaction of the Ironfish SDK Transaction type. It also returns it in transactions/find API.

This is the followup PR. https://github.com/iron-fish/ironfish-api/pull/1693

## Testing Plan

Added test

## Breaking Change

**No**

Transactions will be sent back with null serialized in the case that it was not sent.
