### PR TITLE
Upgrade from NodeJS 18 to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   INFLUXDB_API_TOKEN: test
   INFLUXDB_BUCKET: test
   INFLUXDB_ORG: Iron Fish
-  INFLUXDB_URL: http://localhost:8004 
+  INFLUXDB_URL: http://localhost:8004
   INCENTIVIZED_TESTNET_URL: http://localhost:3001
   IRONFISH_API_KEY: test
   IRONFISH_POSTGRES_CONTAINER: ironfish_postgres
@@ -31,10 +31,12 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
+
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18.13.0'
+          node-version: '20'
+
       - name: Restore Yarn cache
         id: yarn-cache
         uses: actions/cache@v2
@@ -43,11 +45,14 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install packages
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn --non-interactive --frozen-lockfile
+
       - name: Generate Prisma schema
         run: npx prisma generate
+
       - name: Lint
         run: yarn lint
 
@@ -57,10 +62,12 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
+
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18.13.0'
+          node-version: '20'
+
       - name: Restore Yarn cache
         id: yarn-cache
         uses: actions/cache@v2
@@ -69,20 +76,27 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install packages
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn --non-interactive --frozen-lockfile
+
       - name: Generate Prisma schema
         run: npx prisma generate
-      - name: Start Docker 
+
+      - name: Start Docker
         run: yarn docker:start
+
       - name: Wait for Postgres
         run: until docker exec $IRONFISH_POSTGRES_CONTAINER pg_isready; do sleep 5; done
+
       - name: Run migrations
         run: npx prisma migrate deploy
+
       - name: Run tests
         run: yarn test
         env:
           NODE_OPTIONS: --max_old_space_size=8192
+
       - name: Stop Docker
         run: yarn docker:stop

--- a/README.md
+++ b/README.md
@@ -4,40 +4,40 @@
 
 ## Installing
 
-* Make sure you're running at least Node 16 - you may want to avail yourself of a tool like [nvm](https://nvm.sh)
-* Run `yarn` to install dependencies
-* Run `yarn docker:start` to start docker
-* Run `yarn build` to build things locally
-* Run `yarn db:client:generate` to generate the Prisma client
-* Run `yarn db:migrate` to create a migration
-* (Optional) Run `yarn db:seed:testing` to load some sample data into the database
+- Make sure you're running at least Node 20 - you may want to avail yourself of a tool like [nvm](https://nvm.sh)
+- Run `yarn` to install dependencies
+- Run `yarn docker:start` to start docker
+- Run `yarn build` to build things locally
+- Run `yarn db:client:generate` to generate the Prisma client
+- Run `yarn db:migrate` to execute migrations and optionally create a migration if you have made schema changes
+- (Optional) Run `yarn db:seed:testing` to load some sample data into the database
 
 ## Environment
 
 You'll need a `.env` file with the following keys:
 
-* `API_URL`
-* `BLOCK_EXPLORER_URL`
-* `DATABASE_CONNECTION_POOL_URL`
-* `DATABASE_URL`
-* `DATADOG_URL`
-* `INFLUXDB_API_TOKEN`
-* `INFLUXDB_BUCKET`
-* `INFLUXDB_ORG`
-* `INFLUXDB_URL`
-* `IRONFISH_API_KEY`
-* `NETWORK_VERSION`
-* `NODE_ENV`
-* `WORKER_COUNT`
+- `API_URL`
+- `BLOCK_EXPLORER_URL`
+- `DATABASE_CONNECTION_POOL_URL`
+- `DATABASE_URL`
+- `DATADOG_URL`
+- `INFLUXDB_API_TOKEN`
+- `INFLUXDB_BUCKET`
+- `INFLUXDB_ORG`
+- `INFLUXDB_URL`
+- `IRONFISH_API_KEY`
+- `NETWORK_VERSION`
+- `NODE_ENV`
+- `WORKER_COUNT`
 
 You can copy `.env.template` to your own `.env` file
 
 ## Running
 
-* Run `yarn start:dev` to run the app with hot reload
-* If you prefer to run without hot reload, run `yarn build` to build the app and then `yarn start` to run it
+- Run `yarn start:dev` to run the app with hot reload
+- If you prefer to run without hot reload, run `yarn build` to build the app and then `yarn start` to run it
 
 ## Database
 
-* Run `yarn db:client:generate` to generate the Prisma client
-* Run `yarn db:migrate` to create a migration
+- Run `yarn db:client:generate` to generate the Prisma client
+- Run `yarn db:migrate` to create a migration

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MPL-2.0",
   "homepage": "https://github.com/iron-fish/ironfish-api",
   "engines": {
-    "node": "18.x"
+    "node": ">=20"
   },
   "keywords": [
     "api"

--- a/src/blocks/blocks.service.ts
+++ b/src/blocks/blocks.service.ts
@@ -378,7 +378,7 @@ export class BlocksService {
     }
 
     return {
-      averageBlockTimeMs: dateMetricsResponse[0].average_block_time_ms,
+      averageBlockTimeMs: Number(dateMetricsResponse[0].average_block_time_ms),
       averageDifficulty: dateMetricsResponse[0].average_difficulty,
       averageBlockSize: dateMetricsResponse[0].average_block_size,
       blocksCount: Number(dateMetricsResponse[0].blocks_count),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,7 +1639,8 @@ binary-extensions@^2.0.0:
 
 bindings@^1.5.0:
   version "1.5.0"
-  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
 
@@ -2627,7 +2628,8 @@ file-entry-cache@^6.0.1:
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
-  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -2864,7 +2866,8 @@ hexoid@^1.0.0:
 
 hot-shots@10.0.0:
   version "10.0.0"
-  resolved "https://registry.npmjs.org/hot-shots/-/hot-shots-10.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-10.0.0.tgz#d360f9dd252da78297aca1cb08fd84a8936739c2"
+  integrity sha512-uy/uGpuJk7yuyiKRfZMBNkF1GAOX5O2ifO9rDCaX9jw8fu6eW9QeWC7WRPDI+O98frW1HQgV3+xwjWsZPECIzQ==
   optionalDependencies:
     unix-dgram "2.x"
 
@@ -3951,8 +3954,9 @@ multer@1.4.4-lts.1:
     xtend "^4.0.0"
 
 nan@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz"
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
+  integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -5066,7 +5070,8 @@ universalify@^0.2.0:
 
 unix-dgram@2.x:
   version "2.0.6"
-  resolved "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.6.tgz"
+  resolved "https://registry.yarnpkg.com/unix-dgram/-/unix-dgram-2.0.6.tgz#6d567b0eb6d7a9504e561532b598a46e34c5968b"
+  integrity sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==
   dependencies:
     bindings "^1.5.0"
     nan "^2.16.0"


### PR DESCRIPTION
## Summary

- Changed package.json to use >=20 for NodeJS version so hopefully it will be easier to use 22+ down the line
- Upgraded the Github Actions to use NodeJS 20
- Ran `yarn upgrade hot-shot` to upgrade a sub-dependency that was failing
- Modified a test to cast to a number. I'm not exactly sure why this started failing now, but it is more correct now, technically.

## Testing Plan

Unit tests locally
Unit tests on github
Deploy to testnet

## Breaking Change

Only for development if anyone was still using NodeJS 18, so no not really.