### PR TITLE
Track first transaction seen sequence

### DIFF
--- a/prisma/migrations/20240111014427_add_transaction_seen_sequence/migration.sql
+++ b/prisma/migrations/20240111014427_add_transaction_seen_sequence/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "transactions" ADD COLUMN     "seen_sequence" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Transaction {
   hash                String             @db.VarChar
   fee                 Float
   expiration          Int?
+  seen_sequence       Int?
   size                Int
   notes               Json
   spends              Json

--- a/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.spec.ts
@@ -120,6 +120,7 @@ describe('BlocksTransactionsLoader', () => {
         size: transaction.size,
         notes: transaction.notes,
         spends: transaction.spends,
+        seen_sequence: blocks[0].sequence,
       });
 
       const blockTransaction = await blocksTransactionsService.find(

--- a/src/blocks-transactions-loader/blocks-transactions-loader.ts
+++ b/src/blocks-transactions-loader/blocks-transactions-loader.ts
@@ -71,12 +71,15 @@ export class BlocksTransactionsLoader {
             work: BigInt(block.work ?? 0),
           });
 
+          // attach the block sequence to each transaction
+          const create = block.transactions.map((transaction) => ({
+            ...transaction,
+            seen_sequence: block.sequence,
+          }));
+
           // Create new Transaction records
           const transactions =
-            await this.transactionsService.createManyWithClient(
-              prisma,
-              block.transactions,
-            );
+            await this.transactionsService.createManyWithClient(prisma, create);
 
           // Get the index of the each transaction in the block
           const indexedTransactions = block.transactions.map((dto, index) => {

--- a/src/transactions/interfaces/upsert-transaction-options.ts
+++ b/src/transactions/interfaces/upsert-transaction-options.ts
@@ -5,6 +5,7 @@ export interface UpsertTransactionOptions {
   hash: string;
   fee: number;
   expiration?: number;
+  seen_sequence?: number;
   size: number;
   notes: Note[];
   spends: Spend[];

--- a/src/transactions/transactions.rest.module.ts
+++ b/src/transactions/transactions.rest.module.ts
@@ -4,11 +4,17 @@
 import { Module } from '@nestjs/common';
 import { AssetDescriptionsModule } from '../asset-descriptions/asset-descriptions.module';
 import { AssetsModule } from '../assets/assets.module';
+import { BlocksModule } from '../blocks/blocks.module';
 import { TransactionsController } from './transactions.controller';
 import { TransactionsModule } from './transactions.module';
 
 @Module({
   controllers: [TransactionsController],
-  imports: [AssetDescriptionsModule, AssetsModule, TransactionsModule],
+  imports: [
+    AssetDescriptionsModule,
+    AssetsModule,
+    TransactionsModule,
+    BlocksModule,
+  ],
 })
 export class TransactionsRestModule {}

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -36,6 +36,7 @@ export class TransactionsService {
         network_version: networkVersion,
         fee: tx.fee,
         expiration: tx.expiration,
+        seen_sequence: tx.seen_sequence,
         size: tx.size,
         notes: classToPlain(tx.notes),
         spends: classToPlain(tx.spends),


### PR DESCRIPTION
## Summary

This will track the current sequence the transaction was first seen at. If we are uploading it in bulk, we use the chain head. If we are seeing it for the first time in the syncer then we use the current block the transaction added it on.

## Testing Plan

Added tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
