### PR TITLE
feat(api): Return token details in token paths

### DIFF
--- a/src/bridges/bridges.controller.ts
+++ b/src/bridges/bridges.controller.ts
@@ -17,6 +17,7 @@ import {
   ChainportPort,
   ChainportService,
   ChainportToken,
+  ChainportTokenWithNetwork,
 } from './chainport.service';
 import { TransactionsCreateDto } from './dto/transactions-create.dto';
 import { TransactionsStatusDto } from './dto/transactions-status.dto';
@@ -67,7 +68,7 @@ export class BridgesController {
       }),
     )
     token_id: number,
-  ): Promise<List<ChainportNetwork>> {
+  ): Promise<List<ChainportTokenWithNetwork>> {
     const networks = await this.chainportService.getTokenPaths(token_id);
 
     return {

--- a/src/bridges/bridges.controller.ts
+++ b/src/bridges/bridges.controller.ts
@@ -19,6 +19,7 @@ import {
   ChainportToken,
   ChainportTokenWithNetwork,
 } from './chainport.service';
+import { TokenPathsQueryDto } from './dto/token-paths-query.dto';
 import { TransactionsCreateDto } from './dto/transactions-create.dto';
 import { TransactionsStatusDto } from './dto/transactions-status.dto';
 import { BridgesStatus } from './interfaces/bridge-status';
@@ -68,8 +69,18 @@ export class BridgesController {
       }),
     )
     token_id: number,
