### PR TITLE
Additional updates to CORS configuration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,6 @@ async function bootstrap(): Promise<void> {
       origin: enabledOrigins,
       methods: 'GET, POST, PUT, OPTIONS',
       allowedHeaders: ['Content-Type', 'Accept', 'Authorization'],
-      credentials: true,
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,14 +38,11 @@ async function bootstrap(): Promise<void> {
   const config = app.get(ApiConfigService);
   const logger = app.get(LoggerService);
 
-  const defaultOrigins = [/ironfish.network$/, /localhost/];
-  const enabledOrigins = config.isStaging()
-    ? [
-        ...defaultOrigins,
-        /block-explorer.*ironfish\.vercel\.app$/,
-        /oreowallet-bridge.*ironfish\.vercel\.app$/,
-      ]
-    : defaultOrigins;
+  const enabledOrigins = [
+    /ironfish.network$/,
+    /.*ironfish\.vercel\.app$/,
+    /localhost/,
+  ];
 
   if (config.get<boolean>('CORS_ENABLED')) {
     app.enableCors({


### PR DESCRIPTION
## Summary

Allows same origins on both staging and prod, and switches to allowing all Vercel deployments for ironfish for simplicity. Also removes the Allow-Credentials header since we don't really have credentials anymore.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
