### PR TITLE
Add verified assets metadata

### DIFF
--- a/prisma/migrations/20240320231350_add_verified_asset_metadata/migration.sql
+++ b/prisma/migrations/20240320231350_add_verified_asset_metadata/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "VerifiedAssetMetadata" (
+    "identifier" TEXT NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "symbol" TEXT NOT NULL,
+    "decimals" INTEGER,
+    "logo_uri" TEXT,
+    "website" TEXT,
+
+    CONSTRAINT "VerifiedAssetMetadata_pkey" PRIMARY KEY ("identifier")
+);
+
+-- AddForeignKey
+ALTER TABLE "VerifiedAssetMetadata" ADD CONSTRAINT "VerifiedAssetMetadata_identifier_fkey" FOREIGN KEY ("identifier") REFERENCES "assets"("identifier") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,21 +116,33 @@ model Version {
 }
 
 model Asset {
-  id                     Int                @id @default(autoincrement())
-  created_at             DateTime           @default(now()) @db.Timestamp(6)
-  updated_at             DateTime           @default(now()) @updatedAt @db.Timestamp(6)
+  id                     Int                     @id @default(autoincrement())
+  created_at             DateTime                @default(now()) @db.Timestamp(6)
+  updated_at             DateTime                @default(now()) @updatedAt @db.Timestamp(6)
   created_transaction_id Int
-  identifier             String             @unique(map: "uq_assets_on_identifier")
+  identifier             String                  @unique(map: "uq_assets_on_identifier")
   metadata               String
   name                   String
   owner                  String
   supply                 BigInt
-  verified_at            DateTime?          @db.Timestamp(6)
+  verified_at            DateTime?               @db.Timestamp(6)
+  verified_metadata      VerifiedAssetMetadata?
   descriptions           AssetDescription[]
-  created_transaction    Transaction        @relation(fields: [created_transaction_id], references: [id])
+  created_transaction    Transaction             @relation(fields: [created_transaction_id], references: [id])
 
   @@index([created_transaction_id], map: "index_assets_on_created_transaction_id")
   @@map("assets")
+}
+
+model VerifiedAssetMetadata {
+  identifier     String             @id
+  created_at     DateTime           @default(now()) @db.Timestamp(6)
+  updated_at     DateTime           @default(now()) @updatedAt @db.Timestamp(6)
+  symbol         String
+  decimals       Int?
+  logo_uri       String?
+  website        String?
+  asset          Asset              @relation(fields: [identifier], references: [identifier], onDelete: Cascade)
 }
 
 model AssetDescription {

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -579,7 +579,7 @@ describe('AssetsController', () => {
       const { body } = await request(app.getHttpServer())
         .post('/assets/update-verified')
         .set('Authorization', `Bearer ${API_KEY}`)
-        .send({ version: 2, assets: verifiedMetadata });
+        .send({ schemaVersion: 2, assets: verifiedMetadata });
 
       expect(body).toMatchObject({ missing: [] });
 
@@ -613,7 +613,7 @@ describe('AssetsController', () => {
         .post('/assets/update-verified')
         .set('Authorization', `Bearer ${API_KEY}`)
         .send({
-          version: 2,
+          schemaVersion: 2,
           assets: [assetMetadata1],
         });
 
@@ -642,7 +642,7 @@ describe('AssetsController', () => {
       const { body: body2 } = await request(app.getHttpServer())
         .post('/assets/update-verified')
         .set('Authorization', `Bearer ${API_KEY}`)
-        .send({ version: 2, assets: [assetMetadata2] });
+        .send({ schemaVersion: 2, assets: [assetMetadata2] });
 
       expect(body2).toMatchObject({ missing: [] });
 
@@ -686,7 +686,7 @@ describe('AssetsController', () => {
       const { body } = await request(app.getHttpServer())
         .post('/assets/update-verified')
         .set('Authorization', `Bearer ${API_KEY}`)
-        .send({ version: 2, assets });
+        .send({ schemaVersion: 2, assets });
 
       expect(body).toMatchObject({
         missing: [assets[1]],
@@ -711,7 +711,7 @@ describe('AssetsController', () => {
       await request(app.getHttpServer())
         .post('/assets/update-verified')
         .set('Authorization', `Bearer ${API_KEY}`)
-        .send({ version: 2, assets: [metadata] });
+        .send({ schemaVersion: 2, assets: [metadata] });
 
       await expect(prisma.verifiedAssetMetadata.findMany({})).resolves.toEqual([
         {
@@ -728,7 +728,7 @@ describe('AssetsController', () => {
       await request(app.getHttpServer())
         .post('/assets/update-verified')
         .set('Authorization', `Bearer ${API_KEY}`)
-        .send({ version: 2, assets: [] });
+        .send({ schemaVersion: 2, assets: [] });
 
       await expect(prisma.verifiedAssetMetadata.findMany({})).resolves.toEqual(
         [],
@@ -744,7 +744,7 @@ describe('AssetsController', () => {
       await request(app.getHttpServer())
         .post('/assets/update-verified')
         .set('Authorization', `Bearer ${API_KEY}`)
-        .send({ version: 2, assets: [metadata] });
+        .send({ schemaVersion: 2, assets: [metadata] });
 
       await expect(
         prisma.verifiedAssetMetadata.findMany({}),

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -570,14 +570,14 @@ describe('AssetsController', () => {
   });
 
   describe('POST /assets/update_verified', () => {
-    it('Adds metadata for all assets that exist', async () => {
+    it('adds metadata for all assets that exist', async () => {
       const { metadata: metadata1 } = await createRandomAsset();
       const { metadata: metadata2 } = await createRandomAsset();
 
       const verifiedMetadata = [metadata1, metadata2];
 
       const { body } = await request(app.getHttpServer())
-        .post('/assets/update-verified')
+        .post('/assets/verified')
         .set('Authorization', `Bearer ${API_KEY}`)
         .send({ schemaVersion: 2, assets: verifiedMetadata });
 
@@ -598,7 +598,7 @@ describe('AssetsController', () => {
       }
     });
 
-    it('Updates metadata for assets that already have metadata', async () => {
+    it('updates metadata for assets that already have metadata', async () => {
       const { asset } = await createRandomAsset();
 
       const assetMetadata1 = {
@@ -610,7 +610,7 @@ describe('AssetsController', () => {
       };
 
       const { body: body1 } = await request(app.getHttpServer())
-        .post('/assets/update-verified')
+        .post('/assets/verified')
         .set('Authorization', `Bearer ${API_KEY}`)
         .send({
           schemaVersion: 2,
@@ -640,7 +640,7 @@ describe('AssetsController', () => {
       };
 
       const { body: body2 } = await request(app.getHttpServer())
-        .post('/assets/update-verified')
+        .post('/assets/verified')
         .set('Authorization', `Bearer ${API_KEY}`)
         .send({ schemaVersion: 2, assets: [assetMetadata2] });
 
@@ -659,7 +659,7 @@ describe('AssetsController', () => {
       ]);
     });
 
-    it('Only updates metadata for assets that exist and returns those not found', async () => {
+    it('only updates metadata for assets that exist and returns those not found', async () => {
       const {
         block: _block,
         transaction: _transaction,
@@ -684,7 +684,7 @@ describe('AssetsController', () => {
       ];
 
       const { body } = await request(app.getHttpServer())
-        .post('/assets/update-verified')
+        .post('/assets/verified')
         .set('Authorization', `Bearer ${API_KEY}`)
         .send({ schemaVersion: 2, assets });
 
@@ -705,11 +705,11 @@ describe('AssetsController', () => {
       ]);
     });
 
-    it('Deletes metadata items that are not in the list', async () => {
+    it('deletes metadata items that are not in the list', async () => {
       const { metadata, asset } = await createRandomAsset();
 
       await request(app.getHttpServer())
-        .post('/assets/update-verified')
+        .post('/assets/verified')
         .set('Authorization', `Bearer ${API_KEY}`)
         .send({ schemaVersion: 2, assets: [metadata] });
 
@@ -726,7 +726,7 @@ describe('AssetsController', () => {
       ]);
 
       await request(app.getHttpServer())
-        .post('/assets/update-verified')
+        .post('/assets/verified')
         .set('Authorization', `Bearer ${API_KEY}`)
         .send({ schemaVersion: 2, assets: [] });
 
@@ -738,11 +738,11 @@ describe('AssetsController', () => {
       await expect(prisma.asset.findMany({})).resolves.toEqual([asset]);
     });
 
-    it('Deletes metadata if the asset is deleted', async () => {
+    it('deletes metadata if the asset is deleted', async () => {
       const { metadata, asset } = await createRandomAsset();
 
       await request(app.getHttpServer())
-        .post('/assets/update-verified')
+        .post('/assets/verified')
         .set('Authorization', `Bearer ${API_KEY}`)
         .send({ schemaVersion: 2, assets: [metadata] });
 

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -725,6 +725,19 @@ describe('AssetsController', () => {
           .map((asset) => expectedDatabaseMetadata(asset))
           .sort(),
       );
+
+      // Both assets should still be in the database
+      await expect(
+        prisma.asset.findMany({
+          where: { identifier: asset1.identifier },
+        }),
+      ).resolves.toHaveLength(1);
+
+      await expect(
+        prisma.asset.findMany({
+          where: { identifier: asset2.identifier },
+        }),
+      ).resolves.toHaveLength(1);
     });
 
     it('deletes metadata if the asset is deleted', async () => {

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -152,9 +152,9 @@ export class AssetsController {
   }
 
   @ApiExcludeEndpoint()
-  @Post('update-verified')
+  @Post('verified')
   @UseGuards(ApiKeyGuard)
-  async update_verified(
+  async updateVerified(
     @Body(
       new ValidationPipe({
         errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,

--- a/src/assets/dto/update-verified-assets-dto.ts
+++ b/src/assets/dto/update-verified-assets-dto.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsDefined,
+  IsInt,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+
+export class UpdateVerifiedAssetsDto {
+  @ApiProperty({ description: 'Version of the verfied assets schema to use' })
+  @IsDefined()
+  @IsInt()
+  readonly version!: number;
+
+  @ApiProperty({ description: 'List of assets to update as verified' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => VerifiedAssetMetadataDto)
+  readonly assets!: VerifiedAssetMetadataDto[];
+}
+
+export class VerifiedAssetMetadataDto {
+  @IsString()
+  @IsDefined({
+    message: 'Cannot update verified asset without an identifier',
+  })
+  readonly identifier!: string;
+
+  @IsString()
+  @IsDefined()
+  readonly symbol!: string;
+
+  @IsInt()
+  @IsOptional()
+  readonly decimals?: number;
+
+  @IsString()
+  @IsOptional()
+  readonly logoURI?: string;
+
+  @IsString()
+  @IsOptional()
+  readonly website?: string;
+}

--- a/src/assets/dto/update-verified-assets-dto.ts
+++ b/src/assets/dto/update-verified-assets-dto.ts
@@ -16,7 +16,7 @@ export class UpdateVerifiedAssetsDto {
   @ApiProperty({ description: 'Version of the verfied assets schema to use' })
   @IsDefined()
   @IsInt()
-  readonly version!: number;
+  readonly schemaVersion!: number;
 
   @ApiProperty({ description: 'List of assets to update as verified' })
   @IsArray()


### PR DESCRIPTION
## Summary
Adding verified asset metadata with multiple fields to assets. Adding endpoint to sync verified assets from a external JSON list of verified assets

## Testing Plan
Unit tests and testing endpoints locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