-  ): Promise<List<ChainportTokenWithNetwork>> {
-    const networks = await this.chainportService.getTokenPaths(token_id);
+    @Query(
+      new ValidationPipe({
+        errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        transform: true,
+      }),
+    )
+    query: TokenPathsQueryDto,
+  ): Promise<List<ChainportTokenWithNetwork | ChainportNetwork>> {
+    const networks = await this.chainportService.getTokenPaths(
+      token_id,
+      query.with_tokens,
+    );
 
     return {
       object: 'list',

--- a/src/bridges/chainport.service.spec.ts
+++ b/src/bridges/chainport.service.spec.ts
@@ -91,7 +91,23 @@ describe.skip('ChainportService', () => {
   });
 
   describe('getTokenPaths', () => {
-    it('returns token paths', async () => {
+    it('works with v1', async () => {
+      const originalGet = config.get.bind(config);
+      jest.spyOn(config, 'get').mockImplementation((val) => {
+        if (val === 'CHAINPORT_API_VERSION') {
+          return 1;
+        }
+        if (val === 'CHAINPORT_API_URL') {
+          return 'https://api.chainport.io/';
+        }
+        return originalGet(val);
+      });
+      const results = await chainport.getTokenPaths(2804);
+
+      expect(results.length).toBeGreaterThan(0);
+    }, 10000);
+
+    it('works with v2', async () => {
       const originalGet = config.get.bind(config);
       jest.spyOn(config, 'get').mockImplementation((val) => {
         if (val === 'CHAINPORT_API_VERSION') {

--- a/src/bridges/chainport.service.spec.ts
+++ b/src/bridges/chainport.service.spec.ts
@@ -91,23 +91,7 @@ describe.skip('ChainportService', () => {
   });
 
   describe('getTokenPaths', () => {
-    it('works with v1', async () => {
-      const originalGet = config.get.bind(config);
-      jest.spyOn(config, 'get').mockImplementation((val) => {
-        if (val === 'CHAINPORT_API_VERSION') {
-          return 1;
-        }
-        if (val === 'CHAINPORT_API_URL') {
-          return 'https://api.chainport.io/';
-        }
-        return originalGet(val);
-      });
-      const results = await chainport.getTokenPaths(2804);
-
-      expect(results.length).toBeGreaterThan(0);
-    }, 10000);
-
-    it('works with v2', async () => {
+    it('returns token paths', async () => {
       const originalGet = config.get.bind(config);
       jest.spyOn(config, 'get').mockImplementation((val) => {
         if (val === 'CHAINPORT_API_VERSION') {

--- a/src/bridges/chainport.service.ts
+++ b/src/bridges/chainport.service.ts
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { HttpService } from '@nestjs/axios';
-import {
-  BadGatewayException,
-  Injectable,
-} from '@nestjs/common';
+import { BadGatewayException, Injectable } from '@nestjs/common';
 import { AxiosError, AxiosResponse } from 'axios';
 import Joi from 'joi';
 import { URL } from 'node:url';

--- a/src/bridges/chainport.service.ts
+++ b/src/bridges/chainport.service.ts
@@ -70,28 +70,33 @@ const chainportTokenSchema = Joi.object<ChainportToken>({
   is_lifi: Joi.boolean().required(),
 });
 
-export type ChainportTokenWithNetwork = ChainportToken & ChainportNetwork;
+export type ChainportTokenWithNetwork = {
+  network: ChainportNetwork;
+  token: ChainportToken;
+};
 
 const chainportTokenWithNetworkSchema = Joi.object<ChainportTokenWithNetwork>({
-  // Network
-  chainport_network_id: Joi.number().positive().integer().required(),
-  explorer_url: Joi.string().required(),
-  label: Joi.string().required(),
-  network_icon: Joi.string().required(),
-  // Token
-  id: Joi.number().required(),
-  decimals: Joi.number().required(),
-  name: Joi.string().required(),
-  pinned: Joi.boolean().required(),
-  web3_address: Joi.string().required(),
-  symbol: Joi.string().required(),
-  token_image: Joi.string().required(),
-  chain_id: Joi.number().allow(null).required(),
-  network_name: Joi.string().required(),
-  network_id: Joi.number().required(),
-  blockchain_type: Joi.string().required(),
-  is_stable: Joi.boolean().required(),
-  is_lifi: Joi.boolean().required(),
+  network: Joi.object<ChainportNetwork>({
+    chainport_network_id: Joi.number().positive().integer().required(),
+    explorer_url: Joi.string().required(),
+    label: Joi.string().required(),
+    network_icon: Joi.string().required(),
+  }),
+  token: Joi.object<ChainportToken>({
+    id: Joi.number().required(),
+    decimals: Joi.number().required(),
+    name: Joi.string().required(),
+    pinned: Joi.boolean().required(),
+    web3_address: Joi.string().required(),
+    symbol: Joi.string().required(),
+    token_image: Joi.string().required(),
+    chain_id: Joi.number().allow(null).required(),
+    network_name: Joi.string().required(),
+    network_id: Joi.number().required(),
+    blockchain_type: Joi.string().required(),
+    is_stable: Joi.boolean().required(),
+    is_lifi: Joi.boolean().required(),
+  }),
 });
 
 const chainportTokenWithNetworkArraySchema = Joi.array<
@@ -330,20 +335,22 @@ Chainport: ${token.decimals}`;
         }
 
         networkList.push({
-          ...network,
-          id: 0,
-          decimals: 0,
-          name: '',
-          pinned: false,
-          web3_address: '',
-          symbol: '',
-          token_image: '',
-          chain_id: 0,
-          network_name: '',
-          network_id: 0,
-          blockchain_type: '',
-          is_stable: false,
-          is_lifi: false,
+          network,
+          token: {
+            id: 0,
+            decimals: 0,
+            name: '',
+            pinned: false,
+            web3_address: '',
+            symbol: '',
+            token_image: '',
+            chain_id: 0,
+            network_name: '',
+            network_id: 0,
+            blockchain_type: '',
+            is_stable: false,
+            is_lifi: false,
+          },
         });
       }
     } else {
@@ -363,7 +370,7 @@ Chainport: ${token.decimals}`;
           continue;
         }
 
-        networkList.push({ ...token, ...network });
+        networkList.push({ token, network });
       }
     }
 

--- a/src/bridges/chainport.service.ts
+++ b/src/bridges/chainport.service.ts
@@ -300,9 +300,6 @@ Chainport: ${token.decimals}`;
   async getTokenPaths(tokenId: number): Promise<ChainportTokenWithNetwork[]> {
     const apiurl = this.config.get<string>('CHAINPORT_API_URL');
 
-    const tokenPathUrl = new URL(`/token/paths`, apiurl);
-    tokenPathUrl.searchParams.append('token_id', tokenId.toString());
-
     const metaResult = await this.getMeta();
     const networkList: ChainportTokenWithNetwork[] = [];
 
@@ -350,6 +347,8 @@ Chainport: ${token.decimals}`;
         });
       }
     } else {
+      const tokenPathUrl = new URL(`/token/paths`, apiurl);
+      tokenPathUrl.searchParams.append('token_id', tokenId.toString());
       const tokenPathResult = await this.makeChainportRequest<ChainportToken[]>(
         tokenPathUrl.toString(),
       );

--- a/src/bridges/dto/token-paths-query.dto.ts
+++ b/src/bridges/dto/token-paths-query.dto.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, TransformFnParams } from 'class-transformer';
+import { IsOptional } from 'class-validator';
+import { stringToBoolean } from '../../common/utils/boolean';
+
+export class TokenPathsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Whether or not to include tokens in the response',
+  })
+  @IsOptional()
+  @Transform(({ value }: TransformFnParams) => stringToBoolean(value))
+  readonly with_tokens?: boolean;
+}


### PR DESCRIPTION
## Summary

* Remove v1 path since we're not using it
* Return token along with networks for token paths

Fixes IFL-3045

## Testing Plan

Manually curl'd

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
