### PR TITLE
Add uploading serialized transaction to syncer

### DIFF
--- a/src/blocks/blocks.controller.spec.ts
+++ b/src/blocks/blocks.controller.spec.ts
@@ -149,6 +149,16 @@ describe('BlocksController', () => {
                   mints: [],
                   burns: [],
                 },
+                {
+                  hash: uuid(),
+                  fee: faker.datatype.number(),
+                  size: faker.datatype.number(),
+                  notes: [{ commitment: uuid() }],
+                  spends: [{ nullifier: uuid() }],
+                  mints: [],
+                  burns: [],
+                  serialized: 'serialized',
+                },
               ],
             },
           ],
@@ -168,10 +178,14 @@ describe('BlocksController', () => {
           difficulty: block.difficulty,
           sequence: block.sequence,
           timestamp: block.timestamp.toISOString(),
-          transactions_count: 1,
+          transactions_count: 2,
           previous_block_hash: block.previous_block_hash,
           size: block.size,
         });
+
+        const serializedBlock = data[0] as SerializedBlockWithTransactions;
+        expect(serializedBlock.transactions[0].serialized).toBeNull();
+        expect(serializedBlock.transactions[1].serialized).toBe('serialized');
       });
     });
   });

--- a/src/transactions/dto/upsert-transactions.dto.ts
+++ b/src/transactions/dto/upsert-transactions.dto.ts
@@ -61,6 +61,10 @@ export class TransactionDto {
   @ValidateNested({ each: true })
   @Type(() => BurnDto)
   readonly burns!: BurnDto[];
+
+  @IsOptional()
+  @IsString()
+  readonly serialized?: string;
 }
 
 export class UpsertTransactionsDto {

--- a/src/transactions/interfaces/upsert-transaction-options.ts
+++ b/src/transactions/interfaces/upsert-transaction-options.ts
@@ -10,6 +10,7 @@ export interface UpsertTransactionOptions {
   size: number;
   notes: Note[];
   spends: Spend[];
+  serialized?: string;
 }
 
 interface Note {

--- a/src/transactions/transactions.controller.spec.ts
+++ b/src/transactions/transactions.controller.spec.ts
@@ -413,6 +413,7 @@ describe('TransactionsController', () => {
         spends: [{ nullifier: uuid() }],
         mints: [],
         burns: [],
+        serialized: 'serialized',
       };
 
       const API_KEY = 'test';
@@ -432,6 +433,7 @@ describe('TransactionsController', () => {
       expect(body1.spends).toStrictEqual(transaction1.spends);
       expect(body1.hash).toStrictEqual(transaction1.hash);
       expect(body1.expiration).toStrictEqual(transaction1.expiration);
+      expect(body1.serialized).toBeNull();
 
       const { body: body2 } = await request(app.getHttpServer())
         .get('/transactions/find')
@@ -443,6 +445,7 @@ describe('TransactionsController', () => {
       expect(body2.spends).toStrictEqual(transaction2.spends);
       expect(body2.hash).toStrictEqual(transaction2.hash);
       expect(body2.expiration).toStrictEqual(transaction2.expiration);
+      expect(body2.serialized).toBe('serialized');
     });
   });
 

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -40,7 +40,7 @@ export class TransactionsService {
         size: tx.size,
         notes: classToPlain(tx.notes),
         spends: classToPlain(tx.spends),
-        serialized: tx.serialized,
+        serialized: tx.serialized ?? null,
       })),
       skipDuplicates: true,
     });


### PR DESCRIPTION
## Summary

This allows the syncer services command to now upload the serialized transaction format to the API.

## Testing Plan

Added a test.

## Breaking Change

**No.**

The new field is optional.