### PR TITLE
Serialize Transaction.seen_sequence in transaction response

### DIFF
--- a/src/transactions/interfaces/serialized-transaction.ts
+++ b/src/transactions/interfaces/serialized-transaction.ts
@@ -9,6 +9,7 @@ export interface SerializedTransaction {
   hash: string;
   fee: string;
   expiration?: number;
+  seen_sequence: number | null;
   size: number;
   notes: JsonValue;
   spends: JsonValue;

--- a/src/transactions/transactions.controller.spec.ts
+++ b/src/transactions/transactions.controller.spec.ts
@@ -427,6 +427,7 @@ describe('TransactionsController', () => {
         .query({ hash: transaction1.hash })
         .expect(HttpStatus.OK);
 
+      expect(body1.seen_sequence).toEqual(expect.any(Number));
       expect(body1.notes).toStrictEqual(transaction1.notes);
       expect(body1.spends).toStrictEqual(transaction1.spends);
       expect(body1.hash).toStrictEqual(transaction1.hash);
@@ -437,6 +438,7 @@ describe('TransactionsController', () => {
         .query({ hash: transaction2.hash })
         .expect(HttpStatus.OK);
 
+      expect(body2.seen_sequence).toEqual(expect.any(Number));
       expect(body2.notes).toStrictEqual(transaction2.notes);
       expect(body2.spends).toStrictEqual(transaction2.spends);
       expect(body2.hash).toStrictEqual(transaction2.hash);

--- a/src/transactions/utils/transaction-translator.ts
+++ b/src/transactions/utils/transaction-translator.ts
@@ -27,6 +27,7 @@ export function serializedTransactionFromRecord(
     hash: transaction.hash,
     fee: transaction.fee.toString(),
     ...(transaction.expiration ? { expiration: transaction.expiration } : {}),
+    seen_sequence: transaction.seen_sequence,
     size: transaction.size,
     notes: transaction.notes,
     spends: transaction.spends,


### PR DESCRIPTION
## Summary

This serializes seen_sequence into the transaction response

## Testing Plan

Added a test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
