### PR TITLE
Add serialized TX to the DB

### DIFF
--- a/src/transactions/dto/upsert-transactions.dto.ts
+++ b/src/transactions/dto/upsert-transactions.dto.ts
@@ -22,6 +22,10 @@ export class TransactionDto {
   @IsString()
   readonly hash!: string;
 
+  @IsString()
+  @IsOptional()
+  readonly serialized?: string;
+
   @Max(Number.MAX_SAFE_INTEGER)
   @IsInt()
   @Type(() => Number)

--- a/src/transactions/interfaces/upsert-transaction-options.ts
+++ b/src/transactions/interfaces/upsert-transaction-options.ts
@@ -4,6 +4,7 @@
 export interface UpsertTransactionOptions {
   hash: string;
   fee: number;
+  serialized?: string;
   expiration?: number;
   seen_sequence?: number;
   size: number;

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -40,6 +40,7 @@ export class TransactionsService {
         size: tx.size,
         notes: classToPlain(tx.notes),
         spends: classToPlain(tx.spends),
+        serialized: tx.serialized,
       })),
       skipDuplicates: true,
     });


### PR DESCRIPTION
## Summary

This feeds the serialized field into the DB so it's persisted when the syncer sends it up.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
