### PR TITLE
Return full asset metadata from API

### DIFF
--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -15,6 +15,7 @@ import { bootstrapTestApp } from '../test/test-app';
 import { TransactionsService } from '../transactions/transactions.service';
 import { AssetsService } from './assets.service';
 import { VerifiedAssetMetadataDto } from './dto/update-verified-assets-dto';
+import { serializeVerifiedAssetMetadata } from './interfaces/serialized-asset';
 import { Asset, Block, Transaction } from '.prisma/client';
 
 const API_KEY = 'test';
@@ -206,6 +207,7 @@ describe('AssetsController', () => {
           name: asset.name,
           owner: asset.owner,
           supply: asset.supply.toString(),
+          verified_metadata: null,
           verified_at: null,
         });
       });
@@ -240,6 +242,7 @@ describe('AssetsController', () => {
             name: secondAsset.name,
             owner: secondAsset.owner,
             supply: secondAsset.supply.toString(),
+            verified_metadata: null,
             verified_at: null,
           },
           {
@@ -252,6 +255,9 @@ describe('AssetsController', () => {
             name: asset.name,
             owner: asset.owner,
             supply: asset.supply.toString(),
+            verified_metadata: serializeVerifiedAssetMetadata(
+              verifiedAssetMetadata,
+            ),
             verified_at: verifiedAssetMetadata.created_at.toISOString(),
           },
         ],
@@ -334,6 +340,7 @@ describe('AssetsController', () => {
             owner: asset.owner,
             supply: asset.supply.toString(),
             verified_at: null,
+            verified_metadata: null,
           },
         ],
         metadata: {
@@ -366,6 +373,7 @@ describe('AssetsController', () => {
             owner: asset.owner,
             supply: asset.supply.toString(),
             verified_at: null,
+            verified_metadata: null,
           },
         ],
         metadata: {
@@ -405,6 +413,9 @@ describe('AssetsController', () => {
               owner: asset.owner,
               supply: asset.supply.toString(),
               verified_at: verifiedAssetMetadata.created_at.toISOString(),
+              verified_metadata: serializeVerifiedAssetMetadata(
+                verifiedAssetMetadata,
+              ),
             },
           ],
           metadata: {
@@ -450,6 +461,7 @@ describe('AssetsController', () => {
               owner: secondAsset.owner,
               supply: secondAsset.supply.toString(),
               verified_at: null,
+              verified_metadata: null,
             },
           ],
           metadata: {

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -29,7 +29,10 @@ import {
   UpdateVerifiedAssetsDto,
   VerifiedAssetMetadataDto,
 } from './dto/update-verified-assets-dto';
-import { SerializedAsset } from './interfaces/serialized-asset';
+import {
+  SerializedAsset,
+  serializeVerifiedAssetMetadata,
+} from './interfaces/serialized-asset';
 
 @ApiTags('Assets')
 @Controller('assets')
@@ -75,6 +78,9 @@ export class AssetsController {
       owner: asset.owner,
       supply: asset.supply.toString(),
       verified_at: asset.verified_metadata?.created_at.toISOString() ?? null,
+      verified_metadata: asset.verified_metadata
+        ? serializeVerifiedAssetMetadata(asset.verified_metadata)
+        : null,
     };
   }
 
@@ -125,6 +131,9 @@ export class AssetsController {
         owner: asset.owner,
         supply: asset.supply.toString(),
         verified_at: asset.verified_metadata?.created_at.toISOString() ?? null,
+        verified_metadata: asset.verified_metadata
+          ? serializeVerifiedAssetMetadata(asset.verified_metadata)
+          : null,
       });
     }
 

--- a/src/assets/interfaces/serialized-asset.ts
+++ b/src/assets/interfaces/serialized-asset.ts
@@ -1,6 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { VerifiedAssetMetadata } from '@prisma/client';
+
 export interface SerializedAsset {
   object: 'asset';
   created_transaction_hash: string;
@@ -11,5 +14,29 @@ export interface SerializedAsset {
   name: string;
   owner: string;
   supply: string;
+  verified_metadata: SerializedVerifiedAssetMetadata | null;
+  // @deprecated Use `verified_metadata` instead
   verified_at: string | null;
+}
+
+export interface SerializedVerifiedAssetMetadata {
+  created_at: string;
+  updated_at: string;
+  symbol: string;
+  decimals?: number;
+  logo_uri?: string;
+  website?: string;
+}
+
+export function serializeVerifiedAssetMetadata(
+  m: VerifiedAssetMetadata,
+): SerializedVerifiedAssetMetadata {
+  return {
+    created_at: m.created_at.toISOString(),
+    updated_at: m.updated_at.toISOString(),
+    symbol: m.symbol,
+    ...(m.decimals != null && { decimals: m.decimals }),
+    ...(m.logo_uri != null && { logoURI: m.logo_uri }),
+    ...(m.website != null && { website: m.website }),
+  };
 }


### PR DESCRIPTION
## Summary
To render asset decimals correctly on the block explorer we need the full asset metadata (or at least the decimal).

## Testing Plan
Unit tests + running API locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
