### PR TITLE
Hardcode native asset in old verified endpoint

### DIFF
--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -193,18 +193,6 @@ export class AssetsService {
     };
   }
 
-  listVerifiedIdentifiers(): Promise<Partial<Asset>[]> {
-    return this.prisma.readClient.asset.findMany({
-      select: { identifier: true },
-      where: {
-        verified_metadata: {
-          isNot: null,
-        },
-      },
-      orderBy: { id: SortOrder.ASC },
-    });
-  }
-
   listMetadata(): Promise<VerifiedAssetMetadata[]> {
     const orderBy = { created_at: SortOrder.ASC };
 


### PR DESCRIPTION
## Summary
The `assets/verified` endpoint is used by old nodes. The only currently verified asset is IRON. Newly verified assets should not be returned from this old endpoint because they  may include decimal fields. Marking an asset as verified without returning its decimal field could confuse users into sending incorrect amounts of an asset.
 
## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
