### PR TITLE
Allow empty string for symbols

### DIFF
--- a/src/bridges/chainport.service.ts
+++ b/src/bridges/chainport.service.ts
@@ -60,7 +60,7 @@ const chainportTokenSchema = Joi.object<ChainportToken>({
   name: Joi.string().required(),
   pinned: Joi.boolean().required(),
   web3_address: Joi.string().required(),
-  symbol: Joi.string().required(),
+  symbol: Joi.string().required().allow(''),
   token_image: Joi.string().required(),
   chain_id: Joi.number().allow(null).required(),
   network_name: Joi.string().required(),


### PR DESCRIPTION
## Summary

I don't know how realistic this typically is, but an asset on preprod has an empty string for the symbol field, which was breaking the token list.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
