### PR TITLE
Add CORS_ENABLED to Joi schemas

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,7 @@
 API_URL=http://localhost:8003
 BLOCK_EXPLORER_URL=http://localhost:3000
 BLOCK_LOADER_TRANSACTION_TIMEOUT=5000
+CORS_ENABLED=true
 DATABASE_CONNECTION_POOL_URL=postgres://postgres:password@localhost:5432/ironfish_api_development
 DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_development
 DATADOG_URL=127.0.0.1

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
 API_URL=http://localhost:8003
 BLOCK_EXPLORER_URL=test
 BLOCK_LOADER_TRANSACTION_TIMEOUT=5000
+CORS_ENABLED=true
 DATABASE_CONNECTION_POOL_URL=postgres://postgres:password@localhost:5432/ironfish_api_test
 DATABASE_URL=postgres://postgres:password@localhost:5432/ironfish_api_test
 DATADOG_URL=127.0.0.1

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rm -rf ./build",
-    "docker:start": "docker-compose up -d",
-    "docker:stop": "docker-compose down",
+    "docker:start": "docker compose up -d",
+    "docker:stop": "docker compose down",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prestart": "bash bin/check_for_dotenv.sh",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -52,6 +52,7 @@ export const REST_MODULES = [
         API_URL: joi.string().required(),
         BLOCK_EXPLORER_URL: joi.string().required(),
         BLOCK_LOADER_TRANSACTION_TIMEOUT: joi.number().optional(),
+        CORS_ENABLED: joi.boolean().default(true),
         DATABASE_CONNECTION_POOL_URL: joi.string().required(),
         DATABASE_URL: joi.string().required(),
         DATADOG_URL: joi.string().required(),

--- a/src/test/test-app.ts
+++ b/src/test/test-app.ts
@@ -21,6 +21,7 @@ export async function bootstrapTestApp(): Promise<INestApplication> {
           API_URL: joi.string().required(),
           BLOCK_EXPLORER_URL: joi.string().required(),
           BLOCK_LOADER_TRANSACTION_TIMEOUT: joi.number().optional(),
+          CORS_ENABLED: joi.boolean().default(true),
           DATABASE_CONNECTION_POOL_URL: joi.string().required(),
           DATABASE_URL: joi.string().required(),
           DATADOG_URL: joi.string().required(),


### PR DESCRIPTION
## Summary

I'm not sure the CORS_ENABLED environment variable was working as expected -- it looks like we were expecting it to be a boolean, but without the Joi schema it was remaining as a string, so any non-empty value would resolve to true. I added it to the Joi schema and set the default to true, it should have already been set to true everywhere anyway.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
